### PR TITLE
docs: openspec proposal for skill-terraformer

### DIFF
--- a/openspec/changes/skill-terraformer/design.md
+++ b/openspec/changes/skill-terraformer/design.md
@@ -43,14 +43,16 @@ Siempre → find-skills, frontend-design (si hay frontend)
 
 ### D3: `experimental_install` en postinstall
 
-El script postinstall usa `bunx skills experimental_install` que restaura del `skills-lock.json`. Esto asegura que `pnpm install` tras `git clone` reconstituye las skills.
+El script postinstall usa `bunx skills experimental_install`, que restaura skills desde `skills-lock.json`. Ambos comandos (`update` y `experimental_install`) requieren el lock file — sin él no hacen nada. Por eso el lock file **debe commitearse** para que funcione en clones frescos.
 
-`skills update` no funciona sin lock file previo. `experimental_install` sí lo hace.
+`experimental_install` es preferible a `update` porque restaura las versiones exactas del lock file en lugar de actualizar a latest.
 
-**Formato del postinstall:**
+**Formato del postinstall (con graceful degradation):**
 ```json
-"postinstall": "bunx skills experimental_install"
+"postinstall": "[ -f skills-lock.json ] && bunx skills experimental_install || true"
 ```
+
+Solo ejecuta si existe lock file. Si falla, no bloquea `pnpm install`.
 
 Si ya existe un postinstall, se encadena con `&&`.
 

--- a/openspec/changes/skill-terraformer/design.md
+++ b/openspec/changes/skill-terraformer/design.md
@@ -73,6 +73,6 @@ Todas las skills se instalan con `--agent claude-code` ya que es el único agent
 ## Risks / Trade-offs
 
 - **[Lentitud al inicio]** → `bunx skills list --json` y detección de stack son rápidos. Solo se ejecuta `skills add` si hay pendientes.
-- **[CLI cambia experimental_install]** → Es experimental. Mitigación: si falla, fallback a `bunx skills update`.
+- **[CLI cambia experimental_install]** → Es experimental. Mitigación: si falla, advertir al usuario para instalación manual desde lock file en lugar de degradar silenciosamente a `skills update` (que no restaura desde lock file).
 - **[Lista curada se desactualiza]** → Aceptable: actualizar la skill es trivial. Mejor que over-engineering un sistema de config.
 - **[skills-lock.json en git]** → Debe commitearse para que `experimental_install` funcione en clones frescos. Similar a lock files de paquetes.

--- a/openspec/changes/skill-terraformer/design.md
+++ b/openspec/changes/skill-terraformer/design.md
@@ -30,14 +30,18 @@ La skill se activa automáticamente via "using-superpowers" al inicio de sesión
 
 ### D2: Lista curada embebida en SKILL.md
 
-El mapeo detector→skills vive directamente en el markdown de la skill. Reglas tipo:
+El mapeo detector→skills vive directamente en el markdown de la skill. Lista curada inicial:
 
-```
-Si package.json tiene "react" en deps → instalar shadcn/ui, vercel-react-best-practices
-Si package.json tiene "expo" en deps → instalar expo/skills
-Si existe nx.json → instalar nx-related skills
-Siempre → find-skills, frontend-design (si hay frontend)
-```
+| Condición | Repo | Skill | Comando |
+|-----------|------|-------|---------|
+| `react` en deps | `vercel-labs/agent-skills` | `vercel-react-best-practices` | `bunx skills add vercel-labs/agent-skills --skill vercel-react-best-practices --agent claude-code -y` |
+| `react` en deps | `vercel-labs/agent-skills` | `vercel-composition-patterns` | `bunx skills add vercel-labs/agent-skills --skill vercel-composition-patterns --agent claude-code -y` |
+| `react` en deps + `components.json` existe | `shadcn/ui` | `shadcn` | `bunx skills add shadcn/ui --skill shadcn --agent claude-code -y` |
+| `next` en deps | `vercel-labs/next-skills` | `next-best-practices` | `bunx skills add vercel-labs/next-skills --skill next-best-practices --agent claude-code -y` |
+| universal (frontend) | `vercel-labs/agent-skills` | `web-design-guidelines` | `bunx skills add vercel-labs/agent-skills --skill web-design-guidelines --agent claude-code -y` |
+| universal (frontend) | `anthropics/skills` | `frontend-design` | `bunx skills add anthropics/skills --skill frontend-design --agent claude-code -y` |
+
+Skills del mismo repo se pueden batchar: `bunx skills add vercel-labs/agent-skills --skill vercel-react-best-practices --skill web-design-guidelines --skill vercel-composition-patterns --agent claude-code -y`
 
 **Alternativa descartada:** Fichero de config separado — añade complejidad sin beneficio para un solo proyecto.
 

