### PR TITLE
Add qup initial proposal documentation

### DIFF
--- a/openspec/changes/qup/.openspec.yaml
+++ b/openspec/changes/qup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-26

--- a/openspec/changes/qup/design.md
+++ b/openspec/changes/qup/design.md
@@ -1,0 +1,180 @@
+## Context
+
+Qup is a home barista order management app. Guests scan a code/QR, browse a menu, and place orders. The host manages orders in real-time. Built as a side project to deeply explore SolidStart, Hono, Inversify, Drizzle, and DDD/Clean Architecture.
+
+The monorepo already has patterns for publishable packages (`react-clean`, `react-hooks`) with tsdown builds, Vitest testing, and `workspace:*` internal deps. Qup follows the same conventions but introduces two new apps and four new packages.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Functional v1: guests order, host manages — works on phones over local WiFi
+- Deep exploration of SolidStart (SSR, server functions, hybrid rendering, file-based routing)
+- DDD + Clean Architecture with strict layer separation enforced by package boundaries
+- Typed error handling everywhere via neverthrow — zero try/catch in business logic
+- MVVM in frontend via `solid-clean`, port of the existing `react-clean` pattern
+- Inversify as universal DI across all layers
+- Real-time order updates via SSE
+
+**Non-Goals:**
+
+- User accounts, OAuth, or persistent auth — PIN only for v1
+- Menu per session / availability scheduling / stock tracking — future iterations
+- Mobile app — web-only for v1
+- Production deployment / hosting — local network only
+- Multi-host / multi-venue — single host, single session at a time
+- Offline support / PWA — requires network
+
+## Decisions
+
+### 1. Package structure — 6 projects with strict dependency direction
+
+```
+packages/solid-clean        → peerDep: solid-js only
+packages/qup-domain         → dep: inversify, neverthrow
+packages/qup-data           → dep: qup-domain, drizzle-orm, pg
+packages/qup-shared         → dep: neverthrow (types only)
+apps/qup-api                → dep: qup-domain, qup-data, qup-shared, hono, inversify
+apps/qup-web                → dep: qup-shared, solid-clean, solid-start, inversify
+```
+
+**Why**: Package boundaries enforce Clean Architecture at the build level. Domain cannot accidentally import Drizzle. Web cannot accidentally import domain internals. The compiler catches violations.
+
+**Alternative considered**: Single package with folder-based separation. Rejected — too easy to leak cross-layer imports, no build-time enforcement.
+
+### 2. SolidStart as SSR/hybrid client with server functions as BFF
+
+SolidStart handles rendering (SSR, streaming, client hydration) and acts as a Backend-For-Frontend via `"use server"` functions. All business logic lives in the Hono API.
+
+```
+Browser ──server fn──▶ SolidStart Server ──HTTP──▶ Hono API
+Browser ──EventSource────────────────────────────▶ Hono API (SSE only)
+```
+
+**Why**: Server functions keep the admin PIN server-side (httpOnly cookie, never in browser). Eliminates CORS for most requests. Exploits SolidStart's `createAsync`/`cache` features. SSE goes direct because it needs a persistent connection the BFF shouldn't proxy.
+
+**Alternative considered**: Direct browser→API. Rejected — exposes PIN to browser, requires CORS config, wastes SolidStart's server features.
+
+### 3. Hono + Inversify via route factories
+
+Hono routes receive the Inversify container and resolve use cases per request:
+
+```typescript
+function createOrderRoutes(container: Container): Hono {
+  const app = new Hono();
+  app.post('/', async (c) => {
+    const useCase = container.get<CreateOrderUseCase>(TOKENS.CreateOrder);
+    const result = await useCase.execute(await c.req.json());
+    return result.match(
+      (order) => c.json(toDto(order), 201),
+      (error) => c.json(toApiError(error), errorToHttp(error))
+    );
+  });
+  return app;
+}
+```
+
+**Why**: Hono has no built-in DI. Route factories bridge Hono's functional style with Inversify's container. Use cases are resolved per-request, keeping handlers thin. `result.match()` ensures every error path produces a typed HTTP response.
+
+**Alternative considered**: Hono middleware that injects container into context (`c.var.container`). Viable but less explicit — factory pattern makes the container dependency visible.
+
+### 4. Inversify everywhere — with @injectable in domain
+
+`@injectable()` decorators on use cases in qup-domain. Tokens (Symbols) defined in domain. ContainerModule per package for modular composition.
+
+```
+qup-domain/src/tokens.ts          → Symbol definitions
+qup-domain/src/domain.module.ts   → binds use cases
+qup-data/src/data.module.ts       → binds repo implementations
+qup-api/src/api.module.ts         → binds API-specific services (EventBus, etc.)
+qup-api/src/container.ts          → loads all modules (composition root)
+```
+
+**Why**: `@injectable` is metadata only — doesn't change class behavior, doesn't introduce IO. The alternative (manual `toDynamicValue` wiring) creates significant boilerplate and a maintenance footgun when constructor params change.
+
+**Line not crossed**: Domain never imports Drizzle, pg, Hono, fetch, fs, or any IO. Only inversify (metadata) and neverthrow (error types).
+
+### 5. Inversify in SolidStart — singleton container, no Context Provider
+
+```typescript
+// qup-web/src/container.ts
+const container = new Container();
+container.load(webModule);
+export { container };
+
+// In a ViewModel
+import { container } from '../container';
+```
+
+**Why**: Simpler than wrapping the app in a Context Provider. The container is a singleton — there's no scenario where different subtrees need different containers. Direct import is explicit and fails at import-time, not runtime.
+
+### 6. MVVM via solid-clean — BaseViewModel + useViewModel
+
+Port of `@m0n0lab/react-clean` adapted to Solid's execution model:
+
+- `BaseViewModel`: abstract class with `didMount(owner?)`, `willUnmount()`, generic cleanup array (not RxJS Subscription)
+- `useViewModel(factory)`: calls factory once (Solid components run once), wires `onMount`/`onCleanup`, passes `getOwner()` to `didMount`
+
+State in ViewModels uses Solid's `createSignal` directly — no RxJS, no bridge layer.
+
+**Why**: Solid's reactivity is primitive. Signals in a class work natively. RxJS would add a redundant reactive layer requiring a bridge (`observable→signal`). The `owner` parameter allows VMs to use `createEffect` inside `runWithOwner` if needed.
+
+**solid-clean has zero knowledge of Inversify** — it's a pure MVVM lifecycle library. Peer dep is only `solid-js`.
+
+### 7. neverthrow transversal — typed errors, zero try/catch
+
+Every async boundary returns `ResultAsync<T, E>`. Error types are domain value objects.
+
+```
+Domain errors:    SessionNotFoundError, OrderNotCancellableError, etc.
+Data errors:      PersistenceError (wraps unknown cause)
+API mapping:      DomainError → HTTP status code + ApiErrorDto
+BFF mapping:      HTTP response → Result<T, ApiErrorDto>
+ViewModel:        result.match() → update signals or set error signal
+```
+
+Single try/catch boundary: `ResultAsync.fromPromise()` in data layer repos, wrapping Drizzle operations.
+
+**Why**: Explicit error types in function signatures make error handling exhaustive and compiler-checked. `result.match()` forces handling both paths. No surprise exceptions propagating through layers.
+
+### 8. Drizzle + PostgreSQL — schema separate from domain
+
+Drizzle schema in `qup-data/src/schema/`. Four tables: `sessions`, `orders`, `order_items`, `menu_items`. Each repo has `toDomain(row)` and `toRow(entity)` mappers.
+
+`toDomain` reconstructs entities via private/internal constructors (not `Entity.create()` which validates) because DB data is already valid.
+
+**Why Drizzle over Prisma**: Drizzle doesn't impose its model on domain entities. Prisma's generated types tend to become the domain model, violating DDD. Drizzle is a thin query layer — domain entities stay independent.
+
+### 9. SSE for real-time — EventBus port in domain
+
+```
+Domain:  EventBus interface (port) — emit/on
+API:     InMemoryEventBus (adapter) — Node EventEmitter
+Route:   GET /events/sessions/:code — SSE stream filtered by session
+Client:  EventSource API — auto-reconnect built in
+```
+
+Events: `order:created`, `order:status`, `order:cancelled`, `session:closed`. v1 filters by guest name on the client side.
+
+**Why SSE over WebSocket**: Unidirectional (server→client) is sufficient — user actions go via HTTP POST/PATCH. SSE has built-in reconnection, simpler than WS, native browser API, and Hono supports it out of the box.
+
+**Why in-memory over Redis/message queue**: Single server, local network. No need for distributed pub/sub in v1.
+
+### 10. Admin auth — PIN via env var
+
+`API_ADMIN_PIN` env var. Hono middleware checks `X-Admin-Pin` header. SolidStart server functions read the PIN server-side and set an httpOnly cookie.
+
+Admin routes: all mutations on sessions, order status changes, menu CRUD.
+Open routes: join session, view menu, create order, view own orders, SSE.
+
+**Why PIN over passwords/OAuth**: Single user (the host), local network, side project. PIN is the simplest auth that works. httpOnly cookie via server function means the PIN is never in browser JS.
+
+## Risks / Trade-offs
+
+- **[In-memory EventBus loses events on restart]** → Acceptable for v1. Orders persist in DB; clients reconnect and refetch. Migrate to Redis pub/sub if needed later.
+- **[Single session at a time]** → Design doesn't prevent multiple, but UI/UX assumes one active session. Can be extended without architectural changes.
+- **[experimentalDecorators required for Inversify 7.x]** → All qup packages need `experimentalDecorators: true` + `emitDecoratorMetadata: true` in tsconfig. Inversify 8 (March 2026) may change this; contained to qup packages only.
+- **[SolidStart ecosystem less mature than Next/Remix]** → Accepted risk — exploration is the point. Solid UI / Kobalte may have gaps. Fallback: build custom components with Tailwind.
+- **[Server functions add a network hop]** → SolidStart server → Hono API adds ~1ms on local network. Negligible for this use case.
+- **[Signals in class constructors run outside reactive scope]** → `createSignal` works fine outside scope. Only `createEffect` needs an owner, which is passed via `didMount(owner)`.
+- **[Guest name is not authenticated]** → Anyone can claim any name. Acceptable for trusted home environment. v2 could add session-scoped guest tokens.

