### PR TITLE
feat(stryker): migrate from command runner to vitest runner

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -135,8 +135,8 @@
             "dependsOn": ["^build", "build"],
             "inputs": [
                 "default",
-                "{workspaceRoot}/stryker.config.base.ts",
-                "{projectRoot}/stryker.config.ts",
+                "{workspaceRoot}/stryker.config.base.mjs",
+                "{projectRoot}/stryker.config.mjs",
                 "{projectRoot}/reports/stryker-incremental.json"
             ],
             "outputs": [

--- a/stryker.config.base.mjs
+++ b/stryker.config.base.mjs
@@ -1,10 +1,11 @@
 /** @type {import('@stryker-mutator/api/core').PartialStrykerOptions} */
 const config = {
     packageManager: "pnpm",
-    testRunner: "command",
-    commandRunner: {
-        command: "pnpm run test:unit",
-    },
+    plugins: [
+        "@stryker-mutator/vitest-runner",
+        "@stryker-mutator/typescript-checker",
+    ],
+    testRunner: "vitest",
     mutate: [
         "src/**/*.ts",
         "src/**/*.tsx",
@@ -23,7 +24,7 @@ const config = {
         // Ignore type test
         "packages/**/src/**/*.test-d.ts",
     ],
-    coverageAnalysis: "off",
+    coverageAnalysis: "perTest",
     incremental: true,
     incrementalFile: "reports/stryker-incremental.json",
     inPlace: true,


### PR DESCRIPTION
## Summary
- Migrate Stryker mutation testing from generic `command` runner to native `vitest` runner
- `@stryker-mutator/vitest-runner` was already installed but unused — now actively wired up
- Fix stale `nx.json` input references for `test:mutation` target (`stryker.config.base.ts` → `.mjs`, `stryker.config.ts` → `.mjs`)

## Changes
- `stryker.config.base.mjs`: `testRunner: "command"` → `testRunner: "vitest"`, remove `commandRunner` block
- `stryker.config.base.mjs`: `coverageAnalysis: "off"` → `coverageAnalysis: "perTest"` (vitest runner forces perTest, better to be explicit)
- `stryker.config.base.mjs`: add explicit `plugins` array (required for pnpm plugin discovery)
- `nx.json`: fix stale Stryker config file references in `test:mutation` inputs

## Benefits
- **Direct vitest integration** — Stryker communicates with vitest API instead of spawning a subprocess, yielding faster mutation runs
- **Per-test coverage analysis** — Stryker now knows which tests cover which mutants, running only relevant tests per mutant instead of the full suite
- **Incremental reports** are now per-test aware — better cache reuse across runs

## Validation
All 3 packages with mutation testing pass:

| Package | Score | Threshold |
|---|---|---|
| `@m0n0lab/ts-types` | 100% | 75% |
| `@m0n0lab/react-hooks` | 80% | 70% |
| `@m0n0lab/react-clean` | 100% | 80% |

## Note
Stryker's vitest runner does not support [Browser Mode](https://stryker-mutator.io/docs/stryker-js/vitest-runner/#limitations). This is fine because mutation tests only run unit tests (no browser tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded mutation testing infrastructure with improved test runner integration for better performance and compatibility
  * Enhanced code coverage collection capabilities with per-test tracking to provide more detailed quality metrics
  * Updated system configuration formats to align with current development standards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->