### PR TITLE
fix(nx): update stale vitest.workspace.ts refs to vitest.config.ts

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -97,7 +97,7 @@
             "dependsOn": ["^build", "^test:unit"],
             "inputs": [
                 "default",
-                "{workspaceRoot}/vitest.workspace.ts",
+                "{workspaceRoot}/vitest.config.ts",
                 "{projectRoot}/vitest.config.ts"
             ],
             "outputs": [
@@ -110,7 +110,7 @@
             "dependsOn": ["^build", "^test:unit:coverage"],
             "inputs": [
                 "default",
-                "{workspaceRoot}/vitest.workspace.ts",
+                "{workspaceRoot}/vitest.config.ts",
                 "{projectRoot}/vitest.config.ts"
             ],
             "outputs": [


### PR DESCRIPTION
## Summary
- `nx.json` targets `test:unit` and `test:unit:coverage` still referenced the deleted `vitest.workspace.ts` in their inputs
- `vitest.workspace.ts` was migrated to `vitest.config.ts` with `projects` auto-discovery (vitest v4 migration), but 2 of 3 Nx targets weren't updated
- The `test:unit:watch` target already had the correct reference

## Changes
- `nx.json` lines 100, 113: `vitest.workspace.ts` → `vitest.config.ts`

This ensures Nx cache invalidation correctly tracks the root vitest config file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test configuration file references in build settings for consistency and improved configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->