### PR TITLE
feat(experiments): hookify skill proposal

### DIFF
--- a/openspec/changes/hookify-skill/.openspec.yaml
+++ b/openspec/changes/hookify-skill/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-22

--- a/openspec/changes/hookify-skill/design.md
+++ b/openspec/changes/hookify-skill/design.md
@@ -1,0 +1,66 @@
+## Context
+
+The experiments plugin (`claude-plugins/experiments/`) currently has commands but no skills. CLAUDE.md/AGENTS.md files contain a mix of soft guidance and deterministic rules. Deterministic rules ("always X", "never Y") are better enforced as Claude Code hooks, which guarantee execution and reduce context token usage.
+
+Matt Pocock's approach: a command reads CLAUDE.md, identifies deterministic instructions, generates bash hook scripts, and configures them in settings.json. We adapt this as a reusable skill.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Skill that identifies hookifiable instructions in CLAUDE.md/AGENTS.md
+- Proposes ONE highest-impact instruction per invocation (not noisy)
+- Generates command hooks (bash scripts) in `.claude/hooks/`
+- Updates `.claude/settings.json` with hook config
+- Removes hookified instruction from source file
+- Skips `<!-- X start/end -->` delimited sections
+
+**Non-Goals:**
+- Prompt or agent hook types (future, not v1)
+- Global `~/.claude/CLAUDE.md` analysis
+- Auto-hookify without user confirmation
+- Tracking which instructions were previously hookified
+
+## Decisions
+
+### D1: Skill (not command)
+
+Implemented as `skills/hookify/SKILL.md`, not a command. The skill is a prompt that Claude follows — it reads files, classifies, proposes, and implements. No bash scripts or separate tooling needed for the skill itself.
+
+**Why over command**: Skills can be invoked by name and have richer trigger descriptions. The skill content IS the prompt (like Matt's cmd.md but discoverable).
+
+### D2: One proposal per invocation
+
+Each `/experiments:hookify` run proposes at most one instruction to convert.
+
+**Why**: Reduces noise, lets user integrate incrementally, avoids overwhelming settings.json with hooks in one shot. Natural idempotency — removed instructions won't be proposed again.
+
+### D3: Prioritization by gain
+
+Priority factors (descending):
+1. Violation frequency — common actions (package manager, git commands) rank higher
+2. Determinism — exact pattern match > fuzzy match
+3. Token savings — large instruction blocks (tables, examples) rank higher
+4. Failure impact — destructive actions rank higher
+
+Claude evaluates these heuristically per instruction. No scoring algorithm — LLM judgment is the classifier.
+
+### D4: Command hooks only (v1)
+
+Only bash script hooks. Maps to `PreToolUse` → `Bash` matcher (most common case for deterministic rules).
+
+**Why over prompt/agent hooks**: Deterministic instructions map naturally to pattern matching. Zero cost, zero latency. Prompt/agent hooks are future scope.
+
+### D5: Hook file organization
+
+Scripts at `.claude/hooks/hookify-<slug>.sh` (e.g., `hookify-enforce-bun.sh`). Kebab-case, prefixed with `hookify-` so user knows origin.
+
+### D6: Section filtering by HTML comments
+
+Skip content between `<!-- X start-->` and `<!-- X end-->` (case-insensitive, flexible whitespace). These are managed sections injected by tools/plugins.
+
+## Risks / Trade-offs
+
+- [LLM classification may be imprecise] → Confirmation step mitigates; user always approves
+- [Generated hook regex may miss edge cases] → Start with simple patterns, user can refine
+- [Hook scripts need jq dependency] → Most dev machines have it; skill checks and warns if missing
+- [Removing instruction from .md may break formatting] → Skill removes the specific block and ensures no orphaned headers

--- a/openspec/changes/hookify-skill/design.md
+++ b/openspec/changes/hookify-skill/design.md
@@ -28,11 +28,11 @@ Implemented as `skills/hookify/SKILL.md`, not a command. The skill is a prompt t
 
 **Why over command**: Skills can be invoked by name and have richer trigger descriptions. The skill content IS the prompt (like Matt's cmd.md but discoverable).
 
-### D2: One proposal per session
+### D2: One proposal per invocation, auto-trigger once per session
 
-Each `/experiments:hookify` run proposes at most one instruction to convert, and the skill only triggers once per session. Subsequent invocations in the same session are no-ops.
+Each run proposes at most one instruction to convert. The skill's autonomous trigger (description-based) fires at most once per session. Explicit user invocations (`/experiments:hookify`) are never blocked — user can run it as many times as they want.
 
-**Why**: Reduces noise, lets user integrate incrementally, avoids overwhelming settings.json with hooks in one shot. One-per-session ensures the skill doesn't nag — user processes the proposal, next session gets the next one.
+**Why**: Auto-trigger once avoids nagging. Explicit invocations are always honored because the user asked for it.
 
 ### D3: Prioritization by gain
 

--- a/openspec/changes/hookify-skill/design.md
+++ b/openspec/changes/hookify-skill/design.md
@@ -28,11 +28,11 @@ Implemented as `skills/hookify/SKILL.md`, not a command. The skill is a prompt t
 
 **Why over command**: Skills can be invoked by name and have richer trigger descriptions. The skill content IS the prompt (like Matt's cmd.md but discoverable).
 
-### D2: One proposal per invocation
+### D2: One proposal per session
 
-Each `/experiments:hookify` run proposes at most one instruction to convert.
+Each `/experiments:hookify` run proposes at most one instruction to convert, and the skill only triggers once per session. Subsequent invocations in the same session are no-ops.
 
-**Why**: Reduces noise, lets user integrate incrementally, avoids overwhelming settings.json with hooks in one shot. Natural idempotency — removed instructions won't be proposed again.
+**Why**: Reduces noise, lets user integrate incrementally, avoids overwhelming settings.json with hooks in one shot. One-per-session ensures the skill doesn't nag — user processes the proposal, next session gets the next one.
 
 ### D3: Prioritization by gain
 

--- a/openspec/changes/hookify-skill/proposal.md
+++ b/openspec/changes/hookify-skill/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+CLAUDE.md/AGENTS.md instructions are soft rules — Claude tries to follow them but can forget or ignore. Deterministic instructions (always/never + concrete action) are more effective as hooks, which enforce with zero exceptions and free up context tokens.
+
+## What Changes
+
+- New skill `/experiments:hookify` in the experiments plugin
+- Reads CLAUDE.md and AGENTS.md, skips `<!-- X start/end -->` sections
+- Classifies instructions as hookifiable or not
+- Proposes ONE highest-gain hookifiable instruction per invocation
+- On user confirmation: generates bash hook script, updates `.claude/settings.json`, removes instruction from source file
+- If nothing to hookify → reports "all good"
+
+## Capabilities
+
+### New Capabilities
+
+- `hookify-skill`: Skill that analyzes CLAUDE.md/AGENTS.md for deterministic instructions convertible to Claude Code hooks, proposes one at a time prioritized by impact, and implements the hook on confirmation
+
+### Modified Capabilities
+
+- `experiments-plugin`: Adds the hookify skill to the experiments plugin's skills/ directory
+
+## Impact
+
+- New files: `claude-plugins/experiments/skills/hookify/SKILL.md`
+- Modifies on use: `.claude/settings.json` (adds hooks), `CLAUDE.md`/`AGENTS.md` (removes hookified instruction)
+- No code deps, no build changes — pure Claude Code plugin skill

--- a/openspec/changes/hookify-skill/specs/experiments-plugin/spec.md
+++ b/openspec/changes/hookify-skill/specs/experiments-plugin/spec.md
@@ -1,0 +1,27 @@
+## MODIFIED Requirements
+
+### Requirement: Experiments Plugin Structure
+
+The `experiments` plugin SHALL exist at `claude-plugins/experiments/` and follow standard Claude Code plugin structure.
+
+The plugin directory SHALL contain:
+- `.claude-plugin/plugin.json` manifest
+- `commands/` directory for slash commands
+- `skills/` directory for agent skills
+- `package.json` with `"private": true`
+- `README.md` documenting the plugin
+
+#### Scenario: Plugin directory exists
+
+- **WHEN** navigating to `claude-plugins/experiments/`
+- **THEN** the directory SHALL exist with `.claude-plugin/plugin.json` manifest
+
+#### Scenario: Plugin manifest valid
+
+- **WHEN** examining `.claude-plugin/plugin.json`
+- **THEN** it SHALL include `name: "experiments"`, `version`, `description`, and `keywords`
+
+#### Scenario: Skills directory exists
+
+- **WHEN** examining the experiments plugin structure
+- **THEN** `skills/` directory SHALL exist alongside `commands/`

--- a/openspec/changes/hookify-skill/specs/hookify-skill/spec.md
+++ b/openspec/changes/hookify-skill/specs/hookify-skill/spec.md
@@ -46,6 +46,11 @@ The skill SHALL read CLAUDE.md and AGENTS.md from the project root (`$CLAUDE_PRO
 - **WHEN** the skill is invoked and only CLAUDE.md exists
 - **THEN** only CLAUDE.md SHALL be analyzed without error
 
+#### Scenario: Only AGENTS.md exists
+
+- **WHEN** the skill is invoked and only AGENTS.md exists
+- **THEN** only AGENTS.md SHALL be analyzed without error
+
 #### Scenario: Neither file exists
 
 - **WHEN** the skill is invoked and neither file exists

--- a/openspec/changes/hookify-skill/specs/hookify-skill/spec.md
+++ b/openspec/changes/hookify-skill/specs/hookify-skill/spec.md
@@ -1,0 +1,207 @@
+## ADDED Requirements
+
+### Requirement: Skill file exists
+
+The hookify skill SHALL exist at `claude-plugins/experiments/skills/hookify/SKILL.md` with valid frontmatter including name, description, and version.
+
+#### Scenario: Skill file location
+
+- **WHEN** examining the experiments plugin structure
+- **THEN** `skills/hookify/SKILL.md` SHALL exist with YAML frontmatter containing `name: hookify`
+
+---
+
+### Requirement: Read project instruction files
+
+The skill SHALL read CLAUDE.md and AGENTS.md from the project root (`$CLAUDE_PROJECT_DIR`).
+
+#### Scenario: Both files exist
+
+- **WHEN** the skill is invoked and both CLAUDE.md and AGENTS.md exist
+- **THEN** both files SHALL be read and analyzed
+
+#### Scenario: Only CLAUDE.md exists
+
+- **WHEN** the skill is invoked and only CLAUDE.md exists
+- **THEN** only CLAUDE.md SHALL be analyzed without error
+
+#### Scenario: Neither file exists
+
+- **WHEN** the skill is invoked and neither file exists
+- **THEN** the skill SHALL report "No CLAUDE.md or AGENTS.md found"
+
+---
+
+### Requirement: Skip managed sections
+
+The skill SHALL ignore content between `<!-- X start-->` and `<!-- X end-->` HTML comment delimiters (case-insensitive, flexible whitespace).
+
+#### Scenario: Nx managed section
+
+- **WHEN** CLAUDE.md contains `<!-- nx configuration start-->` ... `<!-- nx configuration end-->`
+- **THEN** all instructions within that block SHALL be excluded from analysis
+
+#### Scenario: Multiple managed sections
+
+- **WHEN** a file contains multiple `<!-- X start/end -->` sections
+- **THEN** all managed sections SHALL be excluded and only content outside them SHALL be analyzed
+
+#### Scenario: No managed sections
+
+- **WHEN** a file has no HTML comment delimiters
+- **THEN** the entire file content SHALL be analyzed
+
+---
+
+### Requirement: Classify instructions
+
+The skill SHALL classify each non-managed instruction as hookifiable or not.
+
+An instruction is hookifiable when it:
+- Contains a deterministic directive (always/never/must/don't + concrete CLI action)
+- Can be enforced via pattern matching on Bash tool input
+- Does not require understanding intent or context
+
+#### Scenario: Deterministic package manager rule
+
+- **WHEN** CLAUDE.md contains "Always use bun instead of npm/yarn/pnpm"
+- **THEN** the skill SHALL classify it as hookifiable (PreToolUse Bash, command hook)
+
+#### Scenario: Conceptual guidance
+
+- **WHEN** CLAUDE.md contains "Prefer composition over inheritance"
+- **THEN** the skill SHALL classify it as NOT hookifiable
+
+#### Scenario: Ambiguous rule
+
+- **WHEN** CLAUDE.md contains "Try to keep functions small"
+- **THEN** the skill SHALL classify it as NOT hookifiable
+
+---
+
+### Requirement: Propose one instruction per invocation
+
+The skill SHALL propose at most ONE hookifiable instruction per run, selected by highest gain.
+
+Gain factors:
+- Violation frequency (common actions rank higher)
+- Determinism (exact pattern match ranks higher)
+- Token savings (larger instruction blocks rank higher)
+- Failure impact (destructive action prevention ranks higher)
+
+#### Scenario: Multiple hookifiable instructions
+
+- **WHEN** analysis finds 3 hookifiable instructions
+- **THEN** the skill SHALL propose only the highest-gain one
+
+#### Scenario: Nothing hookifiable
+
+- **WHEN** analysis finds no hookifiable instructions (all managed or conceptual)
+- **THEN** the skill SHALL report that everything looks good and no hooks needed
+
+---
+
+### Requirement: Present proposal with rationale
+
+The skill SHALL present the proposed hook with: the original instruction, what hook it becomes, why it's more effective as a hook, and what the hook script will do.
+
+#### Scenario: Proposal presentation
+
+- **WHEN** proposing to hookify "Always use bun instead of npm"
+- **THEN** the skill SHALL show: the original text, the hook type (PreToolUse Bash), the enforcement mechanism (blocks npm/yarn/pnpm commands), and the gain (deterministic enforcement vs soft instruction)
+
+---
+
+### Requirement: User confirmation before implementation
+
+The skill SHALL ask the user for confirmation before creating any files or modifying any settings.
+
+#### Scenario: User accepts
+
+- **WHEN** user confirms the proposal
+- **THEN** the skill SHALL proceed to generate the hook
+
+#### Scenario: User declines
+
+- **WHEN** user declines the proposal
+- **THEN** the skill SHALL stop without making any changes
+
+---
+
+### Requirement: Generate bash hook script
+
+On confirmation, the skill SHALL create a bash script at `.claude/hooks/hookify-<slug>.sh`.
+
+The script SHALL:
+- Read JSON from stdin
+- Extract relevant fields via jq
+- Pattern match against the rule
+- Exit 2 with descriptive stderr on violation
+- Exit 0 on pass
+
+#### Scenario: Package manager enforcement hook
+
+- **WHEN** generating a hook for "use bun not npm"
+- **THEN** the script SHALL be at `.claude/hooks/hookify-enforce-bun.sh`
+- **AND** it SHALL extract `.tool_input.command` from stdin
+- **AND** it SHALL block commands starting with `npm`, `yarn`, or `pnpm`
+- **AND** stderr SHALL include the equivalent bun command suggestion
+
+#### Scenario: Script is executable
+
+- **WHEN** the hook script is created
+- **THEN** it SHALL have executable permissions (`chmod +x`)
+
+---
+
+### Requirement: Update settings.json with hook config
+
+On confirmation, the skill SHALL add the hook entry to `.claude/settings.json` under `hooks.PreToolUse`.
+
+#### Scenario: Settings file exists without hooks
+
+- **WHEN** `.claude/settings.json` exists but has no `hooks` key
+- **THEN** the skill SHALL add the `hooks` key with the new hook entry
+
+#### Scenario: Settings file exists with existing hooks
+
+- **WHEN** `.claude/settings.json` already has `hooks.PreToolUse` entries
+- **THEN** the skill SHALL append the new entry without removing existing ones
+
+#### Scenario: Settings file does not exist
+
+- **WHEN** `.claude/settings.json` does not exist
+- **THEN** the skill SHALL create it with the hook configuration
+
+---
+
+### Requirement: Remove hookified instruction from source file
+
+On confirmation, the skill SHALL remove the hookified instruction from the source CLAUDE.md or AGENTS.md file.
+
+#### Scenario: Single instruction removal
+
+- **WHEN** the hookified instruction is a single line or paragraph
+- **THEN** that content SHALL be removed from the file
+- **AND** no orphaned empty headers or excess blank lines SHALL remain
+
+#### Scenario: Instruction with supporting content
+
+- **WHEN** the hookified instruction includes a reference table (e.g., npm-to-bun equivalents)
+- **THEN** both the instruction AND supporting content SHALL be removed (the hook's stderr feedback replaces the reference)
+
+---
+
+### Requirement: Verify jq availability
+
+Before generating hooks, the skill SHALL verify that `jq` is available on the system.
+
+#### Scenario: jq is installed
+
+- **WHEN** `which jq` succeeds
+- **THEN** the skill SHALL proceed normally
+
+#### Scenario: jq is not installed
+
+- **WHEN** `which jq` fails
+- **THEN** the skill SHALL warn the user and suggest installing jq before proceeding

--- a/openspec/changes/hookify-skill/specs/hookify-skill/spec.md
+++ b/openspec/changes/hookify-skill/specs/hookify-skill/spec.md
@@ -11,6 +11,22 @@ The hookify skill SHALL exist at `claude-plugins/experiments/skills/hookify/SKIL
 
 ---
 
+### Requirement: Once per session
+
+The skill SHALL only execute its analysis once per session. If invoked again in the same session, it SHALL skip analysis and inform the user it already ran.
+
+#### Scenario: First invocation
+
+- **WHEN** the skill is invoked for the first time in a session
+- **THEN** it SHALL proceed with full analysis
+
+#### Scenario: Repeated invocation
+
+- **WHEN** the skill is invoked a second time in the same session
+- **THEN** it SHALL respond that it already ran this session and take no further action
+
+---
+
 ### Requirement: Read project instruction files
 
 The skill SHALL read CLAUDE.md and AGENTS.md from the project root (`$CLAUDE_PROJECT_DIR`).

--- a/openspec/changes/hookify-skill/specs/hookify-skill/spec.md
+++ b/openspec/changes/hookify-skill/specs/hookify-skill/spec.md
@@ -11,19 +11,24 @@ The hookify skill SHALL exist at `claude-plugins/experiments/skills/hookify/SKIL
 
 ---
 
-### Requirement: Once per session
+### Requirement: Auto-trigger once per session
 
-The skill SHALL only execute its analysis once per session. If invoked again in the same session, it SHALL skip analysis and inform the user it already ran.
+The skill's autonomous trigger (via description match) SHALL fire at most once per session. Explicit user invocations (`/experiments:hookify`) SHALL always execute regardless of prior runs.
 
-#### Scenario: First invocation
+#### Scenario: First autonomous trigger
 
-- **WHEN** the skill is invoked for the first time in a session
+- **WHEN** the skill auto-triggers for the first time in a session
 - **THEN** it SHALL proceed with full analysis
 
-#### Scenario: Repeated invocation
+#### Scenario: Second autonomous trigger attempt
 
-- **WHEN** the skill is invoked a second time in the same session
-- **THEN** it SHALL respond that it already ran this session and take no further action
+- **WHEN** the skill would auto-trigger a second time in the same session
+- **THEN** it SHALL skip and take no action
+
+#### Scenario: Explicit invocation after auto-trigger
+
+- **WHEN** the user explicitly runs `/experiments:hookify` after the skill already auto-triggered
+- **THEN** it SHALL proceed with full analysis normally
 
 ---
 

--- a/openspec/changes/hookify-skill/tasks.md
+++ b/openspec/changes/hookify-skill/tasks.md
@@ -18,4 +18,4 @@
 
 - [ ] 3.1 Verify skill appears in `/experiments:hookify` after plugin reload
 - [ ] 3.2 Test against project CLAUDE.md (should report nothing — all managed sections)
-- [ ] 3.3 Test against `~/CLAUDE.md` bun rule (should propose hookifying it)
+- [ ] 3.3 Test against project-root CLAUDE.md with a hookifiable rule (should propose hookifying it)

--- a/openspec/changes/hookify-skill/tasks.md
+++ b/openspec/changes/hookify-skill/tasks.md
@@ -1,0 +1,21 @@
+## 1. Plugin structure
+
+- [ ] 1.1 Create `claude-plugins/experiments/skills/hookify/` directory
+- [ ] 1.2 Create `SKILL.md` with frontmatter (name, description, version) and full skill prompt
+
+## 2. Skill prompt content
+
+- [ ] 2.1 Write section-filtering logic instructions (skip `<!-- X start/end -->` blocks)
+- [ ] 2.2 Write instruction classification criteria (hookifiable vs not)
+- [ ] 2.3 Write prioritization heuristic (gain factors: frequency, determinism, tokens, impact)
+- [ ] 2.4 Write single-proposal presentation format (original instruction, hook type, rationale)
+- [ ] 2.5 Write confirmation flow (ask user, stop if declined)
+- [ ] 2.6 Write hook generation instructions (bash script template, settings.json update, source removal)
+- [ ] 2.7 Write jq availability check instruction
+- [ ] 2.8 Write "nothing to hookify" happy-path message
+
+## 3. Validation
+
+- [ ] 3.1 Verify skill appears in `/experiments:hookify` after plugin reload
+- [ ] 3.2 Test against project CLAUDE.md (should report nothing — all managed sections)
+- [ ] 3.3 Test against `~/CLAUDE.md` bun rule (should propose hookifying it)


### PR DESCRIPTION
## Summary

- Adds OpenSpec change artifacts for a new `hookify` skill in the experiments plugin
- The skill analyzes CLAUDE.md/AGENTS.md for deterministic instructions that can be converted to Claude Code hooks
- Proposes one highest-impact hook per invocation, generates bash scripts + settings.json config on confirmation

## Test plan

- [ ] Review proposal.md for scope alignment
- [ ] Review specs for requirement completeness
- [ ] Review tasks.md for implementation feasibility
- [ ] Run `/opsx:apply` to implement after approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added design, proposal, specification, and task documentation for a new "hookify" experiments skill that can detect eligible instructions, propose a single automation to convert an instruction into an executable enforcement hook, require user confirmation, and report when nothing needs hookifying.

* **Chores**
  * Added a configuration file for the hookify-skill changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->