--- a/openspec/changes/skill-terraformer/design.md
+++ b/openspec/changes/skill-terraformer/design.md
@@ -34,10 +34,10 @@ El mapeo detector→skills vive directamente en el markdown de la skill. Lista c
 
 | Condición | Repo | Skill |
 |-----------|------|-------|
-| `react` en deps | `vercel-labs/agent-skills` | `vercel-react-best-practices` |
-| `react` en deps | `vercel-labs/agent-skills` | `vercel-composition-patterns` |
-| `react` en deps + `components.json` | `shadcn/ui` | `shadcn` |
-| `next` en deps | `vercel-labs/next-skills` | `next-best-practices` |
+| `react` en dependencies/devDependencies | `vercel-labs/agent-skills` | `vercel-react-best-practices` |
+| `react` en dependencies/devDependencies | `vercel-labs/agent-skills` | `vercel-composition-patterns` |
+| `react` en dependencies/devDependencies + `components.json` | `shadcn/ui` | `shadcn` |
+| `next` en dependencies/devDependencies | `vercel-labs/next-skills` | `next-best-practices` |
 | frontend (universal) | `vercel-labs/agent-skills` | `web-design-guidelines` |
 | frontend (universal) | `anthropics/skills` | `frontend-design` |
 

--- a/openspec/changes/skill-terraformer/design.md
+++ b/openspec/changes/skill-terraformer/design.md
@@ -69,6 +69,7 @@ Los paréntesis limitan el `|| true` a la parte de skills, sin enmascarar fallos
 1. Leer project indicators (package.json, nx.json, configs)
 2. Evaluar reglas curadas → lista de skills aplicables
 3. bunx skills list --json → skills ya instaladas
+   (Si falla: reportar error, pedir confirmación al usuario antes de continuar)
 4. Diff: aplicables - instaladas = pendientes
 5. Para cada pendiente: bunx skills add <repo> --skill <name> --agent claude-code -y
 6. Si se instaló ≥1 skill (ahora o antes): verificar postinstall en package.json

--- a/openspec/changes/skill-terraformer/design.md
+++ b/openspec/changes/skill-terraformer/design.md
@@ -1,0 +1,78 @@
+## Context
+
+monolab tiene 17 skills project-level (openspec + nx), todas gestionadas manualmente. No hay skills de skills.sh instaladas (no existe `skills-lock.json`). El plugin `experiments` (v0.2.1) tiene 2 commands pero 0 skills — esta será la primera.
+
+El CLI de skills.sh (`skills@1.4.5`) soporta: `add`, `remove`, `list --json`, `check`, `update`, `experimental_install` (restaurar desde lock file). Instalación via `npx`/`bunx`, sin dep local.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Skill que detecta stack del proyecto y propone/instala skills de skills.sh relevantes
+- Mantener lista curada de mapeos stack→skills embebida en la skill
+- Asegurar `postinstall` script para persistencia entre installs
+- Project-level scope para todas las instalaciones
+
+**Non-Goals:**
+- Skills globales (`-g`) — fuera de scope
+- Detección de duplicados con plugins de Claude Code — el usuario gestiona esto
+- Fichero de config externo (`.skills-terraform.yml`) — la lista vive en la skill
+- Instalación automática sin confirmación — la skill propone, Claude confirma
+
+## Decisions
+
+### D1: Skill, no Hook ni Command
+
+La skill se activa automáticamente via "using-superpowers" al inicio de sesión. Un hook no puede pedir confirmación interactiva. Un command requiere invocación manual.
+
+**Alternativas descartadas:**
+- SessionStart hook: no interactivo, bloquea inicio
+- Command (`/experiments:skill-terraformer`): requiere que el usuario recuerde invocarlo
+
+### D2: Lista curada embebida en SKILL.md
+
+El mapeo detector→skills vive directamente en el markdown de la skill. Reglas tipo:
+
+```
+Si package.json tiene "react" en deps → instalar shadcn/ui, vercel-react-best-practices
+Si package.json tiene "expo" en deps → instalar expo/skills
+Si existe nx.json → instalar nx-related skills
+Siempre → find-skills, frontend-design (si hay frontend)
+```
+
+**Alternativa descartada:** Fichero de config separado — añade complejidad sin beneficio para un solo proyecto.
+
+### D3: `experimental_install` en postinstall
+
+El script postinstall usa `bunx skills experimental_install` que restaura del `skills-lock.json`. Esto asegura que `pnpm install` tras `git clone` reconstituye las skills.
+
+`skills update` no funciona sin lock file previo. `experimental_install` sí lo hace.
+
+**Formato del postinstall:**
+```json
+"postinstall": "bunx skills experimental_install"
+```
+
+Si ya existe un postinstall, se encadena con `&&`.
+
+### D4: Flujo de la skill
+
+```
+1. Leer project indicators (package.json, nx.json, configs)
+2. Evaluar reglas curadas → lista de skills aplicables
+3. bunx skills list --json → skills ya instaladas
+4. Diff: aplicables - instaladas = pendientes
+5. Para cada pendiente: bunx skills add <repo> --skill <name> --agent claude-code -y
+6. Si se instaló ≥1 skill (ahora o antes): verificar postinstall en package.json
+7. Si falta postinstall: proponer añadirlo
+```
+
+### D5: Agente target `claude-code`
+
+Todas las skills se instalan con `--agent claude-code` ya que es el único agente en uso en monolab.
+
+## Risks / Trade-offs
+
+- **[Lentitud al inicio]** → `bunx skills list --json` y detección de stack son rápidos. Solo se ejecuta `skills add` si hay pendientes.
+- **[CLI cambia experimental_install]** → Es experimental. Mitigación: si falla, fallback a `bunx skills update`.
+- **[Lista curada se desactualiza]** → Aceptable: actualizar la skill es trivial. Mejor que over-engineering un sistema de config.
+- **[skills-lock.json en git]** → Debe commitearse para que `experimental_install` funcione en clones frescos. Similar a lock files de paquetes.