--- a/openspec/changes/qup/proposal.md
+++ b/openspec/changes/qup/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+Home barista hosting needs a simple order management system. Guests should browse a menu and place drink orders from their phones; the host should see incoming orders in real-time and manage their status. This is also a playground to explore SolidStart, Hono, Inversify, Drizzle, and DDD/Clean Architecture patterns in depth.
+
+## What Changes
+
+- New app `qup-web`: SolidStart frontend with SSR/hybrid rendering, MVVM pattern, Solid UI + Tailwind
+- New app `qup-api`: Hono REST API with Inversify DI, SSE real-time events, PIN-based admin auth
+- New package `qup-domain`: Pure domain layer — entities (Session, Order, MenuItem), value objects, use case classes, repository interfaces. Only dependency: inversify (metadata). Uses neverthrow `Result`/`ResultAsync` for typed error handling
+- New package `qup-data`: Drizzle ORM + PostgreSQL implementations of domain repository interfaces, schema definitions, migrations, domain↔persistence mappers
+- New package `qup-shared`: DTOs and API contract types shared between web and api. Zero runtime dependencies
+- New package `solid-clean`: Framework-agnostic MVVM library for SolidJS (port of `@m0n0lab/react-clean`). Exports `BaseViewModel` + `useViewModel`. Peer dep: solid-js only
+- Server functions (BFF pattern) in SolidStart for data loading and mutations; SSE connects directly to Hono API for real-time updates
+- Inversify containers composed via `ContainerModule` per package; singleton container exported directly (no Context Provider)
+
+## Capabilities
+
+### New Capabilities
+
+- `qup-session-management`: Session lifecycle — create, close, join via code/QR. Aggregate root with OPEN→CLOSED status machine
+- `qup-order-management`: Order lifecycle — create, update status (PENDING→PREPARING→DONE), cancel (only PENDING). Aggregate root with typed state transitions
+- `qup-menu-management`: Global menu CRUD — create, update, delete, toggle availability. MenuItem entity with categories (COFFEE, TEA, INFUSION, JUICE, OTHER)
+- `qup-realtime-events`: SSE event system — EventBus port in domain, in-memory impl, browser EventSource. Events: order:created, order:status, order:cancelled, session:closed
+- `qup-admin-auth`: PIN-based admin authentication — env var config, middleware guard on admin routes, httpOnly cookie via server functions
+- `qup-api`: Hono REST API — route factories with Inversify container, neverthrow Result→HTTP response mapping, CORS, error middleware
+- `qup-web`: SolidStart frontend — SSR/hybrid rendering, server functions as BFF, file-based routing, MVVM with ViewModels using Solid signals
+- `solid-clean`: MVVM library for SolidJS — BaseViewModel (lifecycle + generic cleanup), useViewModel hook (onMount/onCleanup bridge). Reusable, not coupled to Qup
+
+### Modified Capabilities
+
+None. All capabilities are new.
+
+## Impact
+
+- **New projects**: 2 apps (`apps/qup-web`, `apps/qup-api`) + 4 packages (`packages/qup-domain`, `packages/qup-data`, `packages/qup-shared`, `packages/solid-clean`)
+- **Dependencies added**: solid-js, solid-start, @solidjs/router, hono, inversify, drizzle-orm, drizzle-kit, pg, neverthrow, tailwindcss, solid-ui/kobalte
+- **Infrastructure**: PostgreSQL database required (local dev via Docker)
+- **Workspace config**: pnpm-workspace.yaml already covers `apps/*` and `packages/*` — no changes needed
+- **Nx config**: New projects auto-detected. May need target defaults for `dev`, `build`, `db:migrate`
+- **Existing code**: Zero impact on existing packages (react-clean, react-hooks, ts-configs, etc.)

--- a/openspec/changes/qup/specs/qup-admin-auth/spec.md
+++ b/openspec/changes/qup/specs/qup-admin-auth/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: PIN configuration via environment variable
+
+The system SHALL read the admin PIN from `API_ADMIN_PIN` environment variable. The API SHALL fail to start if `API_ADMIN_PIN` is not set or is empty.
+
+#### Scenario: API starts with valid PIN
+- **WHEN** the API starts with `API_ADMIN_PIN=1234` in the environment
+- **THEN** the server starts normally
+
+#### Scenario: API fails without PIN
+- **WHEN** the API starts without `API_ADMIN_PIN` set
+- **THEN** the server exits with an error message indicating the missing variable
+
+### Requirement: Admin middleware for Hono
+
+The system SHALL provide an `adminOnly` Hono middleware in `qup-api` that checks for a valid PIN in the `X-Admin-Pin` request header. If the PIN matches `API_ADMIN_PIN`, the request proceeds. If not, the middleware SHALL return 401 with `{ code: "UNAUTHORIZED", message: "Invalid admin PIN" }`.
+
+#### Scenario: Valid PIN header
+- **WHEN** a request includes `X-Admin-Pin: 1234` and the env PIN is `1234`
+- **THEN** the request proceeds to the handler
+
+#### Scenario: Missing PIN header
+- **WHEN** a request to an admin route has no `X-Admin-Pin` header
+- **THEN** the response is 401 with code "UNAUTHORIZED"
+
+#### Scenario: Wrong PIN
+- **WHEN** a request includes an incorrect PIN
+- **THEN** the response is 401 with code "UNAUTHORIZED"
+
+### Requirement: Admin route protection
+
+The middleware SHALL be applied to these routes:
+- `PATCH /orders/:id/status` (update order status)
+- `DELETE /orders/:id` (cancel order)
+- `POST /sessions` (create session)
+- `PATCH /sessions/:id/close` (close session)
+- `POST /menu` (create menu item)
+- `PATCH /menu/:id` (update menu item)
+- `DELETE /menu/:id` (delete menu item)
+
+The following routes SHALL remain open (no auth):
+- `GET /sessions/:code` (join session)
+- `GET /menu` (view menu)
+- `POST /orders` (create order — guest action)
+- `GET /orders` (view orders — filtered by guest)
+- `GET /events/sessions/:code` (SSE stream)
+
+#### Scenario: Guest can create order without PIN
+- **WHEN** a guest POSTs to `/orders` without a PIN header
+- **THEN** the request is processed normally
+
+#### Scenario: Admin route requires PIN
+- **WHEN** a request PATCHes `/orders/123/status` without a PIN header
+- **THEN** the response is 401
+
+### Requirement: PIN transmission via SolidStart server functions
+
+The system SHALL handle PIN authentication through SolidStart server functions. The admin enters their PIN once in the frontend; the server function stores it in an httpOnly cookie. Subsequent server function calls read the PIN from the cookie and forward it to the Hono API in the `X-Admin-Pin` header. The PIN SHALL never be stored in browser-accessible JavaScript (no localStorage, no sessionStorage, no non-httpOnly cookies).
+
+#### Scenario: Admin login via server function
+- **WHEN** the admin submits a PIN through the login UI
+- **THEN** the SolidStart server function validates the PIN against the API and sets an httpOnly cookie
+
+#### Scenario: Subsequent admin requests
+- **WHEN** the admin performs an action (e.g., change order status)
+- **THEN** the SolidStart server function reads the PIN from the httpOnly cookie and forwards it to Hono
+
+#### Scenario: PIN never in client JS
+- **WHEN** the browser's JavaScript context is inspected
+- **THEN** the admin PIN is not accessible via `document.cookie`, localStorage, sessionStorage, or any JS variable

--- a/openspec/changes/qup/specs/qup-api/spec.md
+++ b/openspec/changes/qup/specs/qup-api/spec.md
@@ -51,7 +51,7 @@ Mapping:
 
 ### Requirement: CORS middleware
 
-The system SHALL configure CORS to allow requests from the SolidStart frontend origin. For SSE endpoints, the CORS headers SHALL include `Access-Control-Allow-Headers` for EventSource.
+The system SHALL configure CORS to allow requests from the SolidStart frontend origin. The response SHALL include `Access-Control-Allow-Origin` with the frontend origin. Native `EventSource` (SSE) does not send custom headers and does not trigger preflight — no `Access-Control-Allow-Headers` is needed for SSE endpoints.
 
 #### Scenario: Cross-origin request from SolidStart
 - **WHEN** the SolidStart frontend makes a request to the API from a different port

