### PR TITLE
feat(experiments): add skills-update-check skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
         {
             "name": "experiments",
             "source": "./claude-plugins/experiments",
-            "version": "0.2.1",
+            "version": "0.3.0",
             "description": "Beta skills and commands staging area for monolab"
         }
     ]

--- a/claude-plugins/experiments/.claude-plugin/plugin.json
+++ b/claude-plugins/experiments/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "experiments",
-    "version": "0.2.1",
+    "version": "0.3.0",
     "description": "Beta skills and commands staging area for monolab",
     "author": {
         "name": "Pablo F.G.",

--- a/claude-plugins/experiments/README.md
+++ b/claude-plugins/experiments/README.md
@@ -14,17 +14,23 @@ Generate Ralph loop infrastructure from a project description for autonomous AI 
 
 Creates 5 files in the current directory:
 
--   `prd.json` - PRD items extracted from description
--   `progress.txt` - Iteration tracking file
--   `PROMPT.md` - Prompt template with @-references
--   `ralph-once.sh` - Single iteration script (HITL)
--   `ralph.sh` - Autonomous loop script (AFK)
+- `prd.json` - PRD items extracted from description
+- `progress.txt` - Iteration tracking file
+- `PROMPT.md` - Prompt template with @-references
+- `ralph-once.sh` - Single iteration script (HITL)
+- `ralph.sh` - Autonomous loop script (AFK)
 
 **Requirements:** Docker Desktop 4.58+ with Docker Sandbox
 
 ### `/experiments:hello-experiments`
 
 Explains the purpose of this plugin and lists any experimental features currently available.
+
+## Skills
+
+### `skills-update-check`
+
+Checks for updates to globally-installed skills.sh skills once per session. Detects the project's package runner, runs `skills check -g`, and offers to apply updates if available.
 
 ## Testing
 

--- a/claude-plugins/experiments/package.json
+++ b/claude-plugins/experiments/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@m0n0lab/plugin-experiments",
-    "version": "0.2.1",
+    "version": "0.3.0",
     "private": true,
     "description": "Beta skills and commands staging area for monolab"
 }

--- a/claude-plugins/experiments/skills/skills-update-check/SKILL.md
+++ b/claude-plugins/experiments/skills/skills-update-check/SKILL.md
@@ -9,7 +9,7 @@ Check for updates to globally-installed skills.sh skills. Run this **once per se
 
 ## Once-Per-Session Guard
 
-Before running the check, review your conversation context for any prior `skills check -g` output. If you already ran this check earlier in this session, **skip** — do not re-run.
+Before running the check, search your conversation history for the marker phrase "Skills update check completed". If found, **skip** — do not re-run. After successfully executing the check workflow, always output the marker phrase to confirm completion.
 
 ## Package Runner Detection
 
@@ -26,6 +26,8 @@ Detect the runner using lockfile priority, then global binary, then fallback:
 | 7        | fallback                         | `npx`  |
 
 Check lockfiles in the current working directory first. Only fall through to global binary detection if no lockfile matches.
+
+**Note:** If multiple lockfiles exist, use the first match in priority order (e.g., if both `bun.lockb` and `pnpm-lock.yaml` are present, use `bunx`).
 
 ## Update Check Workflow
 

--- a/claude-plugins/experiments/skills/skills-update-check/SKILL.md
+++ b/claude-plugins/experiments/skills/skills-update-check/SKILL.md
@@ -9,23 +9,7 @@ Check for updates to globally-installed skills.sh skills. Run this **once per se
 
 ## Once-Per-Session Guard
 
-Before running the check, verify it hasn't already run this session:
-
-```bash
-SESSION_GUARD="/tmp/skills-check-${CLAUDE_SESSION_ID:-$(date +%Y%m%d)}"
-if [ -f "$SESSION_GUARD" ]; then
-  echo "SKIP: already checked this session"
-  exit 0
-fi
-```
-
-If the guard file exists, **stop** — report "Already checked this session" and do nothing more.
-
-After a successful check, create the guard file:
-
-```bash
-touch "$SESSION_GUARD"
-```
+Before running the check, review your conversation context for any prior `skills check -g` output. If you already ran this check earlier in this session, **skip** — do not re-run.
 
 ## Package Runner Detection
 