--- a/openspec/changes/skill-terraformer/design.md
+++ b/openspec/changes/skill-terraformer/design.md
@@ -32,16 +32,17 @@ La skill se activa automáticamente via "using-superpowers" al inicio de sesión
 
 El mapeo detector→skills vive directamente en el markdown de la skill. Lista curada inicial:
 
-| Condición | Repo | Skill | Comando |
-|-----------|------|-------|---------|
-| `react` en deps | `vercel-labs/agent-skills` | `vercel-react-best-practices` | `bunx skills add vercel-labs/agent-skills --skill vercel-react-best-practices --agent claude-code -y` |
-| `react` en deps | `vercel-labs/agent-skills` | `vercel-composition-patterns` | `bunx skills add vercel-labs/agent-skills --skill vercel-composition-patterns --agent claude-code -y` |
-| `react` en deps + `components.json` existe | `shadcn/ui` | `shadcn` | `bunx skills add shadcn/ui --skill shadcn --agent claude-code -y` |
-| `next` en deps | `vercel-labs/next-skills` | `next-best-practices` | `bunx skills add vercel-labs/next-skills --skill next-best-practices --agent claude-code -y` |
-| universal (frontend) | `vercel-labs/agent-skills` | `web-design-guidelines` | `bunx skills add vercel-labs/agent-skills --skill web-design-guidelines --agent claude-code -y` |
-| universal (frontend) | `anthropics/skills` | `frontend-design` | `bunx skills add anthropics/skills --skill frontend-design --agent claude-code -y` |
+| Condición | Repo | Skill |
+|-----------|------|-------|
+| `react` en deps | `vercel-labs/agent-skills` | `vercel-react-best-practices` |
+| `react` en deps | `vercel-labs/agent-skills` | `vercel-composition-patterns` |
+| `react` en deps + `components.json` | `shadcn/ui` | `shadcn` |
+| `next` en deps | `vercel-labs/next-skills` | `next-best-practices` |
+| frontend (universal) | `vercel-labs/agent-skills` | `web-design-guidelines` |
+| frontend (universal) | `anthropics/skills` | `frontend-design` |
 
-Skills del mismo repo se pueden batchar: `bunx skills add vercel-labs/agent-skills --skill vercel-react-best-practices --skill web-design-guidelines --skill vercel-composition-patterns --agent claude-code -y`
+Plantilla: `bunx skills add <Repo> --skill <Skill> --agent claude-code -y`
+Batch por repo con múltiples `--skill` flags.
 
 **Alternativa descartada:** Fichero de config separado — añade complejidad sin beneficio para un solo proyecto.
 