--- a/openspec/changes/qup/specs/qup-api/spec.md
+++ b/openspec/changes/qup/specs/qup-api/spec.md
@@ -1,0 +1,102 @@
+## ADDED Requirements
+
+### Requirement: Hono application setup
+
+The system SHALL create a Hono application in `apps/qup-api` that serves on a configurable port (default 3001). The app SHALL be structured via a `createApp(container: Container): Hono` factory function that mounts all route groups and middleware.
+
+#### Scenario: API starts and serves
+- **WHEN** the API entry point is executed
+- **THEN** a Hono server starts on the configured port and responds to requests
+
+### Requirement: Route factories with Inversify container
+
+Each route group SHALL be created via a factory function that receives the Inversify container: `createOrderRoutes(container)`, `createSessionRoutes(container)`, `createMenuRoutes(container)`, `createEventRoutes(container)`. Handlers SHALL resolve use cases from the container per-request.
+
+#### Scenario: Route handler resolves use case
+- **WHEN** a POST request hits `/orders`
+- **THEN** the handler resolves `CreateOrderUseCase` from the container and delegates execution
+
+### Requirement: Composition root
+
+The system SHALL provide a `createContainer()` function in `qup-api/src/container.ts` that creates an Inversify Container and loads modules: `domainModule` (from `qup-domain`), `dataModule` (from `qup-data`), `apiModule` (API-specific services like InMemoryEventBus).
+
+#### Scenario: Container resolves all dependencies
+- **WHEN** `createContainer()` is called and a use case is resolved
+- **THEN** all transitive dependencies (repositories, event bus) are correctly injected
+
+### Requirement: neverthrow Result to HTTP response mapping
+
+The system SHALL provide a `toApiError(error: DomainError): ApiErrorDto` function and an `errorToHttp(error: DomainError): number` function that maps domain errors to HTTP status codes. Every route handler SHALL use `result.match()` to produce the response — never throw.
+
+Mapping:
+- `SessionNotFoundError` → 404
+- `OrderNotFoundError` → 404
+- `MenuItemNotFoundError` → 404
+- `SessionClosedError` → 409
+- `OrderNotCancellableError` → 409
+- `InvalidTransitionError` → 409
+- `EmptyOrderError` → 422
+- `MenuItemNotAvailableError` → 422
+- `ValidationError` → 422
+- `InvalidCodeError` → 422
+- `PersistenceError` → 500
+
+#### Scenario: Domain error maps to correct HTTP status
+- **WHEN** a use case returns `Err<SessionNotFoundError>`
+- **THEN** the API responds with 404 and a JSON body containing `{ code: "SESSION_NOT_FOUND", message: "..." }`
+
+#### Scenario: Successful result maps to success response
+- **WHEN** a use case returns `Ok<Order>`
+- **THEN** the API responds with the appropriate 2xx status and the DTO-serialized body
+
+### Requirement: CORS middleware
+
+The system SHALL configure CORS to allow requests from the SolidStart frontend origin. For SSE endpoints, the CORS headers SHALL include `Access-Control-Allow-Headers` for EventSource.
+
+#### Scenario: Cross-origin request from SolidStart
+- **WHEN** the SolidStart frontend makes a request to the API from a different port
+- **THEN** the response includes appropriate CORS headers
+
+### Requirement: API routes
+
+The system SHALL expose the following REST endpoints:
+
+**Sessions:**
+- `POST /sessions` — create session (admin)
+- `GET /sessions/:code` — get session by code (guest)
+- `PATCH /sessions/:id/close` — close session (admin)
+
+**Orders:**
+- `POST /orders` — create order (guest)
+- `GET /orders?sessionId=X&guest=Y` — list orders with optional filters
+- `PATCH /orders/:id/status` — update order status (admin)
+- `DELETE /orders/:id` — cancel order (admin)
+
+**Menu:**
+- `GET /menu` — list menu items (optional `?available=true` filter)
+- `POST /menu` — create menu item (admin)
+- `PATCH /menu/:id` — update menu item (admin)
+- `DELETE /menu/:id` — delete menu item (admin)
+
+**Events:**
+- `GET /events/sessions/:code` — SSE stream
+
+#### Scenario: Full CRUD for menu items
+- **WHEN** admin creates, reads, updates, and deletes a menu item
+- **THEN** each operation succeeds with the appropriate status code (201, 200, 200, 204)
+
+### Requirement: ContainerModule for API-specific bindings
+
+The system SHALL provide an `apiModule` as an Inversify `ContainerModule` that binds API-layer services: `InMemoryEventBus` → `TOKENS.EventBus` (singleton), database connection config, and any API-specific services.
+
+#### Scenario: EventBus is singleton
+- **WHEN** the EventBus is resolved multiple times from the container
+- **THEN** the same instance is returned each time
+
+### Requirement: DTO serialization
+
+The system SHALL define DTO-serialization functions (`toOrderDto`, `toSessionDto`, `toMenuItemDto`) in `qup-api` that convert domain entities to the shared DTO types from `qup-shared`. API responses SHALL always use DTOs, never expose domain entities directly.
+
+#### Scenario: Order entity serialized to DTO
+- **WHEN** an Order entity is serialized via `toOrderDto`
+- **THEN** the result matches the `OrderDto` type from `qup-shared` with camelCase properties and ISO date strings

--- a/openspec/changes/qup/specs/qup-api/spec.md
+++ b/openspec/changes/qup/specs/qup-api/spec.md
@@ -87,7 +87,7 @@ The system SHALL expose the following REST endpoints:
 
 ### Requirement: ContainerModule for API-specific bindings
 
-The system SHALL provide an `apiModule` as an Inversify `ContainerModule` that binds API-layer services: `InMemoryEventBus` → `TOKENS.EventBus` (singleton), database connection config, and any API-specific services.
+The system SHALL provide an `apiModule` as an Inversify `ContainerModule` that binds API-layer services: `InMemoryEventBus` → `TOKENS.EventBus` (singleton) and other API-specific services. Database connection config SHALL be owned by `dataModule` (`qup-data`). The composition root (`container.ts`) SHALL read connection config from environment variables and pass it to `dataModule`.
 
 #### Scenario: EventBus is singleton
 - **WHEN** the EventBus is resolved multiple times from the container

--- a/openspec/changes/qup/specs/qup-menu-management/spec.md
+++ b/openspec/changes/qup/specs/qup-menu-management/spec.md
@@ -1,0 +1,97 @@
+## ADDED Requirements
+
+### Requirement: MenuItem entity
+
+The system SHALL model MenuItem as an entity in `qup-domain` with: id (UUID), name (string), category (Category value object), description (optional string), available (boolean, default true), sortOrder (number, default 0). `MenuItem.create()` SHALL validate input and return `Result<MenuItem, ValidationError>`.
+
+#### Scenario: Create a valid menu item
+- **WHEN** `MenuItem.create()` is called with name "Flat White", category COFFEE
+- **THEN** it returns `Ok<MenuItem>` with available=true and sortOrder=0
+
+#### Scenario: Create menu item with empty name
+- **WHEN** `MenuItem.create()` is called with an empty name
+- **THEN** it returns `Err<ValidationError>`
+
+### Requirement: Category value object
+
+The system SHALL define a Category value object with values: COFFEE, TEA, INFUSION, JUICE, OTHER. These SHALL be exhaustive for v1.
+
+#### Scenario: Valid categories
+- **WHEN** a Category is instantiated with "COFFEE", "TEA", "INFUSION", "JUICE", or "OTHER"
+- **THEN** a valid Category value object is returned
+
+#### Scenario: Invalid category
+- **WHEN** an unknown category string is provided
+- **THEN** a validation error is returned
+
+### Requirement: Toggle menu item availability
+
+The system SHALL allow toggling a MenuItem's `available` property. This is a simple boolean flip with no preconditions.
+
+#### Scenario: Toggle available to unavailable
+- **WHEN** `menuItem.toggleAvailability()` is called on an available item
+- **THEN** the item's `available` property becomes false
+
+#### Scenario: Toggle unavailable to available
+- **WHEN** `menuItem.toggleAvailability()` is called on an unavailable item
+- **THEN** the item's `available` property becomes true
+
+### Requirement: MenuItem repository interface
+
+The system SHALL define a `MenuItemRepository` interface in `qup-domain` with methods returning `ResultAsync`: `save(menuItem)`, `findById(id)`, `findAll()`, `findAllAvailable()`, `update(menuItem)`, `delete(id)`.
+
+#### Scenario: Find all available items
+- **WHEN** `findAllAvailable()` is called
+- **THEN** it returns `Ok<MenuItem[]>` containing only items with `available: true`, ordered by sortOrder ascending
+
+#### Scenario: Delete a menu item
+- **WHEN** `delete(id)` is called with a valid ID
+- **THEN** the item is removed and `Ok<void>` is returned
+
+### Requirement: Menu CRUD use cases
+
+The system SHALL provide `CreateMenuItemUseCase`, `UpdateMenuItemUseCase`, and `DeleteMenuItemUseCase` classes decorated with `@injectable()`. Each SHALL validate input, perform the operation via the repository, and return typed results.
+
+#### Scenario: Create a new menu item
+- **WHEN** `CreateMenuItemUseCase` is executed with valid input
+- **THEN** the item is persisted and `Ok<MenuItem>` is returned
+
+#### Scenario: Update menu item name
+- **WHEN** `UpdateMenuItemUseCase` is executed with a valid ID and new name
+- **THEN** the item is updated and `Ok<MenuItem>` is returned
+
+#### Scenario: Update non-existent menu item
+- **WHEN** `UpdateMenuItemUseCase` is executed with an unknown ID
+- **THEN** `Err<MenuItemNotFoundError>` is returned
+
+#### Scenario: Delete a menu item
+- **WHEN** `DeleteMenuItemUseCase` is executed with a valid ID
+- **THEN** the item is deleted and `Ok<void>` is returned
+
+### Requirement: GetMenu use case
+
+The system SHALL provide a `GetMenuUseCase` that retrieves menu items. It SHALL accept an optional `availableOnly` flag (default false). When true, it returns only available items.
+
+#### Scenario: Get full menu
+- **WHEN** executed with `availableOnly: false`
+- **THEN** all menu items are returned ordered by sortOrder
+
+#### Scenario: Get available menu only
+- **WHEN** executed with `availableOnly: true`
+- **THEN** only available menu items are returned ordered by sortOrder
+
+### Requirement: Drizzle menu_items table
+
+The system SHALL define a `menu_items` table: `id` (UUID PK), `name` (VARCHAR 100, NOT NULL), `category` (VARCHAR 20, NOT NULL), `description` (TEXT, nullable), `available` (BOOLEAN, NOT NULL, default true), `sort_order` (INTEGER, NOT NULL, default 0).
+
+#### Scenario: Table schema matches domain model
+- **WHEN** the menu_items table is inspected
+- **THEN** it has the specified columns with correct types and constraints
+
+### Requirement: MenuItem domain-persistence mapping
+
+The system SHALL provide `toDomain(row)` and `toRow(entity)` mapper functions for MenuItem in `qup-data`.
+
+#### Scenario: Round-trip mapping
+- **WHEN** a MenuItem entity is mapped to a row and back
+- **THEN** the resulting entity is equivalent to the original

