### PR TITLE
feat: add Node.js base TypeScript configuration

### DIFF
--- a/openspec/changes/add-tsconfig-node-base/proposal.md
+++ b/openspec/changes/add-tsconfig-node-base/proposal.md
@@ -4,12 +4,12 @@
 The monorepo needs a shared base TypeScript configuration for Node.js environments to ensure consistent compiler settings across all backend projects, CLI tools, and Node.js libraries.
 
 ## What Changes
-- Add `tsconfig.node.base.json` in the root directory
-- Configure compiler options optimized for Node.js environments (Node types, appropriate ES targets)
+- Add `tsconfig.node.base.json` in `packages/ts-configs/` directory
+- Configure compiler options optimized for Node.js environments (Node types, NodeNext module system)
 - Enable this configuration to be extended by Node.js applications and libraries
-- Set up proper module resolution for Node.js ecosystem
+- Set up proper module resolution for Node.js ecosystem using NodeNext
 
 ## Impact
 - Affected specs: typescript-config (MODIFIED)
-- Affected code: Root `tsconfig.node.base.json` (new file)
+- Affected code: `packages/ts-configs/tsconfig.node.base.json` (new file)
 - This becomes the foundation for MON-30 (node apps) and MON-32 (node libs)

--- a/openspec/changes/add-tsconfig-node-base/specs/typescript-config/spec.md
+++ b/openspec/changes/add-tsconfig-node-base/specs/typescript-config/spec.md
@@ -11,10 +11,10 @@ The monorepo SHALL provide a base TypeScript configuration file (`tsconfig.node.
 - **AND** the target is set to a modern ES version compatible with Node.js 22.17.0
 - **AND** the lib includes modern ES features without browser-specific APIs
 
-#### Scenario: ESM module support
+#### Scenario: Node.js module support
 - **WHEN** a Node.js project extends from `tsconfig.node.base.json`
-- **THEN** the module system is set to ESNext for ESM support
-- **AND** moduleResolution is set to "bundler" for compatibility with modern tools
+- **THEN** the module system is set to NodeNext for proper Node.js ESM/CJS handling
+- **AND** moduleResolution is automatically configured by TypeScript for Node.js compatibility
 
 #### Scenario: No JSX configuration
 - **WHEN** a Node.js project extends from `tsconfig.node.base.json`

--- a/openspec/changes/add-tsconfig-node-base/tasks.md
+++ b/openspec/changes/add-tsconfig-node-base/tasks.md
@@ -1,11 +1,11 @@
 # Implementation Tasks
 
 ## 1. Create Configuration File
-- [x] 1.1 Create `tsconfig.node.base.json` in project root
-- [x] 1.2 Set target to ES2022 or later for modern Node.js
-- [x] 1.3 Configure lib to include ES2022 features (no DOM)
-- [x] 1.4 Set module to ESNext for ESM support
-- [x] 1.5 Set moduleResolution to bundler
+- [x] 1.1 Create `tsconfig.node.base.json` in `packages/ts-configs/` directory
+- [x] 1.2 Extend from base config (inherits target ES2022 and lib ES2024)
+- [x] 1.3 Add Node.js types (excludes DOM)
+- [x] 1.4 Set module to NodeNext for proper Node.js ESM/CJS support
+- [x] 1.5 Remove moduleResolution (auto-configured by NodeNext)
 - [x] 1.6 Exclude JSX settings (not needed for Node.js)
 
 ## 2. Configure Compiler Options

--- a/packages/ts-configs/tsconfig.node.base.json
+++ b/packages/ts-configs/tsconfig.node.base.json
@@ -5,8 +5,7 @@
         "types": ["node"],
 
         /* Module Configuration */
-        "module": "ESNext",
-        "moduleResolution": "bundler",
+        "module": "NodeNext",
 
         /* Interop & Compatibility */
         "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
## Summary

Implements OpenSpec proposal `add-tsconfig-node-base` to add a shared base TypeScript configuration optimized for Node.js environments.

- Adds `tsconfig.node.base.json` in `packages/ts-configs/` directory
- Extends from platform-agnostic base config (ES2022 target, ES2024 lib)
- Configures Node.js-specific types and excludes DOM definitions
- Uses NodeNext module system for proper Node.js ESM/CJS handling
- moduleResolution automatically configured by TypeScript for Node.js compatibility
- Includes declaration file generation and source maps

## Key Configuration Details

- **Location**: `packages/ts-configs/tsconfig.node.base.json`
- **Extends**: `./tsconfig.base.json` (platform-agnostic foundation)
- **Types**: Node.js types included (no DOM)
- **Module System**: NodeNext (proper Node.js runtime support)
- **Module Resolution**: Auto-configured to "nodenext" by TypeScript
- **Build Output**: Declaration files, declaration maps, source maps

## Why NodeNext instead of bundler?

- `"bundler"` moduleResolution is designed for bundler-consumed code (webpack, vite)
- `"NodeNext"` is designed for Node.js runtime and enforces Node's stricter import rules
- Prevents runtime errors on Node.js 22.17.0 where extensionless imports would fail
- Aligns with project's README which documents `module: "NodeNext"` for Node.js configs

## Impact

This configuration becomes the foundation for:
- MON-30: Node.js applications config
- MON-32: Node.js libraries config

All backend projects, CLI tools, and Node.js libraries can extend from this base.

## Test Plan

- [x] JSON syntax validated
- [x] TypeScript compiler successfully processes configuration
- [x] Configuration extends correctly from base config
- [x] OpenSpec validation passes (`openspec validate add-tsconfig-node-base --strict`)
- [x] Aligned with packages/ts-configs/README.md documentation
- [x] All implementation tasks completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)