### PR TITLE
chore: updated renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,40 +1,57 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    ":dependencyDashboard",
-    ":semanticCommits",
-    ":enableVulnerabilityAlertsWithLabel(security)"
-  ],
-  "timezone": "Europe/Madrid",
-  "reviewers": ["pabloimrik17"],
-  "labels": ["dependencies"],
-  "dependencyDashboard": true,
-  "prConcurrentLimit": 5,
-  "prHourlyLimit": 2,
-  "minimumReleaseAge": "7 days",
-  "packageRules": [
-    {
-      "matchUpdateTypes": ["patch"],
-      "schedule": ["on the first day of the month"]
-    },
-    {
-      "matchUpdateTypes": ["minor"],
-      "schedule": ["on the first day of the month every 2 months"]
-    },
-    {
-      "matchUpdateTypes": ["major"],
-      "schedule": ["on the first day of the month every 3 months"]
-    },
-    {
-      "description": "Pin dependencies except for certain packages",
-      "matchDepTypes": ["dependencies"],
-      "rangeStrategy": "pin"
-    },
-    {
-      "description": "Separate PRs for lockfile updates",
-      "matchFiles": ["pnpm-lock.yaml"],
-      "commitMessageSuffix": "[skip ci]"
-    }
-  ]
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "config:recommended",
+        ":dependencyDashboard",
+        ":semanticCommits",
+        ":enableVulnerabilityAlertsWithLabel(security)"
+    ],
+    "timezone": "Europe/Madrid",
+    "reviewers": ["pabloimrik17"],
+    "labels": ["dependencies"],
+    "baseBranches": ["develop"],
+    "dependencyDashboard": true,
+    "dependencyDashboardTitle": "📦 Dependency Dashboard",
+    "prConcurrentLimit": 10,
+    "prHourlyLimit": 2,
+    "minimumReleaseAge": "7 days",
+    "rangeStrategy": "pin",
+    "packageRules": [
+        {
+            "matchUpdateTypes": ["patch"],
+            "schedule": ["on the first day of the month"]
+        },
+        {
+            "matchUpdateTypes": ["minor"],
+            "schedule": ["on the first day of the month every 2 months"]
+        },
+        {
+            "matchUpdateTypes": ["major"],
+            "schedule": ["on the first day of the month every 3 months"]
+        },
+        {
+            "description": "Pin dependencies except for certain packages",
+            "matchDepTypes": ["dependencies"],
+            "rangeStrategy": "pin"
+        },
+        {
+            "description": "Disable pinning for expo packages",
+            "matchPackageNames": [
+                "expo-linking",
+                "expo-router",
+                "expo-updates"
+            ],
+            "matchUpdateTypes": ["pin"],
+            "enabled": false
+        },
+        {
+            "description": "Follow expo versioning",
+            "matchPackageNames": [
+                "expo-linking",
+                "expo-router",
+                "expo-updates"
+            ],
+            "rangeStrategy": "tilde"
+        }
+    ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,6 @@
     "reviewers": ["pabloimrik17"],
     "labels": ["dependencies"],
     "baseBranches": ["develop"],
-    "dependencyDashboard": true,
     "dependencyDashboardTitle": "📦 Dependency Dashboard",
     "prConcurrentLimit": 10,
     "prHourlyLimit": 2,
@@ -30,27 +29,8 @@
             "schedule": ["on the first day of the month every 3 months"]
         },
         {
-            "description": "Pin dependencies except for certain packages",
-            "matchDepTypes": ["dependencies"],
-            "rangeStrategy": "pin"
-        },
-        {
-            "description": "Disable pinning for expo packages",
-            "matchPackageNames": [
-                "expo-linking",
-                "expo-router",
-                "expo-updates"
-            ],
-            "matchUpdateTypes": ["pin"],
-            "enabled": false
-        },
-        {
-            "description": "Follow expo versioning",
-            "matchPackageNames": [
-                "expo-linking",
-                "expo-router",
-                "expo-updates"
-            ],
+            "description": "Seguir versionado de Expo con ~",
+            "matchPackagePatterns": ["^expo($|-)", "^@expo/"],
             "rangeStrategy": "tilde"
         }
     ]

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,7 @@
     "dependencyDashboardTitle": "📦 Dependency Dashboard",
     "prConcurrentLimit": 10,
     "prHourlyLimit": 2,
+    "configMigration": true,
     "minimumReleaseAge": "7 days",
     "rangeStrategy": "pin",
     "packageRules": [

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
     "timezone": "Europe/Madrid",
     "reviewers": ["pabloimrik17"],
     "labels": ["dependencies"],
-    "baseBranches": ["develop"],
+    "baseBranchPatterns": ["develop"],
     "dependencyDashboardTitle": "📦 Dependency Dashboard",
     "prConcurrentLimit": 10,
     "prHourlyLimit": 2,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Dependency automation now targets develop and includes a labeled dependency dashboard.
  * Increased concurrent dependency PRs; hourly limit unchanged.
  * Default dependency range strategy set to pin globally; added Expo packages to follow tilde versioning.
  * Removed separate lockfile-only update PRs to reduce noise.
  * No user-facing functionality changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->