@@ -58,7 +59,9 @@ El script postinstall usa `bunx skills experimental_install`, que restaura skill
 
 Solo ejecuta si existe lock file. Si falla, no bloquea `pnpm install`.
 
-Si ya existe un postinstall, se encadena con `&&`.
+Si ya existe un postinstall, se encadena con `&&` aislando el fallback:
+`<postinstall-existente> && ( [ -f skills-lock.json ] && bunx skills experimental_install || true )`.
+Los paréntesis limitan el `|| true` a la parte de skills, sin enmascarar fallos del postinstall original.
 
 ### D4: Flujo de la skill
 

--- a/openspec/changes/skill-terraformer/proposal.md
+++ b/openspec/changes/skill-terraformer/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+No hay forma automatizada de asegurar que un proyecto tenga instaladas las skills de skills.sh relevantes para su stack. Cada sesión empieza sin saber si faltan skills útiles, y tras instalarlas manualmente no hay mecanismo para que persistan entre `pnpm install`.
+
+## What Changes
+
+- Nueva skill `skill-terraformer` en `claude-plugins/experiments/skills/`
+- Lista curada embebida en la skill: mapeo stack → skills de skills.sh relevantes
+- Detección automática del stack del proyecto (package.json, configs, frameworks)
+- Instalación de skills faltantes via `bunx skills add` (project-level)
+- Asegurar script `postinstall` en package.json con `bunx skills experimental_install` cuando hay skills gestionadas
+
+## Capabilities
+
+### New Capabilities
+
+- `skill-terraformer`: Skill que al activarse detecta el stack del proyecto, compara contra lista curada de skills.sh, instala las faltantes, y asegura postinstall en package.json
+
+### Modified Capabilities
+
+- `experiments-plugin`: Añade directorio `skills/` con la primera skill del plugin
+
+## Impact
+
+- `claude-plugins/experiments/` — nuevo directorio `skills/skill-terraformer/`
+- `claude-plugins/experiments/.claude-plugin/plugin.json` — posible bump de versión
+- `package.json` (root) — puede añadirse/modificarse script `postinstall`
+- Dependencia externa: `skills` CLI (npx, no instalada como dep)
+- Genera `skills-lock.json` en root del proyecto

--- a/openspec/changes/skill-terraformer/specs/experiments-plugin/spec.md
+++ b/openspec/changes/skill-terraformer/specs/experiments-plugin/spec.md
@@ -1,0 +1,27 @@
+## MODIFIED Requirements
+
+### Requirement: Experiments Plugin Structure
+
+The `experiments` plugin SHALL exist at `claude-plugins/experiments/` and follow standard Claude Code plugin structure.
+
+The plugin directory SHALL contain:
+- `.claude-plugin/plugin.json` manifest
+- `commands/` directory for slash commands
+- `skills/` directory for agent skills
+- `package.json` with `"private": true`
+- `README.md` documenting the plugin
+
+#### Scenario: Plugin directory exists
+
+- **WHEN** navigating to `claude-plugins/experiments/`
+- **THEN** the directory SHALL exist with `.claude-plugin/plugin.json` manifest
+
+#### Scenario: Plugin manifest valid
+
+- **WHEN** examining `.claude-plugin/plugin.json`
+- **THEN** it SHALL include `name: "experiments"`, `version`, `description`, and `keywords`
+
+#### Scenario: Skills directory exists
+
+- **WHEN** examining the plugin structure
+- **THEN** `skills/` directory SHALL exist containing at least `skill-terraformer/SKILL.md`

--- a/openspec/changes/skill-terraformer/specs/skill-terraformer/spec.md
+++ b/openspec/changes/skill-terraformer/specs/skill-terraformer/spec.md
@@ -27,17 +27,17 @@ Detection signals:
 
 #### Scenario: React project detected
 
-- **WHEN** `package.json` contains `react` in dependencies
+- **WHEN** `package.json` contains `react` in dependencies or devDependencies
 - **THEN** the skill SHALL mark as applicable: `vercel-react-best-practices`, `vercel-composition-patterns`
 
 #### Scenario: React + shadcn project detected
 
-- **WHEN** `package.json` contains `react` in dependencies AND `components.json` exists
+- **WHEN** `package.json` contains `react` in dependencies or devDependencies AND `components.json` exists
 - **THEN** the skill SHALL additionally mark as applicable: `shadcn`
 
 #### Scenario: Next.js project detected
 