--- a/claude-plugins/experiments/skills/skills-update-check/SKILL.md
+++ b/claude-plugins/experiments/skills/skills-update-check/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: skills-update-check
+description: Check for available updates to globally-installed skills.sh skills at session start. Detects package runner, runs skills check -g, and offers to update if needed. Execute once per session only.
+---
+
+# Skills Update Check
+
+Check for updates to globally-installed skills.sh skills. Run this **once per session** — do not re-run if already executed.
+
+## Once-Per-Session Guard
+
+Before running the check, verify it hasn't already run this session:
+
+```bash
+SESSION_GUARD="/tmp/skills-check-${CLAUDE_SESSION_ID:-$(date +%Y%m%d)}"
+if [ -f "$SESSION_GUARD" ]; then
+  echo "SKIP: already checked this session"
+  exit 0
+fi
+```
+
+If the guard file exists, **stop** — report "Already checked this session" and do nothing more.
+
+After a successful check, create the guard file:
+
+```bash
+touch "$SESSION_GUARD"
+```
+
+## Package Runner Detection
+
+Detect the runner using lockfile priority, then global binary, then fallback:
+
+| Priority | Condition                        | Runner |
+| -------- | -------------------------------- | ------ |
+| 1        | `bun.lockb` or `bun.lock` exists | `bunx` |
+| 2        | `pnpm-lock.yaml` exists          | `pnpx` |
+| 3        | `yarn.lock` exists               | `npx`  |
+| 4        | `package-lock.json` exists       | `npx`  |
+| 5        | `command -v bun` succeeds        | `bunx` |
+| 6        | `command -v pnpm` succeeds       | `pnpx` |
+| 7        | fallback                         | `npx`  |
+
+Check lockfiles in the current working directory first. Only fall through to global binary detection if no lockfile matches.
+
+## Update Check Workflow
+
+Run the check in background (non-blocking):
+
+```bash
+<runner> skills check -g
+```
+
+Handle three output states:
+
+### Updates Available
+
+If the output lists skills with available updates:
+
+1. Present the update list to the user
+2. Ask: "Would you like to update your global skills?"
+3. If **yes** → run `<runner> skills update -g`
+4. If **no** → skip, continue the session
+
+### All Up to Date
+
+If the output indicates no updates available (e.g., contains "already at the latest"):
+
+> Global skills up to date.
+
+### No Global Skills Installed
+
+If the output contains "No skills tracked":
+
+> No global skills.sh skills are installed. You can install skills with:
+>
+> ```bash
+> <runner> skills add -g <package>
+> ```

--- a/openspec/changes/skills-update-check/tasks.md
+++ b/openspec/changes/skills-update-check/tasks.md
@@ -1,24 +1,24 @@
 ## 1. Plugin Structure
 
-- [ ] 1.1 Create `skills/` directory in `claude-plugins/experiments/`
-- [ ] 1.2 Create `skills/skills-update-check/` subdirectory
+- [x] 1.1 Create `skills/` directory in `claude-plugins/experiments/`
+- [x] 1.2 Create `skills/skills-update-check/` subdirectory
 
 ## 2. Skill Implementation
 
-- [ ] 2.1 Create `skills/skills-update-check/SKILL.md` with frontmatter (`name`, `description`)
-- [ ] 2.2 Write package runner detection logic section (lockfile priority → global binary → npx fallback)
-- [ ] 2.3 Write update check workflow section (`<runner> skills check -g` + three output states)
-- [ ] 2.4 Write once-per-session instruction and non-blocking execution guidance
-- [ ] 2.5 Write user confirmation flow for updates (`<runner> skills update -g`)
+- [x] 2.1 Create `skills/skills-update-check/SKILL.md` with frontmatter (`name`, `description`)
+- [x] 2.2 Write package runner detection logic section (lockfile priority → global binary → npx fallback)
+- [x] 2.3 Write update check workflow section (`<runner> skills check -g` + three output states)
+- [x] 2.4 Write once-per-session instruction and non-blocking execution guidance
+- [x] 2.5 Write user confirmation flow for updates (`<runner> skills update -g`)
 
 ## 3. Plugin Updates
 
-- [ ] 3.1 Update `README.md` to document the new skill
-- [ ] 3.2 Bump plugin version in `plugin.json`
-- [ ] 3.3 Bump plugin version in `marketplace.json`
-- [ ] 3.4 Bump plugin version in `package.json`
+- [x] 3.1 Update `README.md` to document the new skill
+- [x] 3.2 Bump plugin version in `plugin.json`
+- [x] 3.3 Bump plugin version in `marketplace.json` (N/A — file doesn't exist)
+- [x] 3.4 Bump plugin version in `package.json`
 
 ## 4. Validation
 
-- [ ] 4.1 Validate plugin structure with `claude plugins validate claude-plugins/experiments/`
+- [x] 4.1 Validate plugin structure with `claude plugins validate claude-plugins/experiments/`
 - [ ] 4.2 Manual test: invoke skill in a fresh session, verify runner detection and check output

--- a/openspec/changes/skills-update-check/tasks.md
+++ b/openspec/changes/skills-update-check/tasks.md
@@ -15,7 +15,7 @@
 
 - [x] 3.1 Update `README.md` to document the new skill
 - [x] 3.2 Bump plugin version in `plugin.json`
-- [x] 3.3 Bump plugin version in `marketplace.json` (N/A — file doesn't exist)
+- [x] 3.3 Bump plugin version in `marketplace.json`
 - [x] 3.4 Bump plugin version in `package.json`
 
 ## 4. Validation


### PR DESCRIPTION
## Summary
- Add `skills-update-check` skill to experiments plugin — checks for global skills.sh updates once per session
- Detects package runner via lockfile priority → global binary → npx fallback
- Handles 3 states: updates available (prompt), up to date (brief msg), no skills (suggest install)
- Temp file guard (`/tmp/skills-check-<session-id>`) for once-per-session enforcement
- Bump experiments plugin version to 0.3.0

## Test plan
- [ ] Run `claude --plugin-dir ./claude-plugins/experiments` in a fresh session
- [ ] Verify runner detection picks correct runner for project lockfile
- [ ] Verify `skills check -g` output is parsed into correct state
- [ ] Verify guard file prevents re-execution in same session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a skills-update-check skill that checks for updates to globally installed skills once per session and prompts to apply updates.

* **Documentation**
  * Added Skills section documenting the new skill and cleaned up README formatting.
  * Marked related checklist tasks as completed.

* **Chores**
  * Bumped plugin/package version to 0.3.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->