--- a/openspec/changes/qup/specs/qup-order-management/spec.md
+++ b/openspec/changes/qup/specs/qup-order-management/spec.md
@@ -1,0 +1,141 @@
+## ADDED Requirements
+
+### Requirement: Order entity as aggregate root
+
+The system SHALL model Order as a DDD aggregate root in `qup-domain` with identity (UUID), sessionId, guestName, items (OrderItem[]), status (OrderStatus value object), notes (optional), timestamps (createdAt, updatedAt). Order SHALL encapsulate state transition rules. All status mutations SHALL return `Result` types.
+
+#### Scenario: Create a valid order
+- **WHEN** `Order.create()` is called with a sessionId, guestName, at least one item, and optional notes
+- **THEN** it returns `Ok<Order>` with status PENDING and createdAt/updatedAt set
+
+#### Scenario: Create order with no items
+- **WHEN** `Order.create()` is called with an empty items array
+- **THEN** it returns `Err<EmptyOrderError>`
+
+#### Scenario: Create order with empty guest name
+- **WHEN** `Order.create()` is called with an empty guestName
+- **THEN** it returns `Err<ValidationError>`
+
+### Requirement: OrderStatus value object with state machine
+
+The system SHALL model OrderStatus as a value object with states: PENDING, PREPARING, DONE, CANCELLED. Only the following transitions SHALL be allowed: PENDING→PREPARING, PREPARING→DONE, PENDING→CANCELLED. Any other transition SHALL return a typed error.
+
+#### Scenario: Valid transition PENDING to PREPARING
+- **WHEN** `order.markPreparing()` is called on an order with status PENDING
+- **THEN** status changes to PREPARING, updatedAt is refreshed, and `Ok<void>` is returned
+
+#### Scenario: Valid transition PREPARING to DONE
+- **WHEN** `order.markDone()` is called on an order with status PREPARING
+- **THEN** status changes to DONE, updatedAt is refreshed, and `Ok<void>` is returned
+
+#### Scenario: Invalid transition DONE to PREPARING
+- **WHEN** `order.markPreparing()` is called on an order with status DONE
+- **THEN** `Err<InvalidTransitionError>` is returned with from/to states
+
+#### Scenario: Invalid transition CANCELLED to any
+- **WHEN** any status mutation is called on an order with status CANCELLED
+- **THEN** `Err<InvalidTransitionError>` is returned
+
+### Requirement: Cancel an order
+
+The system SHALL allow cancellation only when the order status is PENDING. Cancellation from any other status SHALL return `Err<OrderNotCancellableError>`.
+
+#### Scenario: Cancel a pending order
+- **WHEN** `order.cancel()` is called on an order with status PENDING
+- **THEN** status changes to CANCELLED, updatedAt is refreshed, and `Ok<void>` is returned
+
+#### Scenario: Cancel a non-pending order
+- **WHEN** `order.cancel()` is called on an order with status PREPARING or DONE
+- **THEN** `Err<OrderNotCancellableError>` is returned with the order ID and current status
+
+### Requirement: OrderItem value object
+
+The system SHALL model OrderItem as an immutable value object with: menuItemId (UUID), menuItemName (string, denormalized), quantity (positive integer), customization (optional string). Quantity MUST be greater than zero.
+
+#### Scenario: Create valid order item
+- **WHEN** an OrderItem is created with menuItemId, menuItemName, quantity 2, customization "oat milk"
+- **THEN** a valid OrderItem value object is returned
+
+#### Scenario: Create order item with zero quantity
+- **WHEN** an OrderItem is created with quantity 0 or negative
+- **THEN** a validation error is returned
+
+### Requirement: Order repository interface
+
+The system SHALL define an `OrderRepository` interface in `qup-domain` with all methods returning `ResultAsync`: `save(order)`, `findById(id)`, `findBySessionId(sessionId)`, `updateStatus(id, status, updatedAt)`.
+
+#### Scenario: Find orders by session
+- **WHEN** `findBySessionId()` is called with a valid session ID
+- **THEN** it returns `Ok<Order[]>` with all orders for that session, ordered by createdAt ascending
+
+#### Scenario: Database error
+- **WHEN** any repository method encounters a database error
+- **THEN** it returns `Err<PersistenceError>`
+
+### Requirement: CreateOrder use case
+
+The system SHALL provide a `CreateOrderUseCase` decorated with `@injectable()`. It SHALL: validate the session exists and is open via `SessionRepository`, validate all menu items exist and are available via `MenuItemRepository`, create the Order entity, persist it via `OrderRepository`, emit `order:created` event via EventBus, and return the result. Each failure point SHALL return a specific typed error.
+
+#### Scenario: Successfully create an order
+- **WHEN** executed with a valid session code, guest name, and available menu items
+- **THEN** the order is persisted, `order:created` event is emitted, and `Ok<Order>` is returned
+
+#### Scenario: Session not found
+- **WHEN** executed with an unknown session code
+- **THEN** `Err<SessionNotFoundError>` is returned
+
+#### Scenario: Session is closed
+- **WHEN** executed against a CLOSED session
+- **THEN** `Err<SessionClosedError>` is returned
+
+#### Scenario: Menu item not available
+- **WHEN** one of the requested items has `available: false`
+- **THEN** `Err<MenuItemNotAvailableError>` is returned
+
+### Requirement: UpdateOrderStatus use case
+
+The system SHALL provide an `UpdateOrderStatusUseCase` decorated with `@injectable()`. It SHALL find the order, call the appropriate status transition method on the entity, persist the update, and emit `order:status` event.
+
+#### Scenario: Mark order as preparing
+- **WHEN** executed with an order ID and target status PREPARING
+- **THEN** the order transitions to PREPARING, is persisted, `order:status` event is emitted
+
+#### Scenario: Invalid transition
+- **WHEN** executed with a transition that violates the state machine
+- **THEN** `Err<InvalidTransitionError>` is returned
+
+### Requirement: CancelOrder use case
+
+The system SHALL provide a `CancelOrderUseCase` decorated with `@injectable()`. It SHALL find the order, call `order.cancel()`, persist the update, and emit `order:cancelled` event.
+
+#### Scenario: Cancel a pending order
+- **WHEN** executed with a PENDING order's ID
+- **THEN** the order is cancelled, persisted, `order:cancelled` event is emitted, and `Ok<void>` is returned
+
+#### Scenario: Cancel a non-pending order
+- **WHEN** executed with a non-PENDING order's ID
+- **THEN** `Err<OrderNotCancellableError>` is returned
+
+### Requirement: GetSessionOrders use case
+
+The system SHALL provide a `GetSessionOrdersUseCase` that retrieves all orders for a given session ID via the repository.
+
+#### Scenario: Retrieve orders for a session
+- **WHEN** executed with a valid session ID
+- **THEN** `Ok<Order[]>` is returned
+
+### Requirement: Drizzle orders and order_items tables
+
+The system SHALL define an `orders` table: `id` (UUID PK), `session_id` (UUID FK→sessions.id, NOT NULL), `guest_name` (VARCHAR 50, NOT NULL), `status` (VARCHAR 15, NOT NULL, default 'PENDING'), `notes` (TEXT, nullable), `created_at` (TIMESTAMP, NOT NULL, default now), `updated_at` (TIMESTAMP, NOT NULL, default now). And an `order_items` table: `id` (UUID PK), `order_id` (UUID FK→orders.id, NOT NULL), `menu_item_id` (UUID FK→menu_items.id, NOT NULL), `menu_item_name` (VARCHAR 100, NOT NULL), `quantity` (INTEGER, NOT NULL, >0), `customization` (TEXT, nullable).
+
+#### Scenario: Tables match domain model
+- **WHEN** the orders and order_items tables are inspected
+- **THEN** they have the specified columns, types, constraints, and foreign keys
+
+### Requirement: Order domain-persistence mapping
+
+The system SHALL provide `toDomain(row, itemRows)` and `toRow(entity)` mappers in `qup-data`. `toDomain` SHALL reconstruct the Order aggregate including its OrderItem value objects. `toRow` SHALL flatten to database rows for both the orders and order_items tables.
+
+#### Scenario: Map with order items
+- **WHEN** an order row and its item rows are mapped via `toDomain`
+- **THEN** an Order entity is returned with OrderItem value objects correctly hydrated