-- **WHEN** `package.json` contains `next` in dependencies
+- **WHEN** `package.json` contains `next` in dependencies or devDependencies
 - **THEN** the skill SHALL mark as applicable: `next-best-practices`
 
 #### Scenario: Frontend project detected
@@ -104,6 +104,13 @@ The skill SHALL query currently installed skills using `bunx skills list --json`
 
 - **WHEN** all applicable skills from the manifest are already installed
 - **THEN** the skill SHALL report that no installation is needed and proceed to postinstall verification
+
+#### Scenario: Installed skills query fails
+
+- **WHEN** `bunx skills list --json` fails or returns invalid JSON
+- **THEN** the skill SHALL report the detection state as unknown
+- **AND** the skill SHALL NOT assume all applicable skills are pending
+- **AND** the skill SHOULD require explicit user confirmation before attempting installations
 
 ---
 

--- a/openspec/changes/skill-terraformer/specs/skill-terraformer/spec.md
+++ b/openspec/changes/skill-terraformer/specs/skill-terraformer/spec.md
@@ -1,0 +1,155 @@
+## ADDED Requirements
+
+### Requirement: Skill File Location
+
+The `skill-terraformer` skill SHALL exist at `claude-plugins/experiments/skills/skill-terraformer/SKILL.md`.
+
+#### Scenario: Skill file exists
+
+- **WHEN** examining `claude-plugins/experiments/skills/skill-terraformer/`
+- **THEN** `SKILL.md` SHALL exist with valid YAML frontmatter containing `name` and `description` fields
+
+#### Scenario: Skill registered in plugin
+
+- **WHEN** listing skills for the experiments plugin
+- **THEN** `skill-terraformer` SHALL appear as an available skill
+
+---
+
+### Requirement: Stack Detection
+
+The skill SHALL detect the project's technology stack by examining project files.
+
+Detection signals:
+- `package.json` dependencies and devDependencies
+- Presence of `nx.json` (Nx monorepo)
+- Presence of `app.json` or `app.config.js` (Expo)
+- Presence of framework config files (next.config.*, vite.config.*, etc.)
+
+#### Scenario: React project detected
+
+- **WHEN** `package.json` contains `react` in dependencies
+- **THEN** the skill SHALL mark React-related skills as applicable
+
+#### Scenario: Expo project detected
+
+- **WHEN** `package.json` contains `expo` in dependencies OR `app.json`/`app.config.js` exists
+- **THEN** the skill SHALL mark Expo-related skills as applicable
+
+#### Scenario: Nx monorepo detected
+
+- **WHEN** `nx.json` exists in the project root
+- **THEN** the skill SHALL mark Nx-related skills as applicable
+
+#### Scenario: No matching stack
+
+- **WHEN** no detection rules match the project
+- **THEN** only universal skills (applicable to all projects) SHALL be marked as applicable
+
+---
+
+### Requirement: Curated Skills Manifest
+
+The skill SHALL contain an embedded curated list mapping technology stacks to skills.sh repositories and skill names.
+
+Each entry SHALL specify:
+- Detection condition (what triggers applicability)
+- skills.sh repository (`owner/repo`)
+- Skill name(s) within that repository
+- Whether it's universal (always applicable) or conditional
+
+#### Scenario: Manifest contains entries
+
+- **WHEN** the skill is read
+- **THEN** it SHALL contain at least one universal entry and at least one conditional entry
+
+#### Scenario: Entry format is actionable
+
+- **WHEN** processing a manifest entry
+- **THEN** each entry SHALL provide enough information to construct a `bunx skills add <repo> --skill <name> --agent claude-code -y` command
+
+---
+
+### Requirement: Installed Skills Detection
+
+The skill SHALL query currently installed skills using `bunx skills list --json` and compare against the curated manifest.
+
+#### Scenario: No skills installed
+
+- **WHEN** `bunx skills list --json` returns an empty array or no skills-lock.json exists
+- **THEN** all applicable skills from the manifest SHALL be marked as pending installation
+
+#### Scenario: Some skills already installed
+
+- **WHEN** `bunx skills list --json` returns skills matching some manifest entries
+- **THEN** only non-installed applicable skills SHALL be marked as pending
+
+#### Scenario: All applicable skills installed
+
+- **WHEN** all applicable skills from the manifest are already installed
+- **THEN** the skill SHALL report that no installation is needed and proceed to postinstall verification
+
+---
+
+### Requirement: Skills Installation
+
+The skill SHALL install pending skills using the skills.sh CLI.
+
+Installation command format: `bunx skills add <repo> --skill <name> --agent claude-code -y`
+
+All installations SHALL be project-level (no `-g` flag).
+
+#### Scenario: Install single pending skill
+
+- **WHEN** one applicable skill is not installed
+- **THEN** the skill SHALL execute `bunx skills add <repo> --skill <name> --agent claude-code -y`
+- **AND** the skill SHALL report the installation result
+
+#### Scenario: Install multiple pending skills from same repo
+
+- **WHEN** multiple skills from the same repository are pending
+- **THEN** the skill MAY batch them: `bunx skills add <repo> --skill <name1> --skill <name2> --agent claude-code -y`
+
+#### Scenario: Installation failure
+
+- **WHEN** a `skills add` command fails
+- **THEN** the skill SHALL report the failure and continue with remaining skills
+
+---
+
+### Requirement: Postinstall Script Management
+
+The skill SHALL verify and ensure a `postinstall` script in the root `package.json` when skills are managed (installed now or previously).
+
+The postinstall command SHALL be `bunx skills experimental_install`.
+
+#### Scenario: No postinstall exists
+
+- **WHEN** `package.json` has no `postinstall` script AND skills are managed
+- **THEN** the skill SHALL propose adding `"postinstall": "bunx skills experimental_install"`
+
+#### Scenario: Postinstall exists without skills command
+
+- **WHEN** `package.json` has a `postinstall` script that does NOT include `bunx skills experimental_install`
+- **THEN** the skill SHALL propose appending `&& bunx skills experimental_install` to the existing script
+
+#### Scenario: Postinstall already includes skills command
+
+- **WHEN** `package.json` `postinstall` already contains `skills experimental_install`
+- **THEN** the skill SHALL NOT modify the postinstall script
+
+#### Scenario: No skills managed
+
+- **WHEN** no skills from skills.sh are installed (neither now nor previously)
+- **THEN** the skill SHALL NOT propose postinstall changes
+
+---
+
+### Requirement: Skills Lock File Commitment
+
+The skill SHALL advise that `skills-lock.json` be committed to version control after installation.
+
+#### Scenario: Lock file created
+
+- **WHEN** skills are installed and `skills-lock.json` is created/updated
+- **THEN** the skill SHALL note that `skills-lock.json` should be committed for `experimental_install` to work on fresh clones

