### PR TITLE
feat(openspec): skills-update-check change proposal

### DIFF
--- a/openspec/changes/skills-update-check/.openspec.yaml
+++ b/openspec/changes/skills-update-check/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-22

--- a/openspec/changes/skills-update-check/design.md
+++ b/openspec/changes/skills-update-check/design.md
@@ -46,11 +46,13 @@ The skill runs inside Claude Code sessions where the available package runner va
 
 **Rationale**: Lockfile presence is the most reliable indicator of project intent. Global binary check handles cases with no project context (e.g., opening Claude Code in home dir).
 
-### D3: Once-per-session via prompt instruction
+### D3: Once-per-session via temp file guard
 
-**Choice**: Instruct in skill text: "Execute only once per session. If already executed, do not repeat."
+**Choice**: Use a session-scoped temp file (`/tmp/skills-check-<session-id>`) as a guard. The skill checks for the file before running; if it exists, skip. After successful execution, create the file.
 
-**Alternative considered**: Temp file flag (`/tmp/skills-check-<session-id>`) — over-engineered for a prompt-driven skill. LLM naturally avoids repeating completed background checks.
+**Rationale**: Prompt-only instructions ("do not repeat") are non-deterministic — the LLM may forget or re-trigger across long conversations. A temp file is a concrete, reliable mechanism that survives context compaction.
+
+**Fallback**: If session-id is unavailable, use a per-day file (`/tmp/skills-check-<date>`) to limit to once daily.
 
 ### D4: Three output states
 

--- a/openspec/changes/skills-update-check/design.md
+++ b/openspec/changes/skills-update-check/design.md
@@ -1,0 +1,68 @@
+## Context
+
+The `experiments` plugin (`claude-plugins/experiments/`) currently has only commands (`hello-experiments`, `ralph`). No `skills/` directory exists yet.
+
+Users install global skills via `npx skills add -g <package>`. The `skills` CLI (from skills.sh / `vercel-labs/skills`) tracks installed skills in a `skills-lock.json` and can check for updates via `skills check -g`. However, nobody runs this manually.
+
+The skill runs inside Claude Code sessions where the available package runner varies by project (bun, pnpm, npm) or global installation.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Automatically check for global skills.sh updates once per session, non-blocking
+- Present findings to user and offer to update if applicable
+- Detect and use the correct package runner for the session context
+- Handle edge case: no global skills installed
+
+**Non-Goals:**
+- Project-level skills update checking (only global/user-level)
+- Multi-agent support beyond Claude Code (future: OpenCode, others)
+- Auto-updating without user confirmation
+- Hook-based implementation (reserved as fallback if skill approach has latency issues)
+
+## Decisions
+
+### D1: Skill over Hook
+
+**Choice**: Implement as a skill, not a SessionStart hook.
+
+**Rationale**: `skills check -g` takes 2-3s (npm package download + git check). A SessionStart hook would block every session start. A skill runs in Claude's background processing — non-blocking, and the check result only matters infrequently (most sessions will be "all up to date").
+
+**Alternative considered**: SessionStart hook — guaranteed 1x execution but adds latency to every session. Noted as fallback if needed.
+
+### D2: Package runner detection priority
+
+**Choice**: Local lockfile → global binary → fallback `npx`.
+
+```
+1. bun.lockb / bun.lock  → bunx
+2. pnpm-lock.yaml         → pnpx
+3. yarn.lock               → npx (yarn dlx unreliable across versions)
+4. package-lock.json       → npx
+5. command -v bun          → bunx
+6. command -v pnpm         → pnpx
+7. fallback                → npx
+```
+
+**Rationale**: Lockfile presence is the most reliable indicator of project intent. Global binary check handles cases with no project context (e.g., opening Claude Code in home dir).
+
+### D3: Once-per-session via prompt instruction
+
+**Choice**: Instruct in skill text: "Execute only once per session. If already executed, do not repeat."
+
+**Alternative considered**: Temp file flag (`/tmp/skills-check-<session-id>`) — over-engineered for a prompt-driven skill. LLM naturally avoids repeating completed background checks.
+
+### D4: Three output states
+
+| `skills check -g` output | Interpretation | Action |
+|---|---|---|
+| Contains update listings | Updates available | Ask user to confirm `<runner> skills update -g` |
+| Clean output, no updates | All up to date | Brief "Global skills up to date" message |
+| "No skills tracked" | No global skills.sh installs | Inform user, suggest `<runner> skills add -g` |
+
+## Risks / Trade-offs
+
+- **[Latency]** `npx skills check -g` downloads package on first run per session → Mitigation: skill runs in background, doesn't block user interaction. Bun/pnpm cache mitigates for subsequent runs.
+- **[LLM reliability]** Skill may not trigger every session → Mitigation: acceptable — update checks are nice-to-have, not critical. If reliability becomes important, migrate to hook.
+- **[CLI changes]** `skills` CLI output format may change → Mitigation: parse output loosely, rely on presence of keywords ("No skills tracked", "already at the latest") rather than exact format.
+- **[No global runner]** If neither bun, pnpm, nor npm are available → Mitigation: extremely unlikely in a Claude Code session. Fallback to `npx` which comes with Node.