--- a/openspec/changes/qup/specs/qup-realtime-events/spec.md
+++ b/openspec/changes/qup/specs/qup-realtime-events/spec.md
@@ -1,0 +1,89 @@
+## ADDED Requirements
+
+### Requirement: EventBus port in domain
+
+The system SHALL define an `EventBus` interface in `qup-domain` as a port with methods: `emit<T>(event: string, payload: T): void` and `on<T>(event: string, handler: (payload: T) => void): () => void` (returns unsubscribe function). The EventBus token SHALL be defined in `qup-domain/src/tokens.ts`.
+
+#### Scenario: Emit and receive an event
+- **WHEN** a handler is registered for event "order:created" and an event is emitted
+- **THEN** the handler receives the payload
+
+#### Scenario: Unsubscribe from events
+- **WHEN** the unsubscribe function returned by `on()` is called
+- **THEN** the handler no longer receives events
+
+### Requirement: In-memory EventBus implementation
+
+The system SHALL provide an `InMemoryEventBus` class in `qup-api` decorated with `@injectable()`. It SHALL use Node.js native `EventEmitter` internally. It SHALL be bound as a singleton in the API container module.
+
+#### Scenario: Multiple listeners
+- **WHEN** multiple handlers are registered for the same event
+- **THEN** all handlers receive the payload when the event is emitted
+
+#### Scenario: No listeners
+- **WHEN** an event is emitted with no registered handlers
+- **THEN** no error occurs
+
+### Requirement: Domain events emitted by use cases
+
+The system SHALL emit the following events from use cases via the EventBus:
+- `order:created` — emitted by CreateOrderUseCase after successful persistence, payload: `{ order: Order, sessionId: string }`
+- `order:status` — emitted by UpdateOrderStatusUseCase after successful transition, payload: `{ orderId: string, status: OrderStatus, updatedAt: Date }`
+- `order:cancelled` — emitted by CancelOrderUseCase after successful cancellation, payload: `{ orderId: string }`
+- `session:closed` — emitted by CloseSessionUseCase after successful close, payload: `{ sessionId: string }`
+
+#### Scenario: Order creation emits event
+- **WHEN** an order is successfully created
+- **THEN** the `order:created` event is emitted with the order and sessionId
+
+#### Scenario: Order status change emits event
+- **WHEN** an order status is successfully updated
+- **THEN** the `order:status` event is emitted with orderId, new status, and updatedAt
+
+#### Scenario: Order cancellation emits event
+- **WHEN** an order is successfully cancelled
+- **THEN** the `order:cancelled` event is emitted with the orderId
+
+#### Scenario: Session close emits event
+- **WHEN** a session is successfully closed
+- **THEN** the `session:closed` event is emitted with the sessionId
+
+### Requirement: SSE endpoint
+
+The system SHALL expose `GET /events/sessions/:code` as an SSE endpoint in `qup-api`. It SHALL listen to the EventBus, filter events by the session's ID (resolved from the code parameter), and stream them as Server-Sent Events. Each SSE message SHALL use the event name as the `event:` field and JSON-serialized payload as the `data:` field.
+
+#### Scenario: Client receives order created event
+- **WHEN** a client is connected to `/events/sessions/ABC123` and an order is created for that session
+- **THEN** the client receives an SSE message with `event: order:created` and `data: {"order":...}`
+
+#### Scenario: Client does not receive events from other sessions
+- **WHEN** a client is connected to `/events/sessions/ABC123` and an order is created for session XYZ789
+- **THEN** the client does NOT receive the event
+
+#### Scenario: Invalid session code
+- **WHEN** a client connects with a non-existent session code
+- **THEN** the endpoint returns a 404 response
+
+#### Scenario: Client disconnects
+- **WHEN** the client closes the EventSource connection
+- **THEN** the server unsubscribes the EventBus listeners for that client (no memory leak)
+
+### Requirement: Client-side SSE consumption
+
+The system SHALL consume SSE events in `qup-web` using the browser's native `EventSource` API. An `EventSourceService` class SHALL be provided (injectable via Inversify in the web container) that wraps EventSource, adds typed event listeners, and exposes a cleanup function for use with ViewModel's `addCleanup`.
+
+#### Scenario: Subscribe to session events
+- **WHEN** the EventSourceService subscribes to a session code
+- **THEN** it creates an EventSource connection to `{API_URL}/events/sessions/{code}`
+
+#### Scenario: Receive and parse event
+- **WHEN** an SSE event arrives
+- **THEN** the service parses the JSON data and invokes the typed callback
+
+#### Scenario: Auto-reconnect
+- **WHEN** the SSE connection drops
+- **THEN** the browser's native EventSource reconnects automatically
+
+#### Scenario: Cleanup on unmount
+- **WHEN** the cleanup function is called (via ViewModel willUnmount)
+- **THEN** the EventSource connection is closed

--- a/openspec/changes/qup/specs/qup-realtime-events/spec.md
+++ b/openspec/changes/qup/specs/qup-realtime-events/spec.md
@@ -28,8 +28,8 @@ The system SHALL provide an `InMemoryEventBus` class in `qup-api` decorated with
 
 The system SHALL emit the following events from use cases via the EventBus:
 - `order:created` — emitted by CreateOrderUseCase after successful persistence, payload: `{ order: Order, sessionId: string }`
-- `order:status` — emitted by UpdateOrderStatusUseCase after successful transition, payload: `{ orderId: string, status: OrderStatus, updatedAt: Date }`
-- `order:cancelled` — emitted by CancelOrderUseCase after successful cancellation, payload: `{ orderId: string }`
+- `order:status` — emitted by UpdateOrderStatusUseCase after successful transition, payload: `{ orderId: string, sessionId: string, status: OrderStatus, updatedAt: Date }`
+- `order:cancelled` — emitted by CancelOrderUseCase after successful cancellation, payload: `{ orderId: string, sessionId: string }`
 - `session:closed` — emitted by CloseSessionUseCase after successful close, payload: `{ sessionId: string }`
 
 #### Scenario: Order creation emits event
@@ -38,11 +38,11 @@ The system SHALL emit the following events from use cases via the EventBus:
 
 #### Scenario: Order status change emits event
 - **WHEN** an order status is successfully updated
-- **THEN** the `order:status` event is emitted with orderId, new status, and updatedAt
+- **THEN** the `order:status` event is emitted with orderId, sessionId, new status, and updatedAt
 
 #### Scenario: Order cancellation emits event
 - **WHEN** an order is successfully cancelled
-- **THEN** the `order:cancelled` event is emitted with the orderId
+- **THEN** the `order:cancelled` event is emitted with the orderId and sessionId
 
 #### Scenario: Session close emits event
 - **WHEN** a session is successfully closed