--- a/openspec/changes/skill-terraformer/specs/skill-terraformer/spec.md
+++ b/openspec/changes/skill-terraformer/specs/skill-terraformer/spec.md
@@ -126,17 +126,17 @@ All installations SHALL be project-level (no `-g` flag).
 
 The skill SHALL verify and ensure a `postinstall` script in the root `package.json` when skills are managed (installed now or previously).
 
-The postinstall command SHALL be `bunx skills experimental_install`.
+The postinstall command SHALL be `[ -f skills-lock.json ] && bunx skills experimental_install || true` (graceful degradation: only runs if lock file exists, does not block install on failure).
 
 #### Scenario: No postinstall exists
 
 - **WHEN** `package.json` has no `postinstall` script AND skills are managed
-- **THEN** the skill SHALL propose adding `"postinstall": "bunx skills experimental_install"`
+- **THEN** the skill SHALL propose adding `"postinstall": "[ -f skills-lock.json ] && bunx skills experimental_install || true"`
 
 #### Scenario: Postinstall exists without skills command
 
-- **WHEN** `package.json` has a `postinstall` script that does NOT include `bunx skills experimental_install`
-- **THEN** the skill SHALL propose appending `&& bunx skills experimental_install` to the existing script
+- **WHEN** `package.json` has a `postinstall` script that does NOT include `skills experimental_install`
+- **THEN** the skill SHALL propose appending `&& [ -f skills-lock.json ] && bunx skills experimental_install || true` to the existing script
 
 #### Scenario: Postinstall already includes skills command
 

--- a/openspec/changes/skill-terraformer/specs/skill-terraformer/spec.md
+++ b/openspec/changes/skill-terraformer/specs/skill-terraformer/spec.md
@@ -76,8 +76,13 @@ The skill SHALL query currently installed skills using `bunx skills list --json`
 
 #### Scenario: No skills installed
 
-- **WHEN** `bunx skills list --json` returns an empty array or no skills-lock.json exists
+- **WHEN** `bunx skills list --json` returns an empty array
 - **THEN** all applicable skills from the manifest SHALL be marked as pending installation