--- a/openspec/changes/skills-update-check/proposal.md
+++ b/openspec/changes/skills-update-check/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+No mechanism exists to notify users when their globally-installed skills.sh skills have updates available. Users must manually run `skills check -g` to discover updates, which they rarely do. A session-start skill in the experiments plugin can automate this check non-intrusively.
+
+## What Changes
+
+- Add a new skill `skills-update-check` to the `experiments` plugin that:
+  - Detects the package runner available in the session (lockfile-based, then global binary, fallback `npx`)
+  - Runs `<runner> skills check -g` to detect available updates for global skills.sh skills
+  - Handles three states: updates available (prompt user), all up to date (brief message), no global skills (inform + suggest `skills add -g`)
+  - Self-limits to one execution per session via prompt instruction ("do not re-run if already executed this session")
+- Creates `skills/` directory in the experiments plugin (first skill in this plugin)
+
+## Capabilities
+
+### New Capabilities
+
+- `skills-update-check`: Session-start skill that checks for global skills.sh updates and offers to apply them
+
+### Modified Capabilities
+
+- `experiments-plugin`: Adding `skills/` directory to the plugin structure (currently only has `commands/`)
+
+## Impact
+
+- **Files**: `claude-plugins/experiments/skills/skills-update-check/SKILL.md` (new)
+- **Dependencies**: Requires `skills` npm package available via `npx`/`bunx`/`pnpx` at runtime
+- **Scope**: Claude Code only (v1). Future: OpenCode, then other agents.
+- **Performance note**: If background skill execution causes noticeable latency, migrate to `SessionStart` hook approach

--- a/openspec/changes/skills-update-check/specs/experiments-plugin/spec.md
+++ b/openspec/changes/skills-update-check/specs/experiments-plugin/spec.md
@@ -25,3 +25,13 @@ The plugin directory SHALL contain:
 
 - **WHEN** examining the plugin structure
 - **THEN** `skills/` directory SHALL exist at the plugin root
+
+#### Scenario: package.json is private
+
+- **WHEN** examining `package.json` at the plugin root
+- **THEN** it SHALL contain `"private": true`
+
+#### Scenario: README exists
+
+- **WHEN** examining the plugin root at `claude-plugins/experiments/`
+- **THEN** `README.md` SHALL exist

--- a/openspec/changes/skills-update-check/specs/experiments-plugin/spec.md
+++ b/openspec/changes/skills-update-check/specs/experiments-plugin/spec.md
@@ -1,0 +1,27 @@
+## MODIFIED Requirements
+
+### Requirement: Experiments Plugin Structure
+
+The `experiments` plugin SHALL exist at `claude-plugins/experiments/` and follow standard Claude Code plugin structure.
+
+The plugin directory SHALL contain:
+- `.claude-plugin/plugin.json` manifest
+- `commands/` directory for slash commands
+- `skills/` directory for agent skills
+- `package.json` with `"private": true`
+- `README.md` documenting the plugin
+
+#### Scenario: Plugin directory exists
+
+- **WHEN** navigating to `claude-plugins/experiments/`
+- **THEN** the directory SHALL exist with `.claude-plugin/plugin.json` manifest
+
+#### Scenario: Plugin manifest valid
+
+- **WHEN** examining `.claude-plugin/plugin.json`
+- **THEN** it SHALL include `name: "experiments"`, `version`, `description`, and `keywords`
+
+#### Scenario: Skills directory exists
+
+- **WHEN** examining the plugin structure
+- **THEN** `skills/` directory SHALL exist at the plugin root