--- a/openspec/changes/qup/specs/qup-session-management/spec.md
+++ b/openspec/changes/qup/specs/qup-session-management/spec.md
@@ -1,0 +1,121 @@
+## ADDED Requirements
+
+### Requirement: Session entity as aggregate root
+
+The system SHALL model Session as a DDD aggregate root in `qup-domain` with identity (UUID), name, code (SessionCode value object), status (SessionStatus value object), timestamps (createdAt, closedAt). Session SHALL encapsulate its own state transition rules. All operations on sessions SHALL return `Result` or `ResultAsync` from neverthrow.
+
+#### Scenario: Create a new session
+- **WHEN** the host creates a session with a name
+- **THEN** the system generates a unique 6-character alphanumeric uppercase code (SessionCode), sets status to OPEN, sets createdAt to current time, and returns `Ok<Session>`
+
+#### Scenario: Create session with empty name
+- **WHEN** the host creates a session with an empty or whitespace-only name
+- **THEN** the system returns `Err<ValidationError>`
+
+### Requirement: SessionCode value object
+
+The system SHALL model SessionCode as an immutable value object. It SHALL be exactly 6 characters, alphanumeric, uppercase. SessionCode SHALL provide a static `generate()` factory that creates a random code and a static `from(raw: string)` factory that validates and returns `Result<SessionCode, InvalidCodeError>`.
+
+#### Scenario: Generate a session code
+- **WHEN** `SessionCode.generate()` is called
+- **THEN** it returns a SessionCode with a 6-character alphanumeric uppercase string
+
+#### Scenario: Parse a valid code
+- **WHEN** `SessionCode.from("ABC123")` is called
+- **THEN** it returns `Ok<SessionCode>`
+
+#### Scenario: Parse an invalid code
+- **WHEN** `SessionCode.from("abc")` is called with invalid format (wrong length, lowercase, or special chars)
+- **THEN** it returns `Err<InvalidCodeError>`
+
+### Requirement: Close a session
+
+The system SHALL allow the host to close an open session. Closing SHALL set status to CLOSED and record closedAt timestamp. Closing an already-closed session SHALL return a typed error.
+
+#### Scenario: Close an open session
+- **WHEN** the host closes a session with status OPEN
+- **THEN** the session status changes to CLOSED, closedAt is set, and the system returns `Ok<void>`
+
+#### Scenario: Close an already closed session
+- **WHEN** the host closes a session with status CLOSED
+- **THEN** the system returns `Err<SessionAlreadyClosedError>`
+
+### Requirement: Join a session by code
+
+The system SHALL allow guests to look up an active session by its code. If the session exists and is open, it SHALL be returned. If not found or closed, a typed error SHALL be returned.
+
+#### Scenario: Join with valid code for open session
+- **WHEN** a guest provides a valid session code for an OPEN session
+- **THEN** the system returns `Ok<Session>`
+
+#### Scenario: Join with valid code for closed session
+- **WHEN** a guest provides a valid session code for a CLOSED session
+- **THEN** the system returns `Err<SessionClosedError>`
+
+#### Scenario: Join with unknown code
+- **WHEN** a guest provides a code that matches no session
+- **THEN** the system returns `Err<SessionNotFoundError>`
+
+### Requirement: Session repository interface
+
+The system SHALL define a `SessionRepository` interface in `qup-domain` with methods returning `ResultAsync`. The implementation SHALL live in `qup-data` using Drizzle + PostgreSQL. The interface SHALL include: `save(session)`, `findByCode(code)`, `findById(id)`, `updateStatus(id, status, closedAt?)`.
+
+#### Scenario: Persist a new session
+- **WHEN** `save()` is called with a valid Session entity
+- **THEN** the session is persisted to PostgreSQL and the saved Session is returned as `Ok<Session>`
+
+#### Scenario: Database error during save
+- **WHEN** `save()` encounters a database error
+- **THEN** it returns `Err<PersistenceError>` wrapping the underlying cause
+
+### Requirement: CreateSession use case
+
+The system SHALL provide a `CreateSessionUseCase` class decorated with `@injectable()` in `qup-domain`. It SHALL receive `SessionRepository` via `@inject`. It SHALL generate a SessionCode, create a Session entity, persist it, and return the result.
+
+#### Scenario: Successfully create a session
+- **WHEN** the use case is executed with `{ name: "Sunday Brunch" }`
+- **THEN** it creates and persists a session with a generated code and returns `Ok<Session>`
+
+### Requirement: CloseSession use case
+
+The system SHALL provide a `CloseSessionUseCase` class decorated with `@injectable()`. It SHALL find the session by ID, call `session.close()`, persist the updated status, and emit a `session:closed` event via EventBus.
+
+#### Scenario: Successfully close a session
+- **WHEN** the use case is executed with a valid session ID for an OPEN session
+- **THEN** it closes the session, persists the change, emits `session:closed`, and returns `Ok<void>`
+
+#### Scenario: Session not found
+- **WHEN** the use case is executed with an unknown session ID
+- **THEN** it returns `Err<SessionNotFoundError>`
+
+### Requirement: GetSessionByCode use case
+
+The system SHALL provide a `GetSessionByCodeUseCase` that validates the code format via `SessionCode.from()`, queries the repository, and returns the session or a typed error.
+
+#### Scenario: Retrieve session by valid code
+- **WHEN** the use case receives a valid, existing session code
+- **THEN** it returns `Ok<Session>`
+
+#### Scenario: Invalid code format
+- **WHEN** the use case receives a malformed code
+- **THEN** it returns `Err<InvalidCodeError>` without querying the database
+
+### Requirement: Drizzle sessions table
+
+The system SHALL define a `sessions` table in `qup-data` using Drizzle schema: `id` (UUID, PK, default random), `name` (VARCHAR 100, NOT NULL), `code` (VARCHAR 6, NOT NULL, UNIQUE), `status` (VARCHAR 10, NOT NULL, default 'OPEN'), `created_at` (TIMESTAMP, NOT NULL, default now), `closed_at` (TIMESTAMP, nullable).
+
+#### Scenario: Table schema matches domain model
+- **WHEN** the sessions table is inspected
+- **THEN** it has columns for id, name, code, status, created_at, closed_at with the specified types and constraints
+
+### Requirement: Session domain-persistence mapping
+
+The system SHALL provide `toDomain(row)` and `toRow(entity)` mapper functions in `qup-data`. `toDomain` SHALL reconstruct the Session entity without re-validating (data from DB is trusted). `toRow` SHALL flatten the entity to database column format.
+
+#### Scenario: Map database row to domain entity
+- **WHEN** a row from the sessions table is mapped via `toDomain`
+- **THEN** a Session entity is returned with all properties correctly hydrated including SessionCode and SessionStatus value objects
+
+#### Scenario: Map domain entity to database row
+- **WHEN** a Session entity is mapped via `toRow`
+- **THEN** a plain object is returned with snake_case keys matching the Drizzle schema columns

--- a/openspec/changes/qup/specs/qup-web/spec.md
+++ b/openspec/changes/qup/specs/qup-web/spec.md
@@ -1,0 +1,104 @@
+## ADDED Requirements
+
+### Requirement: SolidStart application with hybrid rendering
+
+The system SHALL create a SolidStart application in `apps/qup-web` with file-based routing, Tailwind CSS, and Solid UI components. The application SHALL use SSR for initial page loads and client-side hydration for interactivity.
+
+#### Scenario: Application starts in dev mode
+- **WHEN** the dev server is started
+- **THEN** the SolidStart application serves on the configured port with hot reload
+
+### Requirement: MVVM pattern with ViewModels
+
+All page-level state and logic SHALL be managed by ViewModel classes (extending `BaseViewModel` from `solid-clean`). Page components SHALL be pure render functions that consume signals from ViewModels. ViewModels SHALL be decorated with `@injectable()` and resolved from the Inversify container.
+
+#### Scenario: Page uses ViewModel
+- **WHEN** a page component renders
+- **THEN** it creates a ViewModel via `useViewModel(() => container.get(TOKEN))` and renders based on the VM's signals
+
+#### Scenario: ViewModel manages state
+- **WHEN** data needs to be loaded or state needs to change
+- **THEN** the ViewModel handles it internally and exposes results via Solid signals
+
+### Requirement: Inversify singleton container
+
+The system SHALL create a singleton Inversify container in `qup-web/src/container.ts` that loads a `webModule` binding all frontend services. The container SHALL be exported directly — no Context Provider wrapper.
+
+#### Scenario: Import container in ViewModel
+- **WHEN** a ViewModel or page needs to resolve a dependency
+- **THEN** it imports the container directly from the container module
+
+### Requirement: Server functions as BFF
+
+The system SHALL use SolidStart `"use server"` functions for data loading and mutations. Server functions SHALL call the Hono API internally, handle auth (PIN from httpOnly cookie), and return typed results using neverthrow `Result`. The browser SHALL never call the Hono API directly except for SSE connections.
+
+#### Scenario: Data loading via server function
+- **WHEN** a page needs to load session orders
+- **THEN** a server function fetches from the Hono API and returns the data
+
+#### Scenario: Mutation via server function
+- **WHEN** the admin changes an order status
+- **THEN** a server function sends the PATCH to Hono with the PIN from the cookie
+
+#### Scenario: Server function returns typed Result
+- **WHEN** the Hono API returns an error response
+- **THEN** the server function returns `Err<ApiErrorDto>` (not throws)
+
+### Requirement: Guest flow routes
+
+The system SHALL provide these guest-facing routes:
+- `/` — landing page (SSR)
+- `/session/:code` — session menu view (SSR + hydration). Displays the menu for the session, guest enters their name.
+- `/session/:code/order` — order creation (CSR). Guest selects items, customizations, submits.
+- `/session/:code/status` — order status (CSR + SSE). Guest sees their orders and real-time status updates.
+
+#### Scenario: Guest joins session
+- **WHEN** a guest navigates to `/session/ABC123`
+- **THEN** the session menu is displayed with available items, rendered via SSR
+
+#### Scenario: Guest places order
+- **WHEN** a guest selects items and submits from `/session/ABC123/order`
+- **THEN** the order is created via server function and guest is redirected to status page
+
+#### Scenario: Guest sees real-time status
+- **WHEN** a guest is on `/session/ABC123/status` and the host marks their order as PREPARING
+- **THEN** the status updates in real-time via SSE without page reload
+
+### Requirement: Admin flow routes
+
+The system SHALL provide these admin-facing routes:
+- `/admin` — admin login (SSR). PIN entry form.
+- `/admin/dashboard` — active session dashboard (SSR + hydration). Shows current session and order queue.
+- `/admin/session/:id` — session order management (CSR + SSE). Real-time order queue with status controls.
+- `/admin/menu` — menu management (SSR + hydration). CRUD for menu items.
+
+#### Scenario: Admin enters PIN
+- **WHEN** the admin enters a valid PIN on `/admin`
+- **THEN** a server function validates it and sets an httpOnly cookie, redirecting to dashboard
+
+#### Scenario: Admin manages order queue
+- **WHEN** the admin views `/admin/session/:id`
+- **THEN** orders are displayed in real-time, grouped by status, with buttons to advance status or cancel
+
+#### Scenario: Admin manages menu
+- **WHEN** the admin visits `/admin/menu`
+- **THEN** all menu items are listed with options to create, edit, delete, and toggle availability
+
+### Requirement: Frontend services via Inversify
+
+The system SHALL provide injectable frontend services in the web container:
+- `HttpClient` — wraps fetch with base URL and error handling
+- `ApiClient` — typed methods for each API endpoint, uses server functions internally
+- `EventSourceService` — wraps browser EventSource for SSE, provides typed callbacks and cleanup
+
+#### Scenario: ApiClient resolves from container
+- **WHEN** `container.get(TOKENS.ApiClient)` is called
+- **THEN** an ApiClient instance is returned with HttpClient injected
+
+### Requirement: Solid UI + Tailwind integration
+
+The system SHALL use Solid UI (shadcn-solid / Kobalte) for accessible UI primitives and Tailwind CSS for styling. Components SHALL be mobile-friendly (guests use phones).
+
+#### Scenario: Mobile-responsive menu
+- **WHEN** a guest views the menu on a phone-sized screen
+- **THEN** the layout is responsive and usable with touch interactions

