### PR TITLE
feat(openspec): plugin-version-bump-skill change artifacts

### DIFF
--- a/openspec/changes/plugin-version-bump-skill/.openspec.yaml
+++ b/openspec/changes/plugin-version-bump-skill/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-22

--- a/openspec/changes/plugin-version-bump-skill/design.md
+++ b/openspec/changes/plugin-version-bump-skill/design.md
@@ -1,0 +1,85 @@
+## Context
+
+Plugin versioning is manual across 3 files per plugin: `.claude-plugin/plugin.json` (source of truth, read by Claude Code), `package.json` (workspace tooling), and root `.claude-plugin/marketplace.json` (discovery catalog). marketplace.json is already stale for experiments (0.1.0 vs 0.2.1). Anthropic's plugin-dev skills offer zero automation — "update version manually" is the official guidance.
+
+The skill lives in the `experiments` plugin and targets this monorepo's plugin ecosystem, but is designed to be portable to any repo with Claude Code plugins.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Skill that the AI agent uses when finishing work on a plugin to bump version + sync all files
+- Determine semver level from change type (new skill/command = minor, edit existing = patch, breaking = major)
+- Update plugin.json, package.json, and marketplace.json atomically
+- Work for any plugin in `claude-plugins/`
+
+**Non-Goals:**
+- CHANGELOG generation (deferred — no official plugin CHANGELOG convention exists)
+- Release Please integration (orthogonal — can be added later)
+- Triggering automatically via hooks (this is a skill, not a hook)
+- Publishing or git tagging (separate concern)
+
+## Decisions
+
+### Decision 1: Skill, not Hook
+
+Use a skill (SKILL.md) that the agent invokes at task completion, not a PostToolUse hook.
+
+**Rationale:** Hooks fire per tool use — wrong granularity. The agent needs to understand "I'm done modifying this plugin" which requires semantic understanding, not file-watching. A skill description like "use after completing plugin modifications" lets the model decide timing.
+
+**Alternatives considered:**
+- PostToolUse hook on Write/Edit in claude-plugins/ → fires too often, can't batch
+- CLAUDE.md instruction → not portable, no structured guidance
+- Slash command → requires user to remember; skill auto-triggers
+
+### Decision 2: Semver Determination via Change Classification
+
+The skill instructs the agent to classify changes:
+
+| Change Type | Semver | Examples |
+|---|---|---|
+| New skill, command, agent, or hook | minor | Add `skills/foo/SKILL.md` |
+| Edit existing component | patch | Fix typo in skill, update description |
+| Remove component or rename | major (if breaking) | Remove a command users depend on |
+| Metadata-only (description, keywords) | patch | Update plugin.json description |
+
+Agent makes the judgment call — the skill provides the classification table.
+
+**Rationale:** The agent already knows what it changed. Trying to diff files programmatically is fragile and unnecessary when the agent has full context.
+
+### Decision 3: File Update Order
+
+1. Read current version from `plugin.json` (source of truth)
+2. Compute new version
+3. Update `plugin.json`
+4. Update `package.json`
+5. Update `marketplace.json` (find entry by plugin name)
+
+**Rationale:** plugin.json is authoritative per Claude Code docs. Others sync from it.
+
+### Decision 4: Marketplace Entry Matching
+
+Match plugin in marketplace.json by `name` field, not array index.
+
+**Rationale:** Array indices are fragile. Plugin names are unique identifiers.
+
+### Decision 5: Multi-Plugin Awareness
+
+If a single task modifies multiple plugins, the skill instructs the agent to bump each independently.
+
+**Rationale:** Each plugin has its own version lifecycle. A change to experiments shouldn't bump expo-developer.
+
+### Decision 6: Skill Location
+
+Place in `experiments` plugin: `claude-plugins/experiments/skills/plugin-version-bump/SKILL.md`
+
+**Rationale:** experiments is the staging area for beta skills. If proven, could graduate to a standalone plugin or be contributed upstream to plugin-dev.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| Agent forgets to use skill | Skill description optimized for high trigger rate on plugin work |
+| Agent bumps version mid-work (not at end) | Skill explicitly says "use AFTER completing all modifications" |
+| Wrong semver level chosen | Classification table in skill guides decision; agent can ask user if unclear |
+| marketplace.json missing the plugin entry | Skill instructs agent to add entry if missing |
+| Multiple independent tasks in same session | Skill instructs: one bump per logical unit of work; if doing two unrelated changes, bump after each |

