### PR TITLE
chore(openspec): oxfmt migration proposal

### DIFF
--- a/openspec/changes/migrate-prettier-to-oxfmt/.openspec.yaml
+++ b/openspec/changes/migrate-prettier-to-oxfmt/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-02

--- a/openspec/changes/migrate-prettier-to-oxfmt/design.md
+++ b/openspec/changes/migrate-prettier-to-oxfmt/design.md
@@ -62,11 +62,11 @@ oxfmt is a Rust-based Prettier-compatible formatter (100% JS/TS conformance) wit
         "internalPattern": ["@m0n0lab/"],
         "newlinesBetween": false,
         "groups": [
-            "builtin",
-            "external",
-            ["internal", "subpath"],
-            ["parent", "sibling", "index"],
-            "type",
+            "value-builtin",
+            "value-external",
+            ["value-internal", "value-subpath"],
+            ["value-parent", "value-sibling", "value-index"],
+            "type-import",
             "unknown"
         ]
     },
@@ -83,7 +83,7 @@ Only non-default values are specified. Defaults we rely on: `printWidth: 100`, `
 - `singleAttributePerLine: true` — override default of false, matches current prettier config
 - `sortImports.internalPattern: ["@m0n0lab/"]` — classifies workspace packages as internal, not external
 - `sortImports.newlinesBetween: false` — flat import style, matches current codebase convention
-- `sortImports.groups` — differs from default by using `"type"` instead of `"style"` to group type-only imports
+- `sortImports.groups` — uses qualified selectors (`value-builtin`, `value-external`, `type-import`, etc.) per oxfmt docs. Differs from default by collapsing type imports into a single `type-import` group at the end
 - `.nvmrc` override — preserves the existing `.prettierrc` override for this file
 
 ### 4. Keep `eslint-config-prettier`
@@ -135,7 +135,7 @@ oxfmt already ignores unknown file types and writes in-place by default.
 
 **`printWidth` 80→100 causes mass reformatting** → Mitigated by: `.git-blame-ignore-revs` preserves blame history. Two-step migration isolates the diff.
 
-**`prettier-plugin-organize-imports` removal loses unused import auto-removal in formatter** → Mitigated by: `@typescript-eslint/no-unused-vars` with `enableAutofixRemoval.imports: true` covers the same behavior via `eslint --fix`. lint-staged runs eslint fix before formatter.
+**`prettier-plugin-organize-imports` removal loses unused import auto-removal in formatter** → Mitigated by: `@typescript-eslint/no-unused-vars` with `enableAutofixRemoval.imports: true` covers the same behavior via `eslint --fix`. lint-staged already runs `nx affected -t lint:eslint:fix` before the formatter command, so unused imports are removed before formatting on commit.
 
 **Root-only target breaks `nx affected` per-project formatting** → Trade-off accepted: formatting the whole workspace is fast enough with oxfmt (30x speedup). No need for per-project granularity.
 

--- a/openspec/changes/migrate-prettier-to-oxfmt/design.md
+++ b/openspec/changes/migrate-prettier-to-oxfmt/design.md
@@ -1,0 +1,184 @@
+## Context
+
+monolab uses prettier 2.8.8 with two plugins (`prettier-plugin-organize-imports`, `prettier-plugin-packagejson`) and per-project `lint:prettier` / `lint:prettier:fix` scripts. Each of the 9 projects has its own `.prettierignore` (all identical to root patterns). The `lint:prettier` Nx target is cached with per-project inputs. `lint-staged` runs `prettier --write --ignore-unknown` on commit.
+
+oxfmt is a Rust-based Prettier-compatible formatter (100% JS/TS conformance) with built-in import sorting and package.json sorting. It runs from root against the entire workspace.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Replace prettier with oxfmt as the single formatter
+- Consolidate from per-project formatter config to single root-level config + command
+- Maintain `eslint-config-prettier` integration for ESLint rule conflict detection
+- Replace `prettier-plugin-organize-imports` unused-import-removal with ESLint autofix
+- Two-phase migration (prettier v3 first, then oxfmt) for reviewable diffs
+- Zero behavioral regressions: all lint, tests, and formatting checks pass post-migration
+
+**Non-Goals:**
+- Migrating to oxlint (separate initiative)
+- Changing import grouping style (keep flat, no newlines between groups)
+- Modifying ESLint rules beyond the `enableAutofixRemoval` addition
+
+## Decisions
+
+### 1. Two-phase migration: prettier v3.8 → oxfmt
+
+**Choice**: Update prettier to v3.8 and reformat first, then migrate to oxfmt.
+
+**Why**: oxfmt targets Prettier v3.8 compatibility. Jumping from v2.8.8 directly would produce a diff mixing Prettier 2→3 changes with oxfmt-specific differences. Two commits keep diffs reviewable and bisectable.
+
+**Alternative**: Direct migration from 2.8.8 → oxfmt. Rejected — larger, harder-to-review diff.
+
+### 2. Root-only formatter command (no per-project targets)
+
+**Choice**: Single `oxfmt` / `oxfmt --check` at workspace root. Remove per-project `lint:prettier` scripts.
+
+**Why**: oxfmt runs from root against the whole workspace. Per-project scripts add maintenance overhead with no benefit — the root `.oxfmtrc.json` with `ignorePatterns` handles everything. The per-project `.prettierignore` files are all identical to root patterns.
+
+**Nx integration**: Define `lint:oxcfmt` as a root-level target in `nx.json` (or root `package.json` scripts), not as per-project targets. This simplifies the target dependency graph — `lint` no longer depends on `^lint:prettier` chain.
+
+**Alternative**: Keep per-project targets. Rejected — unnecessary duplication, oxfmt doesn't benefit from per-project runs.
+
+### 3. oxfmt config (`.oxfmtrc.json`)
+
+**Choice**: Single `.oxfmtrc.json` at root:
+
+```jsonc
+{
+    "$schema": "./node_modules/oxfmt/configuration_schema.json",
+    "tabWidth": 4,
+    "singleAttributePerLine": true,
+    "ignorePatterns": [
+        "**/dist/**",
+        "**/coverage/**",
+        "**/.nx/**",
+        "**/openspec/**",
+        "**/.claude/**",
+        "**/.opencode/**",
+        "**/CHANGELOG.md",
+        "**/reports/**"
+    ],
+    "sortImports": {
+        "internalPattern": ["@m0n0lab/"],
+        "newlinesBetween": false,
+        "groups": [
+            "builtin",
+            "external",
+            ["internal", "subpath"],
+            ["parent", "sibling", "index"],
+            "type",
+            "unknown"
+        ]
+    },
+    "overrides": [
+        { "files": [".nvmrc"], "options": { "printWidth": 1 } }
+    ]
+}
+```
+
+Only non-default values are specified. Defaults we rely on: `printWidth: 100`, `trailingComma: "all"`, `useTabs: false`.
+
+**Key decisions**:
+- `tabWidth: 4` — override default of 2, matches current prettier config
+- `singleAttributePerLine: true` — override default of false, matches current prettier config
+- `sortImports.internalPattern: ["@m0n0lab/"]` — classifies workspace packages as internal, not external
+- `sortImports.newlinesBetween: false` — flat import style, matches current codebase convention
+- `sortImports.groups` — differs from default by using `"type"` instead of `"style"` to group type-only imports
+- `.nvmrc` override — preserves the existing `.prettierrc` override for this file
+
+### 4. Keep `eslint-config-prettier`
+
+**Choice**: Retain `eslint-config-prettier` and per-project `lint:eslint:config-check` scripts.
+
+**Why**: Officially recommended by oxfmt migration guide. oxfmt is Prettier-compatible, so the same ESLint style rules that conflict with Prettier will conflict with oxfmt. The `config-check` scripts verify no ESLint rules are fighting the formatter.
+
+**Alternative**: Remove it. Rejected — risk of silent ESLint/formatter conflicts.
+
+### 5. Unused import removal via ESLint autofix
+
+**Choice**: Enable `@typescript-eslint/no-unused-vars` with `enableAutofixRemoval.imports: true`.
+
+**Why**: `prettier-plugin-organize-imports` silently removed unused imports via TS language service. oxfmt's `sortImports` only sorts — it doesn't remove. The rule is already active (from `tseslint.configs.recommended`) but only as a suggestion fixer. Enabling `enableAutofixRemoval.imports` makes `eslint --fix` auto-remove unused imports.
+
+**ESLint config change**:
+
+```ts
+{
+    rules: {
+        "@typescript-eslint/no-unused-vars": ["error", {
+            enableAutofixRemoval: { imports: true }
+        }]
+    }
+}
+```
+
+**Alternative**: Add `eslint-plugin-unused-imports`. Rejected — unnecessary new dep when existing rule supports it.
+
+### 6. lint-staged update
+
+**Choice**: Replace `prettier --write --ignore-unknown` with `oxfmt` in `lint-staged.config.ts`.
+
+```ts
+// before
+"prettier --write --ignore-unknown",
+// after
+"oxfmt",
+```
+
+oxfmt already ignores unknown file types and writes in-place by default.
+
+## Risks / Trade-offs
+
+**oxfmt is beta** → Mitigated by: 100% Prettier JS/TS conformance, adopted by Vue/Turborepo/Sentry, active development. Can pin version to avoid surprise breaks.
+
+**Import sorting behavior change** → Mitigated by: `newlinesBetween: false` keeps flat style. `internalPattern` correctly classifies `@m0n0lab/*`. Post-migration verification step confirms correct grouping.
+
+**`printWidth` 80→100 causes mass reformatting** → Mitigated by: `.git-blame-ignore-revs` preserves blame history. Two-step migration isolates the diff.
+
+**`prettier-plugin-organize-imports` removal loses unused import auto-removal in formatter** → Mitigated by: `@typescript-eslint/no-unused-vars` with `enableAutofixRemoval.imports: true` covers the same behavior via `eslint --fix`. lint-staged runs eslint fix before formatter.
+
+**Root-only target breaks `nx affected` per-project formatting** → Trade-off accepted: formatting the whole workspace is fast enough with oxfmt (30x speedup). No need for per-project granularity.
+
+## Migration Plan
+
+### Phase 1: Update prettier to v3.8
+
+1. Update `prettier` 2.8.8 → 3.8.x in root `package.json`
+2. Update `prettier-plugin-organize-imports` and `prettier-plugin-packagejson` to latest compatible versions
+3. Run `prettier --write .` to reformat entire codebase
+4. Verify: `prettier --check .` passes, `eslint` passes, all tests pass
+5. Commit: `style: reformat with prettier v3`
+6. Add commit hash to `.git-blame-ignore-revs`
+
+### Phase 2: Migrate to oxfmt
+
+1. Install `oxfmt` as devDependency
+2. Run `oxfmt --migrate=prettier` to generate `.oxfmtrc.json`
+3. Manually adjust config: add `sortImports`, `internalPattern`, `ignorePatterns`, remove defaults auto-migrated from prettier
+4. Delete `.prettierrc`, root `.prettierignore`, all per-project `.prettierignore` files
+5. Remove `prettier`, `prettier-plugin-organize-imports`, `prettier-plugin-packagejson` from deps
+6. Run `oxfmt` to reformat entire codebase
+7. Verify: `oxfmt --check` passes
+8. Commit: `style: reformat with oxfmt`
+9. Add commit hash to `.git-blame-ignore-revs`
+
+### Phase 3: Update tooling
+
+1. Update all per-project `package.json`: remove `lint:prettier`, `lint:prettier:fix` scripts
+2. Update `nx.json`: remove `lint:prettier` target defaults, add root `lint:oxcfmt` target
+3. Update `lint-staged.config.ts`: `prettier --write --ignore-unknown` → `oxfmt`
+4. Update `eslint.config.ts`: add `enableAutofixRemoval.imports` to `no-unused-vars`
+5. Commit: `chore: migrate tooling from prettier to oxfmt`
+
+### Phase 4: Verification
+
+1. `oxfmt --check` — formatter check passes
+2. `pnpm nx run-many -t lint:eslint` — ESLint passes across all projects
+3. `pnpm nx run-many -t lint:eslint:config-check` — no ESLint/formatter conflicts
+4. `pnpm nx run-many -t test:unit` — all tests pass
+5. Test `eslint --fix` on a file with an unused import — confirms auto-removal works
+6. Test import sorting on a file with `@m0n0lab/*` imports — confirms internal grouping
+
+### Rollback
+
+Revert the commits. Prettier config and deps are in git history. No data migration involved.

--- a/openspec/changes/migrate-prettier-to-oxfmt/design.md
+++ b/openspec/changes/migrate-prettier-to-oxfmt/design.md
@@ -35,7 +35,7 @@ oxfmt is a Rust-based Prettier-compatible formatter (100% JS/TS conformance) wit
 
 **Why**: oxfmt runs from root against the whole workspace. Per-project scripts add maintenance overhead with no benefit — the root `.oxfmtrc.json` with `ignorePatterns` handles everything. The per-project `.prettierignore` files are all identical to root patterns.
 
-**Nx integration**: Define `lint:oxcfmt` as a root-level target in `nx.json` (or root `package.json` scripts), not as per-project targets. This simplifies the target dependency graph — `lint` no longer depends on `^lint:prettier` chain.
+**Nx integration**: Define `lint:oxfmt` as a root-level target in `nx.json` (or root `package.json` scripts), not as per-project targets. This simplifies the target dependency graph — `lint` no longer depends on `^lint:prettier` chain.
 
 **Alternative**: Keep per-project targets. Rejected — unnecessary duplication, oxfmt doesn't benefit from per-project runs.
 
@@ -165,7 +165,7 @@ oxfmt already ignores unknown file types and writes in-place by default.
 ### Phase 3: Update tooling
 
 1. Update all per-project `package.json`: remove `lint:prettier`, `lint:prettier:fix` scripts
-2. Update `nx.json`: remove `lint:prettier` target defaults, add root `lint:oxcfmt` target
+2. Update `nx.json`: remove `lint:prettier` target defaults, add root `lint:oxfmt` target
 3. Update `lint-staged.config.ts`: `prettier --write --ignore-unknown` → `oxfmt`
 4. Update `eslint.config.ts`: add `enableAutofixRemoval.imports` to `no-unused-vars`
 5. Commit: `chore: migrate tooling from prettier to oxfmt`

--- a/openspec/changes/migrate-prettier-to-oxfmt/proposal.md
+++ b/openspec/changes/migrate-prettier-to-oxfmt/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+Prettier 2.8.8 is two major versions behind (current: 3.8.x). Rather than upgrading Prettier, we migrate to [oxfmt](https://oxc.rs/blog/2026-02-24-oxfmt-beta) — a Rust-powered, Prettier-compatible formatter that's 30x faster, has 100% JS/TS conformance, and ships built-in replacements for both prettier plugins we use (`prettier-plugin-packagejson`, `prettier-plugin-organize-imports`).
+
+## What Changes
+
+- **BREAKING** Replace `prettier` with `oxfmt` as the codebase formatter
+- **BREAKING** Consolidate per-project formatter targets into a single root-level command. Remove `lint:prettier` / `lint:prettier:fix` scripts from all `package.json` files. Add single root `lint:oxcfmt` / `lint:oxcfmt:fix` Nx targets
+- Replace `.prettierrc` + `.prettierignore` with single `.oxfmtrc.json` at root (auto-migrated via `oxfmt --migrate=prettier`, ignore patterns via `ignorePatterns`)
+- Delete all per-project `.prettierignore` files (root config covers all patterns)
+- Remove `prettier`, `prettier-plugin-organize-imports`, `prettier-plugin-packagejson` deps
+- Keep `eslint-config-prettier` and per-project `lint:eslint:config-check` scripts (officially recommended by oxfmt migration guide to prevent ESLint style rules from conflicting with formatter)
+- Enable `@typescript-eslint/no-unused-vars` autofix for imports (`enableAutofixRemoval.imports: true`) to replace the unused-import-removal behavior of `prettier-plugin-organize-imports`
+- Update `lint-staged.config.ts` to use `oxfmt` instead of `prettier`
+- Update `nx.json`: remove per-project `lint:prettier` target defaults, add root-level `lint:oxcfmt` target
+- Add formatting commits to `.git-blame-ignore-revs`
+- Config: only non-default values — `tabWidth: 4`, `singleAttributePerLine: true`, flat import sorting (`newlinesBetween: false`), `internalPattern: ["@m0n0lab/"]`, `ignorePatterns`
+- Migration strategy: update prettier to v3.8 first → reformat → then migrate to oxfmt, to isolate formatting diffs
+- Post-migration verification: `oxfmt --check` passes, `eslint` passes (including `config-check`), all tests pass, `eslint --fix` auto-removes unused imports, import sorting produces correct grouping for `@m0n0lab/*` internal packages
+
+## Capabilities
+
+### New Capabilities
+
+- `code-formatting`: formatter config, Nx targets, import sorting, ignore patterns, editor integration
+
+### Modified Capabilities
+
+_(none — no existing formatter spec exists)_
+
+## Impact
+
+- **All projects**: remove per-project `lint:prettier`, `lint:prettier:fix` scripts and `.prettierignore` files. Keep `lint:eslint:config-check` scripts
+- **Root**: single `lint:oxcfmt` / `lint:oxcfmt:fix` target, single `.oxfmtrc.json` config
+- **Dependencies**: remove 3 packages (`prettier`, `prettier-plugin-organize-imports`, `prettier-plugin-packagejson`), keep `eslint-config-prettier`, add 1 (`oxfmt`)
+- **nx.json**: remove `lint:prettier` target defaults, add root-level `lint:oxcfmt` with updated inputs
+- **ESLint config**: add `enableAutofixRemoval.imports` to `no-unused-vars` rule
+- **lint-staged**: update formatter command
+- **CI**: faster formatting step (~30x), target name change, simpler config (root-only)
+- **Editor**: switch format-on-save to oxfmt (VS Code, WebStorm, Cursor all supported)
+- **Git history**: two reformat commits (prettier v3 upgrade, then oxfmt migration) added to blame-ignore

--- a/openspec/changes/migrate-prettier-to-oxfmt/proposal.md
+++ b/openspec/changes/migrate-prettier-to-oxfmt/proposal.md
@@ -5,14 +5,14 @@ Prettier 2.8.8 is two major versions behind (current: 3.8.x). Rather than upgrad
 ## What Changes
 
 - **BREAKING** Replace `prettier` with `oxfmt` as the codebase formatter
-- **BREAKING** Consolidate per-project formatter targets into a single root-level command. Remove `lint:prettier` / `lint:prettier:fix` scripts from all `package.json` files. Add single root `lint:oxcfmt` / `lint:oxcfmt:fix` Nx targets
+- **BREAKING** Consolidate per-project formatter targets into a single root-level command. Remove `lint:prettier` / `lint:prettier:fix` scripts from all `package.json` files. Add single root `lint:oxfmt` / `lint:oxfmt:fix` Nx targets
 - Replace `.prettierrc` + `.prettierignore` with single `.oxfmtrc.json` at root (auto-migrated via `oxfmt --migrate=prettier`, ignore patterns via `ignorePatterns`)
 - Delete all per-project `.prettierignore` files (root config covers all patterns)
 - Remove `prettier`, `prettier-plugin-organize-imports`, `prettier-plugin-packagejson` deps
 - Keep `eslint-config-prettier` and per-project `lint:eslint:config-check` scripts (officially recommended by oxfmt migration guide to prevent ESLint style rules from conflicting with formatter)
 - Enable `@typescript-eslint/no-unused-vars` autofix for imports (`enableAutofixRemoval.imports: true`) to replace the unused-import-removal behavior of `prettier-plugin-organize-imports`
 - Update `lint-staged.config.ts` to use `oxfmt` instead of `prettier`
-- Update `nx.json`: remove per-project `lint:prettier` target defaults, add root-level `lint:oxcfmt` target
+- Update `nx.json`: remove per-project `lint:prettier` target defaults, add root-level `lint:oxfmt` target
 - Add formatting commits to `.git-blame-ignore-revs`
 - Config: only non-default values — `tabWidth: 4`, `singleAttributePerLine: true`, flat import sorting (`newlinesBetween: false`), `internalPattern: ["@m0n0lab/"]`, `ignorePatterns`
 - Migration strategy: update prettier to v3.8 first → reformat → then migrate to oxfmt, to isolate formatting diffs
@@ -31,9 +31,9 @@ _(none — no existing formatter spec exists)_
 ## Impact
 
 - **All projects**: remove per-project `lint:prettier`, `lint:prettier:fix` scripts and `.prettierignore` files. Keep `lint:eslint:config-check` scripts
-- **Root**: single `lint:oxcfmt` / `lint:oxcfmt:fix` target, single `.oxfmtrc.json` config
+- **Root**: single `lint:oxfmt` / `lint:oxfmt:fix` target, single `.oxfmtrc.json` config
 - **Dependencies**: remove 3 packages (`prettier`, `prettier-plugin-organize-imports`, `prettier-plugin-packagejson`), keep `eslint-config-prettier`, add 1 (`oxfmt`)
-- **nx.json**: remove `lint:prettier` target defaults, add root-level `lint:oxcfmt` with updated inputs
+- **nx.json**: remove `lint:prettier` target defaults, add root-level `lint:oxfmt` with updated inputs
 - **ESLint config**: add `enableAutofixRemoval.imports` to `no-unused-vars` rule
 - **lint-staged**: update formatter command
 - **CI**: faster formatting step (~30x), target name change, simpler config (root-only)

--- a/openspec/changes/migrate-prettier-to-oxfmt/proposal.md
+++ b/openspec/changes/migrate-prettier-to-oxfmt/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-Prettier 2.8.8 is two major versions behind (current: 3.8.x). Rather than upgrading Prettier, we migrate to [oxfmt](https://oxc.rs/blog/2026-02-24-oxfmt-beta) — a Rust-powered, Prettier-compatible formatter that's 30x faster, has 100% JS/TS conformance, and ships built-in replacements for both prettier plugins we use (`prettier-plugin-packagejson`, `prettier-plugin-organize-imports`).
+Prettier 2.8.8 is one major version behind (current stable: 3.x). Rather than upgrading Prettier, we migrate to [oxfmt](https://oxc.rs/blog/2026-02-24-oxfmt-beta) — a Rust-powered, Prettier-compatible formatter that's 30x faster, has 100% JS/TS conformance, and ships built-in replacements for both prettier plugins we use (`prettier-plugin-packagejson`, `prettier-plugin-organize-imports`).
 
 ## What Changes
 

--- a/openspec/changes/migrate-prettier-to-oxfmt/specs/code-formatting/spec.md
+++ b/openspec/changes/migrate-prettier-to-oxfmt/specs/code-formatting/spec.md
@@ -1,0 +1,105 @@
+## ADDED Requirements
+
+### Requirement: oxfmt as workspace formatter
+The workspace SHALL use oxfmt as the sole code formatter, configured via a single `.oxfmtrc.json` at the workspace root.
+
+#### Scenario: Format check passes on clean codebase
+- **WHEN** `oxfmt --check` is run from workspace root
+- **THEN** all files pass formatting validation with zero errors
+
+#### Scenario: Format write reformats files
+- **WHEN** `oxfmt` is run from workspace root
+- **THEN** all eligible files are reformatted in-place according to `.oxfmtrc.json`
+
+### Requirement: Root-only configuration
+The formatter SHALL be configured exclusively at the workspace root. No per-project formatter config files or ignore files SHALL exist.
+
+#### Scenario: No per-project config files
+- **WHEN** the workspace is inspected
+- **THEN** no `.prettierrc`, `.prettierignore`, or `.oxfmtrc.json` files exist inside `apps/` or `packages/` directories
+
+#### Scenario: Ignore patterns cover all projects
+- **WHEN** `.oxfmtrc.json` `ignorePatterns` is evaluated
+- **THEN** `**/dist/**`, `**/coverage/**`, `**/.nx/**`, `**/openspec/**`, `**/.claude/**`, `**/.opencode/**`, `**/CHANGELOG.md`, and `**/reports/**` are excluded from formatting
+
+### Requirement: Minimal non-default configuration
+The `.oxfmtrc.json` SHALL only specify values that differ from oxfmt defaults. Default values (e.g., `printWidth: 100`, `trailingComma: "all"`, `useTabs: false`) SHALL NOT be included.
+
+#### Scenario: Config contains only overrides
+- **WHEN** `.oxfmtrc.json` is inspected
+- **THEN** it contains only: `$schema`, `tabWidth`, `singleAttributePerLine`, `ignorePatterns`, `sortImports`, and `overrides`
+
+### Requirement: Import sorting with internal package recognition
+The formatter SHALL sort imports with `@m0n0lab/*` packages classified as internal. Import sorting SHALL use flat style (no newlines between groups).
+
+#### Scenario: Internal packages grouped correctly
+- **WHEN** a file imports from `@m0n0lab/ts-types` and `react`
+- **THEN** `react` is sorted in the external group and `@m0n0lab/ts-types` in the internal group
+
+#### Scenario: No newlines between import groups
+- **WHEN** imports are sorted
+- **THEN** no blank lines are inserted between import groups
+
+#### Scenario: Type-only imports grouped separately
+- **WHEN** a file has both `import type { Foo }` and `import { bar }` from different modules
+- **THEN** type-only imports are grouped after value imports
+
+### Requirement: Root-level Nx targets
+The workspace SHALL define `lint:oxcfmt` and `lint:oxcfmt:fix` as root-level Nx targets. No per-project formatter targets SHALL exist.
+
+#### Scenario: lint:oxcfmt runs from root
+- **WHEN** `pnpm nx lint:oxcfmt` is run
+- **THEN** `oxfmt --check` executes against the entire workspace
+
+#### Scenario: lint:oxcfmt:fix runs from root
+- **WHEN** `pnpm nx lint:oxcfmt:fix` is run
+- **THEN** `oxfmt` executes and reformats all eligible files
+
+#### Scenario: No per-project formatter scripts
+- **WHEN** any project's `package.json` is inspected
+- **THEN** no `lint:prettier`, `lint:prettier:fix`, `lint:oxcfmt`, or `lint:oxcfmt:fix` scripts exist
+
+### Requirement: ESLint-formatter conflict detection
+The workspace SHALL keep `eslint-config-prettier` and per-project `lint:eslint:config-check` scripts to detect ESLint rules that conflict with the formatter.
+
+#### Scenario: Config check detects conflicts
+- **WHEN** `lint:eslint:config-check` runs in any project
+- **THEN** it reports any ESLint rules that conflict with formatter output
+
+### Requirement: Unused import auto-removal via ESLint
+ESLint SHALL auto-remove unused imports when `--fix` is applied, replacing the behavior previously provided by `prettier-plugin-organize-imports`.
+
+#### Scenario: eslint --fix removes unused import
+- **WHEN** a file contains an unused import and `eslint --fix` is run
+- **THEN** the unused import is automatically removed
+
+#### Scenario: Used imports are preserved
+- **WHEN** a file contains only used imports and `eslint --fix` is run
+- **THEN** all imports remain unchanged
+
+### Requirement: lint-staged integration
+The pre-commit hook SHALL run `oxfmt` (not `prettier`) on staged files via lint-staged.
+
+#### Scenario: Commit triggers oxfmt
+- **WHEN** files are committed via git
+- **THEN** lint-staged runs `oxfmt` on the staged files
+
+### Requirement: Git blame preservation
+Reformat commits SHALL be added to `.git-blame-ignore-revs` so `git blame` skips them.
+
+#### Scenario: Blame ignores reformat commits
+- **WHEN** `git blame` is run on any file
+- **THEN** the prettier v3 reformat and oxfmt reformat commits are skipped
+
+### Requirement: No prettier artifacts remain
+After migration, no prettier-related config files, ignore files, or dependencies SHALL remain (except `eslint-config-prettier`).
+
+#### Scenario: Dependencies cleaned
+- **WHEN** `package.json` is inspected
+- **THEN** `prettier`, `prettier-plugin-organize-imports`, and `prettier-plugin-packagejson` are absent
+- **AND** `eslint-config-prettier` is present
+- **AND** `oxfmt` is present as a devDependency
+
+#### Scenario: Config files cleaned
+- **WHEN** the workspace is inspected
+- **THEN** no `.prettierrc`, `.prettierrc.json`, or `.prettierignore` files exist anywhere

--- a/openspec/changes/migrate-prettier-to-oxfmt/specs/code-formatting/spec.md
+++ b/openspec/changes/migrate-prettier-to-oxfmt/specs/code-formatting/spec.md
@@ -45,19 +45,19 @@ The formatter SHALL sort imports with `@m0n0lab/*` packages classified as intern
 - **THEN** type-only imports are grouped after value imports
 
 ### Requirement: Root-level Nx targets
-The workspace SHALL define `lint:oxcfmt` and `lint:oxcfmt:fix` as root-level Nx targets. No per-project formatter targets SHALL exist.
+The workspace SHALL define `lint:oxfmt` and `lint:oxfmt:fix` as root-level Nx targets. No per-project formatter targets SHALL exist.
 
-#### Scenario: lint:oxcfmt runs from root
-- **WHEN** `pnpm nx lint:oxcfmt` is run
+#### Scenario: lint:oxfmt runs from root
+- **WHEN** `pnpm nx lint:oxfmt` is run
 - **THEN** `oxfmt --check` executes against the entire workspace
 
-#### Scenario: lint:oxcfmt:fix runs from root
-- **WHEN** `pnpm nx lint:oxcfmt:fix` is run
+#### Scenario: lint:oxfmt:fix runs from root
+- **WHEN** `pnpm nx lint:oxfmt:fix` is run
 - **THEN** `oxfmt` executes and reformats all eligible files
 
 #### Scenario: No per-project formatter scripts
 - **WHEN** any project's `package.json` is inspected
-- **THEN** no `lint:prettier`, `lint:prettier:fix`, `lint:oxcfmt`, or `lint:oxcfmt:fix` scripts exist
+- **THEN** no `lint:prettier`, `lint:prettier:fix`, `lint:oxfmt`, or `lint:oxfmt:fix` scripts exist
 
 ### Requirement: ESLint-formatter conflict detection
 The workspace SHALL keep `eslint-config-prettier` and per-project `lint:eslint:config-check` scripts to detect ESLint rules that conflict with the formatter.

--- a/openspec/changes/migrate-prettier-to-oxfmt/tasks.md
+++ b/openspec/changes/migrate-prettier-to-oxfmt/tasks.md
@@ -24,8 +24,8 @@
 ## 3. Update tooling
 
 - [ ] 3.1 Remove `lint:prettier` and `lint:prettier:fix` scripts from all per-project `package.json` files
-- [ ] 3.2 Add root-level `lint:oxcfmt` (`oxfmt --check`) and `lint:oxcfmt:fix` (`oxfmt`) targets (root `package.json` or `nx.json`)
-- [ ] 3.3 Update `nx.json`: remove `lint:prettier` target defaults, remove `^lint:prettier` from `lint` dependsOn, add `lint:oxcfmt` target config with appropriate inputs
+- [ ] 3.2 Add root-level `lint:oxfmt` (`oxfmt --check`) and `lint:oxfmt:fix` (`oxfmt`) targets (root `package.json` or `nx.json`)
+- [ ] 3.3 Update `nx.json`: remove `lint:prettier` target defaults, remove `^lint:prettier` from `lint` dependsOn, add `lint:oxfmt` target config with appropriate inputs
 - [ ] 3.4 Update `lint-staged.config.ts`: replace `prettier --write --ignore-unknown` with `oxfmt`
 - [ ] 3.5 Update `eslint.config.ts`: add `@typescript-eslint/no-unused-vars` rule with `enableAutofixRemoval: { imports: true }`
 - [ ] 3.6 Commit: `chore: migrate tooling from prettier to oxfmt`

--- a/openspec/changes/migrate-prettier-to-oxfmt/tasks.md
+++ b/openspec/changes/migrate-prettier-to-oxfmt/tasks.md
@@ -24,7 +24,7 @@
 ## 3. Update tooling
 
 - [ ] 3.1 Remove `lint:prettier` and `lint:prettier:fix` scripts from all per-project `package.json` files
-- [ ] 3.2 Add root-level `lint:oxfmt` (`oxfmt --check`) and `lint:oxfmt:fix` (`oxfmt`) targets (root `package.json` or `nx.json`)
+- [ ] 3.2 Add `lint:oxfmt` (`oxfmt --check`) and `lint:oxfmt:fix` (`oxfmt`) scripts to root `package.json`
 - [ ] 3.3 Update `nx.json`: remove `lint:prettier` target defaults, remove `^lint:prettier` from `lint` dependsOn, add `lint:oxfmt` target config with appropriate inputs
 - [ ] 3.4 Update `lint-staged.config.ts`: replace `prettier --write --ignore-unknown` with `oxfmt`
 - [ ] 3.5 Update `eslint.config.ts`: add `@typescript-eslint/no-unused-vars` rule with `enableAutofixRemoval: { imports: true }`

--- a/openspec/changes/migrate-prettier-to-oxfmt/tasks.md
+++ b/openspec/changes/migrate-prettier-to-oxfmt/tasks.md
@@ -1,0 +1,47 @@
+## 1. Update prettier to v3.8
+
+- [ ] 1.1 Update `prettier` 2.8.8 → 3.8.x in root `package.json`
+- [ ] 1.2 Update `prettier-plugin-organize-imports` to latest v3-compatible version
+- [ ] 1.3 Update `prettier-plugin-packagejson` to latest version
+- [ ] 1.4 Run `pnpm install`
+- [ ] 1.5 Run `prettier --write .` to reformat entire codebase
+- [ ] 1.6 Verify: `prettier --check .` passes, `eslint` passes, all tests pass
+- [ ] 1.7 Commit: `style: reformat with prettier v3`
+
+## 2. Migrate to oxfmt
+
+- [ ] 2.1 Install `oxfmt` as devDependency
+- [ ] 2.2 Run `oxfmt --migrate=prettier` to generate `.oxfmtrc.json`
+- [ ] 2.3 Edit `.oxfmtrc.json`: remove default values, add `sortImports` config (`internalPattern`, `newlinesBetween: false`, groups with `type`), add `ignorePatterns`, add `.nvmrc` override
+- [ ] 2.4 Delete `.prettierrc` and root `.prettierignore`
+- [ ] 2.5 Delete all per-project `.prettierignore` files (`apps/*/`, `packages/*/`)
+- [ ] 2.6 Remove `prettier`, `prettier-plugin-organize-imports`, `prettier-plugin-packagejson` from root `package.json` devDependencies
+- [ ] 2.7 Run `pnpm install`
+- [ ] 2.8 Run `oxfmt` to reformat entire codebase
+- [ ] 2.9 Verify: `oxfmt --check` passes
+- [ ] 2.10 Commit: `style: reformat with oxfmt`
+
+## 3. Update tooling
+
+- [ ] 3.1 Remove `lint:prettier` and `lint:prettier:fix` scripts from all per-project `package.json` files
+- [ ] 3.2 Add root-level `lint:oxcfmt` (`oxfmt --check`) and `lint:oxcfmt:fix` (`oxfmt`) targets (root `package.json` or `nx.json`)
+- [ ] 3.3 Update `nx.json`: remove `lint:prettier` target defaults, remove `^lint:prettier` from `lint` dependsOn, add `lint:oxcfmt` target config with appropriate inputs
+- [ ] 3.4 Update `lint-staged.config.ts`: replace `prettier --write --ignore-unknown` with `oxfmt`
+- [ ] 3.5 Update `eslint.config.ts`: add `@typescript-eslint/no-unused-vars` rule with `enableAutofixRemoval: { imports: true }`
+- [ ] 3.6 Commit: `chore: migrate tooling from prettier to oxfmt`
+
+## 4. Git blame preservation
+
+- [ ] 4.1 Create or update `.git-blame-ignore-revs` with the two reformat commit hashes (prettier v3, oxfmt)
+- [ ] 4.2 Commit: `chore: add reformat commits to git-blame-ignore-revs`
+
+## 5. Verification
+
+- [ ] 5.1 `oxfmt --check` passes on entire workspace
+- [ ] 5.2 `pnpm nx run-many -t lint:eslint` passes across all projects
+- [ ] 5.3 `pnpm nx run-many -t lint:eslint:config-check` passes (no ESLint/formatter conflicts)
+- [ ] 5.4 `pnpm nx run-many -t test:unit` passes
+- [ ] 5.5 Add unused import to a test file, run `eslint --fix`, confirm it's auto-removed
+- [ ] 5.6 Verify `@m0n0lab/*` imports are classified as internal (check sorted output on a file with mixed imports)
+- [ ] 5.7 Verify no `.prettierrc`, `.prettierignore`, or per-project formatter scripts remain
+- [ ] 5.8 Verify `lint-staged` runs `oxfmt` on commit (test with a small change)


### PR DESCRIPTION
## Summary

- Proposal to migrate from prettier 2.8.8 to [oxfmt](https://oxc.rs/blog/2026-02-24-oxfmt-beta) (Rust-based, Prettier-compatible, 30x faster)
- Includes complete OpenSpec change: proposal, design, specs (10 requirements, 16 scenarios), and tasks (25 tasks across 5 phases)
- Key decisions: root-only config, keep `eslint-config-prettier`, ESLint autofix for unused imports, two-phase migration (prettier v3 → oxfmt)

## Test plan

- [ ] Review proposal, design, specs, and tasks artifacts
- [ ] Validate oxfmt config against current prettier setup
- [ ] Approve before starting `/opsx:apply`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive migration planning for replacing Prettier with oxfmt: design, proposal, requirements/specs, and step-by-step tasks covering phased migration, configuration approach, tooling updates, verification and rollback strategies, and Git/blame handling.
  * Added a new migration configuration spec file to anchor the process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->