--- a/openspec/changes/qup/specs/solid-clean/spec.md
+++ b/openspec/changes/qup/specs/solid-clean/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: BaseViewModel abstract class
+
+The system SHALL provide an abstract `BaseViewModel` class in `packages/solid-clean` with:
+- A private `cleanups` array of `(() => void)` functions
+- `addCleanup(...fns: (() => void)[]): void` — adds cleanup functions to the list
+- `didMount(owner?: Owner): Promise<void> | void` — lifecycle hook called on component mount, receives optional Solid Owner for reactive scope access
+- `willUnmount(): void` — executes all cleanup functions and resets the array
+
+`BaseViewModel` SHALL NOT depend on inversify, rxjs, or any DI framework. It SHALL NOT use `@injectable()` — concrete ViewModels in consuming apps add that decorator themselves.
+
+#### Scenario: Add and execute cleanups
+- **WHEN** `addCleanup(fn1, fn2)` is called and then `willUnmount()` is called
+- **THEN** both fn1 and fn2 are executed
+
+#### Scenario: Cleanups reset after willUnmount
+- **WHEN** `willUnmount()` is called, then new cleanups are added, then `willUnmount()` is called again
+- **THEN** only the newly added cleanups are executed on the second call
+
+#### Scenario: didMount receives owner
+- **WHEN** `didMount(owner)` is called with a Solid Owner
+- **THEN** the ViewModel can use `runWithOwner(owner, ...)` to create effects within the component's reactive scope
+
+#### Scenario: didMount without owner
+- **WHEN** `didMount()` is called without an owner
+- **THEN** it executes normally (owner is optional)
+
+### Requirement: useViewModel hook
+
+The system SHALL provide a `useViewModel<T extends BaseViewModel>(factory: () => T): T` function that:
+1. Calls the factory function once to create the ViewModel instance (no ref needed — Solid components execute once)
+2. Captures the current Solid owner via `getOwner()`
+3. Calls `vm.didMount(owner)` inside `onMount()`
+4. Registers `vm.willUnmount()` via `onCleanup()`
+5. Returns the ViewModel instance
+
+#### Scenario: ViewModel created once
+- **WHEN** `useViewModel(() => new MyVM())` is called
+- **THEN** the factory is invoked exactly once and the VM instance is returned
+
+#### Scenario: Lifecycle wired to Solid
+- **WHEN** the component mounts
+- **THEN** `didMount` is called with the component's owner
+
+#### Scenario: Cleanup on unmount
+- **WHEN** the component is unmounted
+- **THEN** `willUnmount()` is called, executing all registered cleanups
+
+### Requirement: Package structure and exports
+
+The package SHALL be named `@m0n0lab/solid-clean` and SHALL export exactly two items: `BaseViewModel` and `useViewModel`. Peer dependency SHALL be `solid-js` only. The package SHALL have zero runtime dependencies. It SHALL follow the same build conventions as `@m0n0lab/react-clean`: tsdown build, Vitest tests, ESM-only, exports validated with `attw --pack`.
+
+#### Scenario: Package exports
+- **WHEN** `@m0n0lab/solid-clean` is imported
+- **THEN** `BaseViewModel` and `useViewModel` are available as named exports
+
+#### Scenario: No inversify dependency
+- **WHEN** the package's dependencies and peerDependencies are inspected
+- **THEN** inversify is NOT listed (consuming apps bring their own DI)
+
+#### Scenario: Build output validation
+- **WHEN** `attw --pack` is run against the built package
+- **THEN** exports resolve correctly for ESM consumers
+
+### Requirement: Test coverage
+
+The system SHALL include unit tests for `BaseViewModel` (lifecycle, cleanup management) and `useViewModel` (Solid lifecycle integration). Tests SHALL follow the same patterns as `@m0n0lab/react-clean` tests: factory mocks, lifecycle verification, re-render safety (though Solid components run once, ensuring no double-execution).
+
+#### Scenario: BaseViewModel unit tests
+- **WHEN** the test suite runs
+- **THEN** BaseViewModel cleanup add/execute/reset behavior is verified
+
+#### Scenario: useViewModel integration tests
+- **WHEN** the test suite runs with a Solid testing environment
+- **THEN** onMount→didMount and onCleanup→willUnmount wiring is verified

--- a/openspec/changes/qup/tasks.md
+++ b/openspec/changes/qup/tasks.md
@@ -103,8 +103,8 @@
 - [ ] 7.10 Implement `createMenuRoutes(container)` — GET /menu, POST /menu, PATCH /menu/:id, DELETE /menu/:id
 - [ ] 7.11 Implement `createEventRoutes(container)` — GET /events/sessions/:code (SSE endpoint)
 - [ ] 7.12 Implement `createApp(container)` — mount all routes, CORS, error middleware
-- [ ] 7.13 Create `apiModule` (ContainerModule) — bind InMemoryEventBus as singleton, DB config
-- [ ] 7.14 Implement `createContainer()` composition root — load domainModule, dataModule, apiModule
+- [ ] 7.13 Create `apiModule` (ContainerModule) — bind InMemoryEventBus as singleton, API-specific services only
+- [ ] 7.14 Implement `createContainer()` composition root — read DB config from env, pass to dataModule, load domainModule, dataModule, apiModule
 - [ ] 7.15 Implement entry point (index.ts) — validate API_ADMIN_PIN, create container, start server
 - [ ] 7.16 Add Docker Compose file for local PostgreSQL
 - [ ] 7.17 Test full API flow: create session → create order → update status → SSE events