+
+#### Scenario: Lock file missing
+
+- **WHEN** `skills-lock.json` does not exist but skills are installed
+- **THEN** the skill SHOULD warn about missing lock-file persistence
 
 #### Scenario: Some skills already installed
 

--- a/openspec/changes/skill-terraformer/specs/skill-terraformer/spec.md
+++ b/openspec/changes/skill-terraformer/specs/skill-terraformer/spec.md
@@ -21,47 +21,58 @@ The `skill-terraformer` skill SHALL exist at `claude-plugins/experiments/skills/
 The skill SHALL detect the project's technology stack by examining project files.
 
 Detection signals:
-- `package.json` dependencies and devDependencies
-- Presence of `nx.json` (Nx monorepo)
-- Presence of `app.json` or `app.config.js` (Expo)
-- Presence of framework config files (next.config.*, vite.config.*, etc.)
+- `package.json` dependencies and devDependencies (`react`, `next`)
+- Presence of `components.json` (shadcn/ui)
+- Presence of any frontend dependency (triggers universal frontend skills)
 
 #### Scenario: React project detected
 
 - **WHEN** `package.json` contains `react` in dependencies
-- **THEN** the skill SHALL mark React-related skills as applicable
+- **THEN** the skill SHALL mark as applicable: `vercel-react-best-practices`, `vercel-composition-patterns`
 
-#### Scenario: Expo project detected
+#### Scenario: React + shadcn project detected
 
-- **WHEN** `package.json` contains `expo` in dependencies OR `app.json`/`app.config.js` exists
-- **THEN** the skill SHALL mark Expo-related skills as applicable
+- **WHEN** `package.json` contains `react` in dependencies AND `components.json` exists
+- **THEN** the skill SHALL additionally mark as applicable: `shadcn`
 
-#### Scenario: Nx monorepo detected
+#### Scenario: Next.js project detected
 
-- **WHEN** `nx.json` exists in the project root
-- **THEN** the skill SHALL mark Nx-related skills as applicable
+- **WHEN** `package.json` contains `next` in dependencies
+- **THEN** the skill SHALL mark as applicable: `next-best-practices`
+
+#### Scenario: Frontend project detected
+
+- **WHEN** the project has any frontend dependency (`react`, `next`, `vue`, `svelte`, etc.)
+- **THEN** the skill SHALL mark as applicable: `web-design-guidelines`, `frontend-design`
 
 #### Scenario: No matching stack
 
 - **WHEN** no detection rules match the project
-- **THEN** only universal skills (applicable to all projects) SHALL be marked as applicable
+- **THEN** no skills SHALL be marked as applicable
 
 ---
 
 ### Requirement: Curated Skills Manifest
 
-The skill SHALL contain an embedded curated list mapping technology stacks to skills.sh repositories and skill names.
+The skill SHALL contain the following embedded curated list:
 
-Each entry SHALL specify:
-- Detection condition (what triggers applicability)
-- skills.sh repository (`owner/repo`)
-- Skill name(s) within that repository
-- Whether it's universal (always applicable) or conditional
+| Condición | Repo | Skill |
+|-----------|------|-------|
+| `react` en deps | `vercel-labs/agent-skills` | `vercel-react-best-practices` |
+| `react` en deps | `vercel-labs/agent-skills` | `vercel-composition-patterns` |
+| `react` en deps + `components.json` | `shadcn/ui` | `shadcn` |
+| `next` en deps | `vercel-labs/next-skills` | `next-best-practices` |
+| frontend (universal) | `vercel-labs/agent-skills` | `web-design-guidelines` |
+| frontend (universal) | `anthropics/skills` | `frontend-design` |
 
-#### Scenario: Manifest contains entries
+Each entry SHALL map to a `bunx skills add <repo> --skill <name> --agent claude-code -y` command.
+
+Skills from the same repo MAY be batched in a single `skills add` with multiple `--skill` flags.
+
+#### Scenario: Manifest contains all 6 skills
 
 - **WHEN** the skill is read
-- **THEN** it SHALL contain at least one universal entry and at least one conditional entry
+- **THEN** it SHALL contain exactly the 6 skills listed above
 
 #### Scenario: Entry format is actionable
 

--- a/openspec/changes/skill-terraformer/specs/skill-terraformer/spec.md
+++ b/openspec/changes/skill-terraformer/specs/skill-terraformer/spec.md
@@ -147,7 +147,7 @@ The postinstall command SHALL be `[ -f skills-lock.json ] && bunx skills experim
 #### Scenario: Postinstall exists without skills command
 
 - **WHEN** `package.json` has a `postinstall` script that does NOT include `skills experimental_install`