--- a/openspec/changes/plugin-version-bump-skill/design.md
+++ b/openspec/changes/plugin-version-bump-skill/design.md
@@ -1,8 +1,8 @@
 ## Context
 
-Plugin versioning is manual across 3 files per plugin: `.claude-plugin/plugin.json` (source of truth, read by Claude Code), `package.json` (workspace tooling), and root `.claude-plugin/marketplace.json` (discovery catalog). marketplace.json is already stale for experiments (0.1.0 vs 0.2.1). Anthropic's plugin-dev skills offer zero automation — "update version manually" is the official guidance.
+Plugin versioning is manual across 3 files per plugin: `.claude-plugin/plugin.json` (source of truth, read by Claude Code), `package.json` (workspace tooling), and root `.claude-plugin/marketplace.json` (discovery catalog). Anthropic's plugin-dev skills offer zero automation — "update version manually" is the official guidance.
 
-The skill lives in the `experiments` plugin and targets this monorepo's plugin ecosystem, but is designed to be portable to any repo with Claude Code plugins.
+The skill lives in the `experiments` plugin but is designed to be fully portable — it identifies plugins by structure (presence of `.claude-plugin/plugin.json`), not by hardcoded path.
 
 ## Goals / Non-Goals
 
@@ -10,7 +10,7 @@ The skill lives in the `experiments` plugin and targets this monorepo's plugin e
 - Skill that the AI agent uses when finishing work on a plugin to bump version + sync all files
 - Determine semver level from change type (new skill/command = minor, edit existing = patch, breaking = major)
 - Update plugin.json, package.json, and marketplace.json atomically
-- Work for any plugin in `claude-plugins/`
+- Work for any Claude Code plugin (detected by `.claude-plugin/plugin.json` presence, not hardcoded path)
 
 **Non-Goals:**
 - CHANGELOG generation (deferred — no official plugin CHANGELOG convention exists)
@@ -62,13 +62,23 @@ Match plugin in marketplace.json by `name` field, not array index.
 
 **Rationale:** Array indices are fragile. Plugin names are unique identifiers.
 
-### Decision 5: Multi-Plugin Awareness
+### Decision 5: Plugin Detection by Structure
+
+Identify plugins by the presence of `.claude-plugin/plugin.json` in any ancestor directory of the modified files, not by a hardcoded path like `claude-plugins/`.
+
+**Rationale:** Makes the skill portable to any repo layout. A plugin is a plugin regardless of where it lives. The agent should recognize it's editing a plugin when any modified file has a `.claude-plugin/plugin.json` in its directory tree.
+
+**Alternatives considered:**
+- Hardcode `claude-plugins/` path → breaks portability, excludes plugins in other locations
+- Check only working directory → misses nested plugin structures
+
+### Decision 6: Multi-Plugin Awareness
 
 If a single task modifies multiple plugins, the skill instructs the agent to bump each independently.
 
 **Rationale:** Each plugin has its own version lifecycle. A change to experiments shouldn't bump expo-developer.
 
-### Decision 6: Skill Location
+### Decision 7: Skill Location
 
 Place in `experiments` plugin: `claude-plugins/experiments/skills/plugin-version-bump/SKILL.md`
 

--- a/openspec/changes/plugin-version-bump-skill/proposal.md
+++ b/openspec/changes/plugin-version-bump-skill/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-Plugin versioning is fully manual — version lives in 3 files (`plugin.json`, `package.json`, `marketplace.json`) and there's no automation to keep them in sync. marketplace.json is already stale (experiments shows 0.1.0 vs actual 0.2.1). Anthropic's official plugin-dev skills only say "update version manually". A skill that handles this automatically fills a real gap for any Claude Code plugin author.
+Plugin versioning is fully manual — version lives in 3 files (`plugin.json`, `package.json`, `marketplace.json`) and there's no automation to keep them in sync. Anthropic's official plugin-dev skills only say "update version manually". A skill that handles this automatically fills a real gap for any Claude Code plugin author.
 
 ## What Changes
 