--- a/openspec/changes/qup/tasks.md
+++ b/openspec/changes/qup/tasks.md
@@ -1,0 +1,139 @@
+## 1. Scaffold packages and apps
+
+- [ ] 1.1 Scaffold `packages/solid-clean` — package.json (peerDep: solid-js), tsconfig (experimentalDecorators: false), tsdown.config, vitest.config, src/index.ts
+- [ ] 1.2 Scaffold `packages/qup-domain` — package.json (deps: inversify, neverthrow), tsconfig (experimentalDecorators: true, emitDecoratorMetadata: true), tsdown.config, vitest.config, src/index.ts
+- [ ] 1.3 Scaffold `packages/qup-shared` — package.json (dep: neverthrow for types), tsconfig, tsdown.config, src/index.ts
+- [ ] 1.4 Scaffold `packages/qup-data` — package.json (deps: qup-domain via workspace:*, drizzle-orm, pg), tsconfig, tsdown.config, vitest.config, src/index.ts
+- [ ] 1.5 Scaffold `apps/qup-api` — package.json (deps: qup-domain, qup-data, qup-shared via workspace:*, hono, inversify), tsconfig, src/index.ts
+- [ ] 1.6 Scaffold `apps/qup-web` — SolidStart project with Tailwind CSS, Solid UI, file-based routing, tsconfig (experimentalDecorators: true), deps: qup-shared via workspace:*, solid-clean via workspace:*, inversify
+- [ ] 1.7 Run `pnpm install` and verify all workspace links resolve
+- [ ] 1.8 Verify `nx run-many --target=build` succeeds for all new projects (may need nx project.json or package.json targets)
+
+## 2. solid-clean package
+
+- [ ] 2.1 Implement `BaseViewModel` abstract class — cleanups array, addCleanup(), didMount(owner?), willUnmount()
+- [ ] 2.2 Write unit tests for BaseViewModel — cleanup add/execute/reset behavior
+- [ ] 2.3 Implement `useViewModel` hook — factory call, getOwner(), onMount→didMount, onCleanup→willUnmount
+- [ ] 2.4 Write integration tests for useViewModel with Solid testing environment
+- [ ] 2.5 Export BaseViewModel and useViewModel from index.ts
+- [ ] 2.6 Verify build: `nx run @m0n0lab/solid-clean:build` and validate exports with `attw --pack`
+
+## 3. qup-domain — value objects and entities
+
+- [ ] 3.1 Implement `DomainError` base class and all error types: SessionNotFoundError, SessionClosedError, SessionAlreadyClosedError, OrderNotFoundError, OrderNotCancellableError, InvalidTransitionError, EmptyOrderError, MenuItemNotFoundError, MenuItemNotAvailableError, ValidationError, InvalidCodeError
+- [ ] 3.2 Implement `SessionStatus` value object (OPEN, CLOSED)
+- [ ] 3.3 Implement `OrderStatus` value object with state machine (PENDING→PREPARING→DONE, PENDING→CANCELLED)
+- [ ] 3.4 Write tests for OrderStatus transitions — valid and invalid
+- [ ] 3.5 Implement `Category` value object (COFFEE, TEA, INFUSION, JUICE, OTHER)
+- [ ] 3.6 Implement `SessionCode` value object — generate(), from(), validation
+- [ ] 3.7 Write tests for SessionCode — generate format, from valid/invalid
+- [ ] 3.8 Implement `OrderItem` value object — menuItemId, menuItemName, quantity (>0), customization
+- [ ] 3.9 Implement `Session` entity — create(), close(), isOpen(), state transitions returning Result
+- [ ] 3.10 Write tests for Session — create valid/invalid, close open/already-closed
+- [ ] 3.11 Implement `Order` entity — create(), markPreparing(), markDone(), cancel(), all returning Result
+- [ ] 3.12 Write tests for Order — create valid/empty items, all status transitions, cancel from each state
+- [ ] 3.13 Implement `MenuItem` entity — create(), toggleAvailability()
+- [ ] 3.14 Write tests for MenuItem — create valid/invalid, toggle
+
+## 4. qup-domain — repository interfaces, tokens, and use cases
+
+- [ ] 4.1 Define tokens in `src/tokens.ts` — Symbols for all repositories, use cases, EventBus
+- [ ] 4.2 Define `SessionRepository` interface with ResultAsync methods
+- [ ] 4.3 Define `OrderRepository` interface with ResultAsync methods
+- [ ] 4.4 Define `MenuItemRepository` interface with ResultAsync methods
+- [ ] 4.5 Define `EventBus` port interface (emit, on)
+- [ ] 4.6 Implement `CreateSessionUseCase` (@injectable) — generate code, create session, persist
+- [ ] 4.7 Write tests for CreateSessionUseCase with mock repos
+- [ ] 4.8 Implement `CloseSessionUseCase` (@injectable) — find, close, persist, emit event
+- [ ] 4.9 Write tests for CloseSessionUseCase
+- [ ] 4.10 Implement `GetSessionByCodeUseCase` (@injectable) — validate code, query repo
+- [ ] 4.11 Write tests for GetSessionByCodeUseCase
+- [ ] 4.12 Implement `CreateOrderUseCase` (@injectable) — validate session open, validate items available, create order, persist, emit event
+- [ ] 4.13 Write tests for CreateOrderUseCase — all success/failure paths
+- [ ] 4.14 Implement `UpdateOrderStatusUseCase` (@injectable) — find order, transition, persist, emit event
+- [ ] 4.15 Write tests for UpdateOrderStatusUseCase
+- [ ] 4.16 Implement `CancelOrderUseCase` (@injectable) — find order, cancel, persist, emit event
+- [ ] 4.17 Write tests for CancelOrderUseCase
+- [ ] 4.18 Implement `GetSessionOrdersUseCase` (@injectable)
+- [ ] 4.19 Implement `GetMenuUseCase` (@injectable) — availableOnly flag
+- [ ] 4.20 Implement `CreateMenuItemUseCase`, `UpdateMenuItemUseCase`, `DeleteMenuItemUseCase` (@injectable)
+- [ ] 4.21 Write tests for menu use cases
+- [ ] 4.22 Create `domainModule` (ContainerModule) binding all use cases
+- [ ] 4.23 Export all public API from index.ts
+- [ ] 4.24 Verify build: `nx run @m0n0lab/qup-domain:build`
+
+## 5. qup-shared — DTOs and API types
+
+- [ ] 5.1 Define `SessionDto`, `OrderDto`, `OrderItemDto`, `MenuItemDto` types
+- [ ] 5.2 Define `ApiErrorDto` type (code, message, statusCode)
+- [ ] 5.3 Define request types: `CreateOrderRequest`, `CreateSessionRequest`, `CreateMenuItemRequest`, `UpdateMenuItemRequest`, `UpdateOrderStatusRequest`
+- [ ] 5.4 Define SSE event payload types: `OrderCreatedEvent`, `OrderStatusEvent`, `OrderCancelledEvent`, `SessionClosedEvent`
+- [ ] 5.5 Export all from index.ts
+- [ ] 5.6 Verify build: `nx run @m0n0lab/qup-shared:build` and validate exports with `attw --pack`
+
+## 6. qup-data — Drizzle schema and repositories
+
+- [ ] 6.1 Define Drizzle schema: `sessions` table
+- [ ] 6.2 Define Drizzle schema: `orders` table with FK to sessions
+- [ ] 6.3 Define Drizzle schema: `order_items` table with FKs to orders and menu_items
+- [ ] 6.4 Define Drizzle schema: `menu_items` table
+- [ ] 6.5 Configure Drizzle Kit for migrations (drizzle.config.ts)
+- [ ] 6.6 Generate initial migration
+- [ ] 6.7 Implement `toDomain` / `toRow` mappers for Session
+- [ ] 6.8 Implement `toDomain` / `toRow` mappers for Order (including OrderItems)
+- [ ] 6.9 Implement `toDomain` / `toRow` mappers for MenuItem
+- [ ] 6.10 Implement `PgSessionRepository` (@injectable) implementing SessionRepository with Drizzle queries wrapped in ResultAsync
+- [ ] 6.11 Implement `PgOrderRepository` (@injectable) implementing OrderRepository
+- [ ] 6.12 Implement `PgMenuItemRepository` (@injectable) implementing MenuItemRepository
+- [ ] 6.13 Create `dataModule` (ContainerModule) binding all repos and database connection
+- [ ] 6.14 Export public API from index.ts
+- [ ] 6.15 Verify build: `nx run @m0n0lab/qup-data:build`
+
+## 7. qup-api — Hono application
+
+- [ ] 7.1 Implement `InMemoryEventBus` (@injectable, singleton) using Node EventEmitter
+- [ ] 7.2 Write tests for InMemoryEventBus
+- [ ] 7.3 Implement `adminOnly` middleware — checks X-Admin-Pin header against API_ADMIN_PIN env var
+- [ ] 7.4 Write tests for adminOnly middleware
+- [ ] 7.5 Implement `toApiError` and `errorToHttp` mapping functions
+- [ ] 7.6 Write tests for error mapping (all domain errors → correct HTTP status)
+- [ ] 7.7 Implement DTO serializers: `toOrderDto`, `toSessionDto`, `toMenuItemDto`
+- [ ] 7.8 Implement `createSessionRoutes(container)` — POST /sessions, GET /sessions/:code, PATCH /sessions/:id/close
+- [ ] 7.9 Implement `createOrderRoutes(container)` — POST /orders, GET /orders, PATCH /orders/:id/status, DELETE /orders/:id
+- [ ] 7.10 Implement `createMenuRoutes(container)` — GET /menu, POST /menu, PATCH /menu/:id, DELETE /menu/:id
+- [ ] 7.11 Implement `createEventRoutes(container)` — GET /events/sessions/:code (SSE endpoint)
+- [ ] 7.12 Implement `createApp(container)` — mount all routes, CORS, error middleware
+- [ ] 7.13 Create `apiModule` (ContainerModule) — bind InMemoryEventBus as singleton, DB config
+- [ ] 7.14 Implement `createContainer()` composition root — load domainModule, dataModule, apiModule
+- [ ] 7.15 Implement entry point (index.ts) — validate API_ADMIN_PIN, create container, start server
+- [ ] 7.16 Add Docker Compose file for local PostgreSQL
+- [ ] 7.17 Test full API flow: create session → create order → update status → SSE events
+
+## 8. qup-web — SolidStart frontend
+
+- [ ] 8.1 Configure Tailwind CSS and Solid UI (Kobalte) in the SolidStart project
+- [ ] 8.2 Create `webModule` (ContainerModule) binding HttpClient, ApiClient, EventSourceService
+- [ ] 8.3 Create singleton container in `src/container.ts` loading webModule
+- [ ] 8.4 Implement `HttpClient` service (@injectable) — base fetch wrapper
+- [ ] 8.5 Implement `ApiClient` service (@injectable, depends on HttpClient) — typed methods using server functions
+- [ ] 8.6 Implement `EventSourceService` (@injectable) — wraps EventSource, typed callbacks, cleanup
+- [ ] 8.7 Implement server functions for data loading: getSessionByCode, getMenu, getSessionOrders
+- [ ] 8.8 Implement server functions for mutations: createOrder, updateOrderStatus, cancelOrder, createSession, closeSession
+- [ ] 8.9 Implement server function for admin auth: login (validate PIN, set httpOnly cookie), logout
+- [ ] 8.10 Implement guest routes: `/` landing page
+- [ ] 8.11 Implement guest routes: `/session/:code` — session menu view with JoinSessionViewModel
+- [ ] 8.12 Implement guest routes: `/session/:code/order` — order form with CreateOrderViewModel
+- [ ] 8.13 Implement guest routes: `/session/:code/status` — order status with OrderStatusViewModel + SSE
+- [ ] 8.14 Implement admin routes: `/admin` — PIN login with AdminLoginViewModel
+- [ ] 8.15 Implement admin routes: `/admin/dashboard` — session dashboard with DashboardViewModel
+- [ ] 8.16 Implement admin routes: `/admin/session/:id` — order queue with OrderQueueViewModel + SSE
+- [ ] 8.17 Implement admin routes: `/admin/menu` — menu CRUD with MenuManagementViewModel
+- [ ] 8.18 Add SolidStart middleware for admin route protection (redirect to /admin if no valid cookie)
+- [ ] 8.19 Test full flow: create session → guest joins → places order → admin sees and manages
+
+## 9. Integration and verification
+
+- [ ] 9.1 Verify `nx run-many --target=build` succeeds for all qup projects
+- [ ] 9.2 Verify `nx run-many --target=test` passes for solid-clean, qup-domain, qup-api
+- [ ] 9.3 End-to-end manual test: full guest + admin flow on local network
+- [ ] 9.4 Verify `attw --pack` passes for solid-clean and qup-shared (publishable packages)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added extensive Qup documentation: design, proposal, domain specs (sessions, orders, menu, realtime events, admin auth), API and web specs, MVVM/solid-clean spec, DTOs and event contracts, and implementation blueprints.
  * Added project tasks and roadmap detailing scaffolding, packages, and integration steps.

* **Chores**
  * Added metadata/config file for the Qup changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->