--- a/openspec/changes/skills-update-check/specs/skills-update-check/spec.md
+++ b/openspec/changes/skills-update-check/specs/skills-update-check/spec.md
@@ -1,0 +1,107 @@
+## ADDED Requirements
+
+### Requirement: Package Runner Detection
+
+The skill SHALL detect the appropriate package runner for the current session using the following priority:
+
+1. Local lockfile in CWD (first match): `bun.lockb`/`bun.lock` → `bunx`, `pnpm-lock.yaml` → `pnpx`, `yarn.lock` → `npx`, `package-lock.json` → `npx`
+2. Global binary available: `bun` → `bunx`, `pnpm` → `pnpx`
+3. Fallback: `npx`
+
+#### Scenario: Project with bun lockfile
+
+- **WHEN** `bun.lockb` or `bun.lock` exists in the current working directory
+- **THEN** the skill SHALL use `bunx` as the runner
+
+#### Scenario: Project with pnpm lockfile
+
+- **WHEN** `pnpm-lock.yaml` exists in the current working directory
+- **THEN** the skill SHALL use `pnpx` as the runner
+
+#### Scenario: No lockfile but bun globally available
+
+- **WHEN** no lockfile exists in CWD
+- **AND** `bun` is available via `command -v bun`
+- **THEN** the skill SHALL use `bunx` as the runner
+
+#### Scenario: No lockfile and no preferred runner
+
+- **WHEN** no lockfile exists and neither `bun` nor `pnpm` are globally available
+- **THEN** the skill SHALL fall back to `npx`
+
+---
+
+### Requirement: Global Skills Update Check
+
+The skill SHALL run `<runner> skills check -g` to detect available updates for globally-installed skills.sh skills.
+
+#### Scenario: Updates available
+
+- **WHEN** `skills check -g` output lists skills with available updates
+- **THEN** the skill SHALL present the update list to the user
+- **AND** ask whether to run `<runner> skills update -g`
+
+#### Scenario: All skills up to date
+
+- **WHEN** `skills check -g` output indicates no updates available
+- **THEN** the skill SHALL display a brief "Global skills up to date" message
+
+#### Scenario: No global skills installed
+
+- **WHEN** `skills check -g` output contains "No skills tracked"
+- **THEN** the skill SHALL inform the user that no global skills.sh skills are installed
+- **AND** suggest using `<runner> skills add -g <package>` to install
+
+---
+
+### Requirement: Once Per Session Execution
+
+The skill SHALL execute at most once per session.
+
+#### Scenario: First invocation in session
+
+- **WHEN** the skill is triggered for the first time in a session
+- **THEN** it SHALL run the update check
+
+#### Scenario: Subsequent trigger in same session
+
+- **WHEN** the skill has already been executed in the current session
+- **THEN** it SHALL NOT re-run the update check
+
+---
+
+### Requirement: Non-Blocking Execution
+
+The skill SHALL run in background without blocking user interaction.
+
+#### Scenario: User starts typing during check
+
+- **WHEN** the skills check is running
+- **THEN** the user SHALL be able to continue their conversation without waiting
+
+---
+
+### Requirement: User-Confirmed Updates
+
+The skill SHALL NOT auto-update skills without user confirmation.
+
+#### Scenario: User confirms update
+
+- **WHEN** updates are available and user confirms
+- **THEN** the skill SHALL run `<runner> skills update -g`
+
+#### Scenario: User declines update
+
+- **WHEN** updates are available and user declines
+- **THEN** the skill SHALL skip the update and continue the session
+
+---
+
+### Requirement: Claude Code Agent Scope
+
+The skill SHALL target Claude Code agent only (v1).
+
+#### Scenario: Skill file location
+
+- **WHEN** examining the skill file
+- **THEN** it SHALL be located at `claude-plugins/experiments/skills/skills-update-check/SKILL.md`