@@ -8,7 +8,7 @@ Plugin versioning is fully manual — version lives in 3 files (`plugin.json`, `
 - Skill determines semver level (patch/minor/major) based on change type
 - Updates `plugin.json` (source of truth), `package.json`, and `marketplace.json` in one pass
 - Triggers at work completion, not per individual file edit
-- Fix current marketplace.json staleness as part of implementation
+- Establishes automated version sync to prevent future staleness
 
 ## Capabilities
 
@@ -16,12 +16,12 @@ Plugin versioning is fully manual — version lives in 3 files (`plugin.json`, `
 - `plugin-version-bump`: Skill that detects plugin changes, determines semver bump type, and synchronizes version across all version-bearing files (`plugin.json`, `package.json`, `marketplace.json`)
 
 ### Modified Capabilities
-- `claude-code-plugins`: marketplace.json version field policy — clarify whether version is required or optional, and document sync expectations
+- `claude-code-plugins`: marketplace.json version field policy — require and sync version with plugin.json
 - `experiments-plugin`: register the new skill as a component of the experiments plugin
 
 ## Impact
 
 - `claude-plugins/experiments/skills/plugin-version-bump/SKILL.md` — new skill file
-- `.claude-plugin/marketplace.json` — updated by skill + fix current staleness
+- `.claude-plugin/marketplace.json` — updated by skill during version bumps
 - `openspec/specs/claude-code-plugins/spec.md` — updated versioning requirements
 - `openspec/specs/experiments-plugin/spec.md` — register new skill

--- a/openspec/changes/plugin-version-bump-skill/proposal.md
+++ b/openspec/changes/plugin-version-bump-skill/proposal.md
@@ -13,7 +13,7 @@ Plugin versioning is fully manual — version lives in 3 files (`plugin.json`, `
 ## Capabilities
 
 ### New Capabilities
-- `plugin-version-bump`: Skill that detects plugin changes, determines semver bump type, and synchronizes version across all version-bearing files (`plugin.json`, `package.json`, `marketplace.json`)
+- `plugin-version-bump`: Skill that detects plugin changes (identified by `.claude-plugin/plugin.json` presence, not hardcoded path), determines semver bump type, and synchronizes version across all version-bearing files (`plugin.json`, `package.json`, `marketplace.json`)
 
 ### Modified Capabilities
 - `claude-code-plugins`: marketplace.json version field policy — require and sync version with plugin.json

--- a/openspec/changes/plugin-version-bump-skill/proposal.md
+++ b/openspec/changes/plugin-version-bump-skill/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Plugin versioning is fully manual — version lives in 3 files (`plugin.json`, `package.json`, `marketplace.json`) and there's no automation to keep them in sync. marketplace.json is already stale (experiments shows 0.1.0 vs actual 0.2.1). Anthropic's official plugin-dev skills only say "update version manually". A skill that handles this automatically fills a real gap for any Claude Code plugin author.
+
+## What Changes
+
+- New skill in `experiments` plugin that detects plugin modifications and bumps versions
+- Skill determines semver level (patch/minor/major) based on change type
+- Updates `plugin.json` (source of truth), `package.json`, and `marketplace.json` in one pass
+- Triggers at work completion, not per individual file edit
+- Fix current marketplace.json staleness as part of implementation
+
+## Capabilities
+
+### New Capabilities
+- `plugin-version-bump`: Skill that detects plugin changes, determines semver bump type, and synchronizes version across all version-bearing files (`plugin.json`, `package.json`, `marketplace.json`)
+
+### Modified Capabilities
+- `claude-code-plugins`: marketplace.json version field policy — clarify whether version is required or optional, and document sync expectations
+- `experiments-plugin`: register the new skill as a component of the experiments plugin
+
+## Impact
+
+- `claude-plugins/experiments/skills/plugin-version-bump/SKILL.md` — new skill file
+- `.claude-plugin/marketplace.json` — updated by skill + fix current staleness
+- `openspec/specs/claude-code-plugins/spec.md` — updated versioning requirements
+- `openspec/specs/experiments-plugin/spec.md` — register new skill

--- a/openspec/changes/plugin-version-bump-skill/specs/claude-code-plugins/spec.md
+++ b/openspec/changes/plugin-version-bump-skill/specs/claude-code-plugins/spec.md
@@ -1,0 +1,38 @@
+## MODIFIED Requirements
+
+### Requirement: Marketplace Registration
+
+The repository SHALL be registered as a Claude Code marketplace via a root-level `.claude-plugin/marketplace.json` file.
+
+The marketplace manifest SHALL include:
+- `name`: Marketplace identifier (string)
+- `owner`: Object with `name` and optional `email`
+- `metadata`: Object with `description`, `version`, and `pluginRoot`
+- `plugins`: Array of plugin entries with `name`, `source`, `version`, and `description`
+
+Plugin entry `version` fields SHALL be kept in sync with each plugin's `.claude-plugin/plugin.json` version. The `plugin.json` is the source of truth; marketplace.json versions are informational for discovery.
+
+#### Scenario: Marketplace manifest exists
+
+- **GIVEN** the monolab repository
+- **WHEN** checking the root directory
+- **THEN** `.claude-plugin/marketplace.json` SHALL exist
+
+#### Scenario: Users can add marketplace
+
+- **GIVEN** a user with Claude Code installed
+- **WHEN** they run `/plugin marketplace add pabloimrik17/monolab`
+- **THEN** the monolab marketplace SHALL be registered in their Claude Code configuration
+- **AND** plugins from monolab SHALL appear in the Discover tab
+
+#### Scenario: Plugin installation from marketplace
+
+- **GIVEN** a user has added the monolab marketplace
+- **WHEN** they run `/plugin install expo-developer@monolab`
+- **THEN** the expo-developer plugin SHALL be installed
+- **AND** its skills SHALL be available
+
+#### Scenario: Version consistency
+
+- **WHEN** examining marketplace.json plugin entries
+- **THEN** each entry's `version` SHALL match the corresponding `claude-plugins/<name>/.claude-plugin/plugin.json` version

--- a/openspec/changes/plugin-version-bump-skill/specs/experiments-plugin/spec.md
+++ b/openspec/changes/plugin-version-bump-skill/specs/experiments-plugin/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Plugin Version Bump Skill
+
+The experiments plugin SHALL include a `plugin-version-bump` skill at `skills/plugin-version-bump/SKILL.md`.
+
+The skill SHALL:
+- Guide the AI agent to bump plugin versions after completing plugin modifications
+- Provide a semver classification table for determining bump level
+- Instruct synchronization of version across plugin.json, package.json, and marketplace.json
+
+#### Scenario: Skill directory exists
+
+- **WHEN** examining `claude-plugins/experiments/skills/`
+- **THEN** `plugin-version-bump/SKILL.md` SHALL exist
+
+#### Scenario: Skill discoverable by Claude Code
+
+- **WHEN** the experiments plugin is installed
+- **THEN** the `plugin-version-bump` skill SHALL appear in the available skills list

--- a/openspec/changes/plugin-version-bump-skill/specs/plugin-version-bump/spec.md
+++ b/openspec/changes/plugin-version-bump-skill/specs/plugin-version-bump/spec.md
@@ -15,23 +15,44 @@ The SKILL.md SHALL include frontmatter with:
 
 ---
 
+### Requirement: Plugin Detection
+
+The skill SHALL identify a Claude Code plugin by the presence of `.claude-plugin/plugin.json` in the directory tree of any modified file. The skill SHALL NOT rely on a hardcoded directory path.
+
+#### Scenario: Plugin in standard location
+
+- **WHEN** agent modifies files under a directory containing `.claude-plugin/plugin.json`
+- **THEN** the skill SHALL recognize that directory as a plugin root
+
+#### Scenario: Plugin in non-standard location
+
+- **WHEN** agent modifies files under `tools/my-plugin/` which contains `.claude-plugin/plugin.json`
+- **THEN** the skill SHALL recognize `tools/my-plugin/` as a plugin root
+
+#### Scenario: No plugin structure present
+
+- **WHEN** agent modifies files in a directory without `.claude-plugin/plugin.json` in its tree
+- **THEN** the skill SHALL NOT activate
+
+---
+
 ### Requirement: Trigger Conditions
 
-The skill SHALL activate when the agent completes modifications to any plugin under `claude-plugins/`.
+The skill SHALL activate when the agent completes modifications to any Claude Code plugin (any directory containing `.claude-plugin/plugin.json`).
 
 The skill SHALL NOT activate:
 - During ongoing work (mid-task)
-- For tasks that do not modify files under `claude-plugins/`
+- For tasks that do not modify files within a plugin directory
 - For tasks that only affect non-plugin files (e.g., openspec/, packages/)
 
 #### Scenario: Agent finishes adding a new skill to a plugin
 
-- **WHEN** agent completes creating a new skill file under `claude-plugins/<plugin>/skills/`
+- **WHEN** agent completes creating a new skill file under a plugin's `skills/` directory
 - **THEN** the skill SHALL activate and guide version bumping
 
-#### Scenario: Agent edits files outside claude-plugins
+#### Scenario: Agent edits files outside any plugin
 
-- **WHEN** agent modifies files only in `packages/` or `apps/`
+- **WHEN** agent modifies files only in directories without `.claude-plugin/plugin.json`
 - **THEN** the skill SHALL NOT activate
 
 #### Scenario: Agent is mid-task in a plugin
@@ -73,11 +94,11 @@ The skill SHALL instruct the agent to classify changes and determine the semver 
 
 The skill SHALL instruct the agent to update ALL version-bearing files for the affected plugin:
 
-1. `.claude-plugin/plugin.json` — `version` field (source of truth)
-2. `package.json` — `version` field
-3. Root `.claude-plugin/marketplace.json` — `plugins[].version` for the matching plugin entry (matched by `name` field)
+1. `.claude-plugin/plugin.json` — `version` field (source of truth, always present)
+2. `package.json` — `version` field (if present in plugin root)
+3. Marketplace `marketplace.json` — `plugins[].version` for the matching entry (if a marketplace.json exists and contains the plugin, matched by `name` field)
 
-All three files SHALL contain the same version string after the bump.
+All updated files SHALL contain the same version string after the bump.
 
 #### Scenario: All files updated after bump
 
@@ -105,7 +126,7 @@ When a task modifies multiple plugins, the skill SHALL guide the agent to bump e
 
 #### Scenario: Two plugins modified in same task
 
-- **WHEN** agent modifies files in both `claude-plugins/experiments/` and `claude-plugins/expo-developer/`
+- **WHEN** agent modifies files in two different plugin directories (each containing `.claude-plugin/plugin.json`)
 - **THEN** the skill SHALL guide separate version bumps for each plugin
 - **AND** each bump SHALL reflect only that plugin's changes
 

--- a/openspec/changes/plugin-version-bump-skill/specs/plugin-version-bump/spec.md
+++ b/openspec/changes/plugin-version-bump-skill/specs/plugin-version-bump/spec.md
@@ -21,8 +21,8 @@ The skill SHALL activate when the agent completes modifications to any plugin un
 
 The skill SHALL NOT activate:
 - During ongoing work (mid-task)
-- For changes outside `claude-plugins/`
-- For changes that only affect non-plugin files (e.g., openspec/, packages/)
+- For tasks that do not modify files under `claude-plugins/`
+- For tasks that only affect non-plugin files (e.g., openspec/, packages/)
 
 #### Scenario: Agent finishes adding a new skill to a plugin
 

--- a/openspec/changes/plugin-version-bump-skill/specs/plugin-version-bump/spec.md
+++ b/openspec/changes/plugin-version-bump-skill/specs/plugin-version-bump/spec.md
@@ -1,0 +1,127 @@
+## ADDED Requirements
+
+### Requirement: Skill File Structure
+
+The skill SHALL exist at `claude-plugins/experiments/skills/plugin-version-bump/SKILL.md`.
+
+The SKILL.md SHALL include frontmatter with:
+- `name`: "Plugin Version Bump"
+- `description`: Trigger-optimized description for detecting plugin modification work
+
+#### Scenario: Skill file exists
+
+- **WHEN** examining `claude-plugins/experiments/skills/plugin-version-bump/`
+- **THEN** `SKILL.md` SHALL exist with valid frontmatter
+
+---
+
+### Requirement: Trigger Conditions
+
+The skill SHALL activate when the agent completes modifications to any plugin under `claude-plugins/`.
+
+The skill SHALL NOT activate:
+- During ongoing work (mid-task)
+- For changes outside `claude-plugins/`
+- For changes that only affect non-plugin files (e.g., openspec/, packages/)
+
+#### Scenario: Agent finishes adding a new skill to a plugin
+
+- **WHEN** agent completes creating a new skill file under `claude-plugins/<plugin>/skills/`
+- **THEN** the skill SHALL activate and guide version bumping
+
+#### Scenario: Agent edits files outside claude-plugins
+
+- **WHEN** agent modifies files only in `packages/` or `apps/`
+- **THEN** the skill SHALL NOT activate
+
+#### Scenario: Agent is mid-task in a plugin
+
+- **WHEN** agent has edited one skill file but is about to edit another as part of the same task
+- **THEN** the skill SHALL NOT activate until the task is complete
+
+---
+
+### Requirement: Semver Level Determination
+
+The skill SHALL instruct the agent to classify changes and determine the semver bump level:
+
+| Change Type | Semver Level |
+|---|---|
+| New skill, command, agent, or hook added | minor |
+| Existing component edited (content, description, fix) | patch |
+| Component removed or renamed (breaking) | major |
+| Metadata-only change (plugin.json fields, README) | patch |
+
+#### Scenario: New command added
+
+- **WHEN** agent has added a new command file to a plugin
+- **THEN** the skill SHALL guide the agent to apply a minor version bump
+
+#### Scenario: Existing skill content edited
+
+- **WHEN** agent has edited the content of an existing SKILL.md
+- **THEN** the skill SHALL guide the agent to apply a patch version bump
+
+#### Scenario: Command removed
+
+- **WHEN** agent has removed a command file from a plugin
+- **THEN** the skill SHALL guide the agent to apply a major version bump
+
+---
+
+### Requirement: Version File Synchronization
+
+The skill SHALL instruct the agent to update ALL version-bearing files for the affected plugin:
+
+1. `.claude-plugin/plugin.json` — `version` field (source of truth)
+2. `package.json` — `version` field
+3. Root `.claude-plugin/marketplace.json` — `plugins[].version` for the matching plugin entry (matched by `name` field)
+
+All three files SHALL contain the same version string after the bump.
+
+#### Scenario: All files updated after bump
+
+- **WHEN** agent bumps experiments plugin from 0.2.1 to 0.3.0
+- **THEN** `claude-plugins/experiments/.claude-plugin/plugin.json` version SHALL be "0.3.0"
+- **AND** `claude-plugins/experiments/package.json` version SHALL be "0.3.0"
+- **AND** `.claude-plugin/marketplace.json` experiments entry version SHALL be "0.3.0"
+
+#### Scenario: Marketplace entry matched by name
+
+- **WHEN** agent bumps a plugin named "expo-developer"
+- **THEN** the agent SHALL find the marketplace entry where `name` equals "expo-developer"
+- **AND** update that entry's `version` field
+
+#### Scenario: Plugin not in marketplace
+
+- **WHEN** agent bumps a plugin that has no entry in marketplace.json
+- **THEN** the agent SHALL add a new entry to the `plugins` array with `name`, `source`, `version`, and `description`
+
+---
+
+### Requirement: Multi-Plugin Independence
+
+When a task modifies multiple plugins, the skill SHALL guide the agent to bump each plugin's version independently.
+
+#### Scenario: Two plugins modified in same task
+
+- **WHEN** agent modifies files in both `claude-plugins/experiments/` and `claude-plugins/expo-developer/`
+- **THEN** the skill SHALL guide separate version bumps for each plugin
+- **AND** each bump SHALL reflect only that plugin's changes
+
+---
+
+### Requirement: Multiple Independent Tasks
+
+When the agent performs multiple independent tasks on the same plugin in one session, the skill SHALL guide a version bump after each logical unit of work completes.
+
+#### Scenario: Two independent changes to same plugin
+
+- **WHEN** agent adds a new skill to experiments, then later fixes a command in experiments (separate tasks)
+- **THEN** the skill SHALL guide a bump after the first task (minor)
+- **AND** a second bump after the second task (patch)
+
+#### Scenario: Related changes grouped
+
+- **WHEN** agent adds a new skill and its supporting command as part of a single feature
+- **THEN** the skill SHALL guide a single bump (minor, since new component added)

--- a/openspec/changes/plugin-version-bump-skill/tasks.md
+++ b/openspec/changes/plugin-version-bump-skill/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Fix Current State
 
-- [ ] 1.1 Fix marketplace.json staleness — update experiments version from 0.1.0 to 0.2.1 to match plugin.json
+- [ ] 1.1 Verify marketplace.json/plugin.json version consistency for all plugins (no-op if already in sync)
 
 ## 2. Create Skill
 

--- a/openspec/changes/plugin-version-bump-skill/tasks.md
+++ b/openspec/changes/plugin-version-bump-skill/tasks.md
@@ -1,0 +1,20 @@
+## 1. Fix Current State
+
+- [ ] 1.1 Fix marketplace.json staleness — update experiments version from 0.1.0 to 0.2.1 to match plugin.json
+
+## 2. Create Skill
+
+- [ ] 2.1 Create directory `claude-plugins/experiments/skills/plugin-version-bump/`
+- [ ] 2.2 Write `SKILL.md` with trigger-optimized description frontmatter
+- [ ] 2.3 Write skill body with semver classification table, file update instructions, multi-plugin/multi-task guidance, and marketplace sync instructions
+
+## 3. Update Specs
+
+- [ ] 3.1 Sync delta specs to `openspec/specs/plugin-version-bump/spec.md` (new)
+- [ ] 3.2 Sync delta specs to `openspec/specs/claude-code-plugins/spec.md` (modified — version consistency requirement)
+- [ ] 3.3 Sync delta specs to `openspec/specs/experiments-plugin/spec.md` (added — skill registration)
+
+## 4. Verify
+
+- [ ] 4.1 Verify skill appears in Claude Code available skills list after plugin reload
+- [ ] 4.2 Verify all 3 version files are in sync for both plugins

--- a/openspec/changes/plugin-version-bump-skill/tasks.md
+++ b/openspec/changes/plugin-version-bump-skill/tasks.md
@@ -14,7 +14,11 @@
 - [ ] 3.2 Sync delta specs to `openspec/specs/claude-code-plugins/spec.md` (modified — version consistency requirement)
 - [ ] 3.3 Sync delta specs to `openspec/specs/experiments-plugin/spec.md` (added — skill registration)
 
-## 4. Verify
+## 4. Bump Plugin Version
 
-- [ ] 4.1 Verify skill appears in Claude Code available skills list after plugin reload
-- [ ] 4.2 Verify all 3 version files are in sync for both plugins
+- [ ] 4.1 Bump experiments plugin version (minor — new skill added): update `plugin.json`, `package.json`, and `marketplace.json`
+
+## 5. Verify
+
+- [ ] 5.1 Verify skill appears in Claude Code available skills list after plugin reload
+- [ ] 5.2 Verify all 3 version files are in sync for both plugins


### PR DESCRIPTION
## Summary

- OpenSpec change artifacts for a new skill in `experiments` plugin that auto-bumps plugin versions after modifications
- Skill detects change type (new/edit/remove) → determines semver level (major/minor/patch)
- Synchronizes version across `plugin.json`, `package.json`, and `marketplace.json`
- Includes proposal, design (6 decisions), 3 specs, and implementation tasks

## Test plan

- [ ] Review proposal for completeness and motivation
- [ ] Review design decisions (skill vs hook, semver classification table, file update order)
- [ ] Review specs for testable scenarios
- [ ] Verify tasks cover all implementation work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a plugin version-bump skill that detects plugin changes and synchronizes semantic versions across plugin manifests.

* **Documentation**
  * Added design, proposal, specs, and task guidance describing version-bump behavior, semver rules, discovery/detection, sync requirements, and verification workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->