### PR TITLE
fix(experiments): ralph outputs to current dir, not subdirectory

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
         {
             "name": "experiments",
             "source": "./claude-plugins/experiments",
-            "version": "0.1.0",
+            "version": "0.2.1",
             "description": "Beta skills and commands staging area for monolab"
         }
     ]

--- a/claude-plugins/experiments/.claude-plugin/plugin.json
+++ b/claude-plugins/experiments/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "experiments",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "Beta skills and commands staging area for monolab",
     "author": {
         "name": "Pablo F.G.",

--- a/claude-plugins/experiments/commands/ralph.md
+++ b/claude-plugins/experiments/commands/ralph.md
@@ -20,6 +20,10 @@ If ARGUMENTS is empty or not provided, use the **AskUserQuestion** tool to promp
 
 Wait for the user's response before proceeding.
 
+## Critical: Output Location
+
+**Create ALL files directly in the current working directory.** Do NOT create a `ralph/` subdirectory or any other folder. If user runs `/ralph` in `/home/user/myproject`, files go directly in `/home/user/myproject`.
+
 ## Step 1: Generate PRD
 
 Analyze the user's description and extract distinct features/tasks. For each feature:
@@ -177,7 +181,7 @@ chmod +x ralph-once.sh ralph.sh
 
 ## Output
 
-After running this command, the current directory will contain:
+After running this command, the current directory (NOT a subdirectory) will contain:
 
 1. `prd.json` - PRD items extracted from your description
 2. `progress.txt` - Empty file for tracking between iterations

--- a/claude-plugins/experiments/package.json
+++ b/claude-plugins/experiments/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@m0n0lab/plugin-experiments",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "private": true,
     "description": "Beta skills and commands staging area for monolab"
 }


### PR DESCRIPTION
## Summary
- Added explicit instruction to create files in current directory, not `ralph/` subdirectory
- Bumped experiments plugin version to 0.2.1
- Synced marketplace.json version

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated experiments plugin to version 0.2.1.

* **Documentation**
  * Clarified output file location instructions to ensure files are created in the current working directory without creating subdirectories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->