-- **THEN** the skill SHALL propose appending `&& [ -f skills-lock.json ] && bunx skills experimental_install || true` to the existing script
+- **THEN** the skill SHALL propose appending `&& ( [ -f skills-lock.json ] && bunx skills experimental_install || true )` to the existing script (parenthesized to avoid masking failures from the original postinstall)
 
 #### Scenario: Postinstall already includes skills command
 

--- a/openspec/changes/skill-terraformer/tasks.md
+++ b/openspec/changes/skill-terraformer/tasks.md
@@ -1,0 +1,39 @@
+## 1. Plugin Structure
+
+- [ ] 1.1 Create `claude-plugins/experiments/skills/skill-terraformer/` directory
+- [ ] 1.2 Create `SKILL.md` with YAML frontmatter (`name: skill-terraformer`, `description` for auto-trigger on session start)
+
+## 2. Skill Content — Stack Detection
+
+- [ ] 2.1 Write detection rules section: read `package.json` deps, check for `nx.json`, `app.json`, framework configs
+- [ ] 2.2 Document detection signals → stack tags mapping (react, expo, nx, next, vite, etc.)
+
+## 3. Skill Content — Curated Manifest
+
+- [ ] 3.1 Define curated list of skills.sh repos and skills with their conditions
+- [ ] 3.2 Include universal skills (always applicable) and conditional skills (stack-dependent)
+- [ ] 3.3 Format entries so each maps to a `bunx skills add <repo> --skill <name> --agent claude-code -y` command
+
+## 4. Skill Content — Installation Flow
+
+- [ ] 4.1 Write instructions for querying installed skills: `bunx skills list --json`
+- [ ] 4.2 Write diff logic: applicable skills minus already-installed
+- [ ] 4.3 Write installation instructions per pending skill with `bunx skills add`
+- [ ] 4.4 Write error handling: report failures, continue with remaining
+
+## 5. Skill Content — Postinstall Management
+
+- [ ] 5.1 Write check for existing `postinstall` script in root `package.json`
+- [ ] 5.2 Write logic for adding/appending `bunx skills experimental_install` to postinstall
+- [ ] 5.3 Write advisory note about committing `skills-lock.json`
+
+## 6. Plugin Metadata Update
+
+- [ ] 6.1 Bump `claude-plugins/experiments/.claude-plugin/plugin.json` version
+- [ ] 6.2 Update `.claude-plugin/marketplace.json` version if needed
+
+## 7. Validation
+
+- [ ] 7.1 Verify skill appears in `bunx skills list` or plugin skill listing
+- [ ] 7.2 Test skill trigger: invoke in a session and confirm stack detection + diff logic
+- [ ] 7.3 Verify postinstall script proposal works correctly

--- a/openspec/changes/skill-terraformer/tasks.md
+++ b/openspec/changes/skill-terraformer/tasks.md
@@ -30,7 +30,7 @@
 ## 6. Plugin Metadata Update
 
 - [ ] 6.1 Bump `claude-plugins/experiments/.claude-plugin/plugin.json` version
-- [ ] 6.2 Update `.claude-plugin/marketplace.json` version if needed
+- [ ] 6.2 Update `.claude-plugin/marketplace.json` to same version as `plugin.json`
 
 ## 7. Validation
 


### PR DESCRIPTION
## Summary

- OpenSpec change proposal for `skill-terraformer` skill in the experiments plugin
- Skill auto-detects project stack, installs relevant skills.sh skills, ensures postinstall script
- Artifacts: proposal, design, specs (skill-terraformer + experiments-plugin delta), tasks (16 tasks / 7 groups)

## Test plan

- [ ] Review proposal.md for scope alignment
- [ ] Review design.md decisions (skill vs hook, embedded manifest, experimental_install)
- [ ] Review specs for completeness of requirements and scenarios
- [ ] Review tasks.md for implementation coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a project-level "skill-terraformer" that auto-activates on sign-in, detects the project stack, computes applicable skills, installs missing skills at project scope, and reports progress; restores managed skills on reinstall via a safe post-install script when a skills lockfile is present.

* **Documentation**
  * Added design, proposal, specs, and task guidance covering plugin structure, stack-detection rules, curated skill mappings, install flow, post-install behavior, and lockfile best practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->