--- a/openspec/changes/skills-update-check/specs/skills-update-check/spec.md
+++ b/openspec/changes/skills-update-check/specs/skills-update-check/spec.md
@@ -18,11 +18,28 @@ The skill SHALL detect the appropriate package runner for the current session us
 - **WHEN** `pnpm-lock.yaml` exists in the current working directory
 - **THEN** the skill SHALL use `pnpx` as the runner
 
+#### Scenario: Project with yarn lockfile
+
+- **WHEN** `yarn.lock` exists in the current working directory
+- **THEN** the skill SHALL use `npx` as the runner
+
+#### Scenario: Project with package-lock.json
+
+- **WHEN** `package-lock.json` exists in the current working directory
+- **THEN** the skill SHALL use `npx` as the runner
+
 #### Scenario: No lockfile but bun globally available
 
 - **WHEN** no lockfile exists in CWD
 - **AND** `bun` is available via `command -v bun`
 - **THEN** the skill SHALL use `bunx` as the runner
+
+#### Scenario: No lockfile but pnpm globally available
+
+- **WHEN** no lockfile exists in CWD
+- **AND** `pnpm` is available via `command -v pnpm`
+- **AND** `bun` is NOT available
+- **THEN** the skill SHALL use `pnpx` as the runner
 
 #### Scenario: No lockfile and no preferred runner
 

--- a/openspec/changes/skills-update-check/tasks.md
+++ b/openspec/changes/skills-update-check/tasks.md
@@ -14,7 +14,9 @@
 ## 3. Plugin Updates
 
 - [ ] 3.1 Update `README.md` to document the new skill
-- [ ] 3.2 Bump plugin version in `.claude-plugin/plugin.json`
+- [ ] 3.2 Bump plugin version in `plugin.json`
+- [ ] 3.3 Bump plugin version in `marketplace.json`
+- [ ] 3.4 Bump plugin version in `package.json`
 
 ## 4. Validation
 

--- a/openspec/changes/skills-update-check/tasks.md
+++ b/openspec/changes/skills-update-check/tasks.md
@@ -1,0 +1,22 @@
+## 1. Plugin Structure
+
+- [ ] 1.1 Create `skills/` directory in `claude-plugins/experiments/`
+- [ ] 1.2 Create `skills/skills-update-check/` subdirectory
+
+## 2. Skill Implementation
+
+- [ ] 2.1 Create `skills/skills-update-check/SKILL.md` with frontmatter (`name`, `description`)
+- [ ] 2.2 Write package runner detection logic section (lockfile priority → global binary → npx fallback)
+- [ ] 2.3 Write update check workflow section (`<runner> skills check -g` + three output states)
+- [ ] 2.4 Write once-per-session instruction and non-blocking execution guidance
+- [ ] 2.5 Write user confirmation flow for updates (`<runner> skills update -g`)
+
+## 3. Plugin Updates
+
+- [ ] 3.1 Update `README.md` to document the new skill
+- [ ] 3.2 Bump plugin version in `.claude-plugin/plugin.json`
+
+## 4. Validation
+
+- [ ] 4.1 Validate plugin structure with `claude plugins validate claude-plugins/experiments/`
+- [ ] 4.2 Manual test: invoke skill in a fresh session, verify runner detection and check output


### PR DESCRIPTION
## Summary

- Adds OpenSpec change artifacts for `skills-update-check` — a session-start skill in the `experiments` plugin
- Checks for global skills.sh updates via `skills check -g` with auto-detected package runner
- Includes proposal, design, specs (2 capabilities), and implementation tasks

## Test plan

- [ ] Review proposal.md for completeness
- [ ] Review design decisions (skill vs hook, runner detection priority)
- [ ] Review specs for testable scenarios
- [ ] Review tasks for implementation coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added design, proposal, specs, and implementation checklist for a non-blocking, once-per-session global skills update check. 
  * Defines runner detection priority, background execution, three user-facing outcomes (updates found → prompt to update; up to date → brief message; no global skills → guidance), and explicit confirmation before applying updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->