### PR TITLE
feat(experiments): add plugin-version-bump skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
         {
             "name": "experiments",
             "source": "./claude-plugins/experiments",
-            "version": "0.2.1",
+            "version": "0.3.0",
             "description": "Beta skills and commands staging area for monolab"
         }
     ]

--- a/claude-plugins/experiments/.claude-plugin/plugin.json
+++ b/claude-plugins/experiments/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "experiments",
-    "version": "0.2.1",
+    "version": "0.3.0",
     "description": "Beta skills and commands staging area for monolab",
     "author": {
         "name": "Pablo F.G.",

--- a/claude-plugins/experiments/package.json
+++ b/claude-plugins/experiments/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@m0n0lab/plugin-experiments",
-    "version": "0.2.1",
+    "version": "0.3.0",
     "private": true,
     "description": "Beta skills and commands staging area for monolab"
 }

--- a/claude-plugins/experiments/skills/plugin-version-bump/SKILL.md
+++ b/claude-plugins/experiments/skills/plugin-version-bump/SKILL.md
@@ -34,7 +34,7 @@ For each affected plugin:
 2. **Compute** new version using the semver level determined above
 3. **Update** `.claude-plugin/plugin.json` `version` field
 4. **Update** `package.json` `version` field (if present in plugin root)
-5. **Update** root `marketplace.json` — find the plugin entry by `name` field (not array index) and update its `version`
+5. **Update** root `.claude-plugin/marketplace.json` (registry file) — find the plugin entry by `name` field (not array index) and update its `version`
     - If the plugin has no marketplace entry, add one with `name`, `source`, `version`, and `description`
 
 All files MUST contain the same version string after the bump.

--- a/claude-plugins/experiments/skills/plugin-version-bump/SKILL.md
+++ b/claude-plugins/experiments/skills/plugin-version-bump/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: plugin-version-bump
+description: Bump plugin version and sync version files after completing modifications to a Claude Code plugin (any directory with .claude-plugin/plugin.json). Use after finishing all changes to a plugin — not mid-task.
+---
+
+# Plugin Version Bump
+
+Use this skill **after completing all modifications** to a Claude Code plugin. Do NOT use mid-task.
+
+## Plugin Detection
+
+A Claude Code plugin is any directory containing `.claude-plugin/plugin.json`. Identify affected plugins by finding `.claude-plugin/plugin.json` in the directory tree of modified files. Do NOT rely on hardcoded paths.
+
+If no modified files belong to a plugin directory, this skill does not apply.
+
+## Semver Classification
+
+Determine bump level from the type of change made:
+
+| Change Type                                | Bump  | Examples                               |
+| ------------------------------------------ | ----- | -------------------------------------- |
+| New skill, command, agent, or hook         | minor | Add `skills/foo/SKILL.md`, new command |
+| Existing component edited                  | patch | Fix typo in skill, update description  |
+| Component removed or renamed (breaking)    | major | Remove a command users depend on       |
+| Metadata-only (plugin.json fields, README) | patch | Update description or keywords         |
+
+If the correct level is unclear, ask the user.
+
+## File Update Order
+
+For each affected plugin:
+
+1. **Read** current version from `.claude-plugin/plugin.json` (source of truth)
+2. **Compute** new version using the semver level determined above
+3. **Update** `.claude-plugin/plugin.json` `version` field
+4. **Update** `package.json` `version` field (if present in plugin root)
+5. **Update** root `marketplace.json` — find the plugin entry by `name` field (not array index) and update its `version`
+    - If the plugin has no marketplace entry, add one with `name`, `source`, `version`, and `description`
+
+All files MUST contain the same version string after the bump.
+
+## Multi-Plugin / Multi-Task Rules
+
+- If a single task modifies **multiple plugins**, bump each independently — each plugin has its own version lifecycle
+- If performing **multiple independent tasks** on the same plugin in one session, bump after each logical unit of work completes
+- If multiple changes are part of a **single feature** (e.g., new skill + supporting command), apply a single bump at the highest applicable level

--- a/openspec/changes/plugin-version-bump-skill/tasks.md
+++ b/openspec/changes/plugin-version-bump-skill/tasks.md
@@ -1,24 +1,24 @@
 ## 1. Fix Current State
 
-- [ ] 1.1 Verify marketplace.json/plugin.json version consistency for all plugins (no-op if already in sync)
+- [x] 1.1 Verify marketplace.json/plugin.json version consistency for all plugins (no-op if already in sync)
 
 ## 2. Create Skill
 
-- [ ] 2.1 Create directory `claude-plugins/experiments/skills/plugin-version-bump/`
-- [ ] 2.2 Write `SKILL.md` with trigger-optimized description frontmatter
-- [ ] 2.3 Write skill body with semver classification table, file update instructions, multi-plugin/multi-task guidance, and marketplace sync instructions
+- [x] 2.1 Create directory `claude-plugins/experiments/skills/plugin-version-bump/`
+- [x] 2.2 Write `SKILL.md` with trigger-optimized description frontmatter
+- [x] 2.3 Write skill body with semver classification table, file update instructions, multi-plugin/multi-task guidance, and marketplace sync instructions
 
 ## 3. Update Specs
 
-- [ ] 3.1 Sync delta specs to `openspec/specs/plugin-version-bump/spec.md` (new)
-- [ ] 3.2 Sync delta specs to `openspec/specs/claude-code-plugins/spec.md` (modified — version consistency requirement)
-- [ ] 3.3 Sync delta specs to `openspec/specs/experiments-plugin/spec.md` (added — skill registration)
+- [x] 3.1 Sync delta specs to `openspec/specs/plugin-version-bump/spec.md` (new)
+- [x] 3.2 Sync delta specs to `openspec/specs/claude-code-plugins/spec.md` (modified — version consistency requirement)
+- [x] 3.3 Sync delta specs to `openspec/specs/experiments-plugin/spec.md` (added — skill registration)
 
 ## 4. Bump Plugin Version
 
-- [ ] 4.1 Bump experiments plugin version (minor — new skill added): update `plugin.json`, `package.json`, and `marketplace.json`
+- [x] 4.1 Bump experiments plugin version (minor — new skill added): update `plugin.json`, `package.json`, and `marketplace.json`
 
 ## 5. Verify
 
-- [ ] 5.1 Verify skill appears in Claude Code available skills list after plugin reload
-- [ ] 5.2 Verify all 3 version files are in sync for both plugins
+- [x] 5.1 Verify skill appears in Claude Code available skills list after plugin reload
+- [x] 5.2 Verify all 3 version files are in sync for both plugins

--- a/openspec/specs/claude-code-plugins/spec.md
+++ b/openspec/specs/claude-code-plugins/spec.md
@@ -39,6 +39,8 @@ The marketplace manifest SHALL include:
 - `metadata`: Object with `description`, `version`, and `pluginRoot`
 - `plugins`: Array of plugin entries with `name`, `source`, `version`, and `description`
 
+Plugin entry `version` fields SHALL be kept in sync with each plugin's `.claude-plugin/plugin.json` version. The `plugin.json` is the source of truth; marketplace.json versions are informational for discovery.
+
 #### Scenario: Marketplace manifest exists
 
 - **GIVEN** the monolab repository
@@ -58,6 +60,11 @@ The marketplace manifest SHALL include:
 - **WHEN** they run `/plugin install expo-developer@monolab`
 - **THEN** the expo-developer plugin SHALL be installed
 - **AND** its skills SHALL be available
+
+#### Scenario: Version consistency
+
+- **WHEN** examining marketplace.json plugin entries
+- **THEN** each entry's `version` SHALL match the corresponding `claude-plugins/<name>/.claude-plugin/plugin.json` version
 
 ---
 

--- a/openspec/specs/experiments-plugin/spec.md
+++ b/openspec/specs/experiments-plugin/spec.md
@@ -85,3 +85,24 @@ The plugin SHALL be recognized as a pnpm workspace member.
 
 - **WHEN** running `pnpm install` from root
 - **THEN** the experiments plugin SHALL be recognized as workspace member
+
+---
+
+### Requirement: Plugin Version Bump Skill
+
+The experiments plugin SHALL include a `plugin-version-bump` skill at `skills/plugin-version-bump/SKILL.md`.
+
+The skill SHALL:
+- Guide the AI agent to bump plugin versions after completing plugin modifications
+- Provide a semver classification table for determining bump level
+- Instruct synchronization of version across plugin.json, package.json, and marketplace.json
+
+#### Scenario: Skill directory exists
+
+- **WHEN** examining `claude-plugins/experiments/skills/`
+- **THEN** `plugin-version-bump/SKILL.md` SHALL exist
+
+#### Scenario: Skill discoverable by Claude Code
+
+- **WHEN** the experiments plugin is installed
+- **THEN** the `plugin-version-bump` skill SHALL appear in the available skills list

--- a/openspec/specs/plugin-version-bump/spec.md
+++ b/openspec/specs/plugin-version-bump/spec.md
@@ -102,7 +102,7 @@ The skill SHALL instruct the agent to update ALL version-bearing files for the a
 
 1. `.claude-plugin/plugin.json` — `version` field (source of truth, always present)
 2. `package.json` — `version` field (if present in plugin root)
-3. Marketplace `marketplace.json` — `plugins[].version` for the matching entry (if a marketplace.json exists and contains the plugin, matched by `name` field)
+3. Root `.claude-plugin/marketplace.json` — `plugins[].version` for the matching entry (if the root marketplace exists and contains the plugin, matched by `name` field)
 
 All updated files SHALL contain the same version string after the bump.
 
@@ -119,9 +119,9 @@ All updated files SHALL contain the same version string after the bump.
 - **THEN** the agent SHALL find the marketplace entry where `name` equals "expo-developer"
 - **AND** update that entry's `version` field
 
-#### Scenario: Plugin not in marketplace
+#### Scenario: Plugin not in root marketplace registry
 
-- **WHEN** agent bumps a plugin that has no entry in marketplace.json
+- **WHEN** agent bumps a plugin that has no entry in `.claude-plugin/marketplace.json`
 - **THEN** the agent SHALL add a new entry to the `plugins` array with `name`, `source`, `version`, and `description`
 
 ---

--- a/openspec/specs/plugin-version-bump/spec.md
+++ b/openspec/specs/plugin-version-bump/spec.md
@@ -1,0 +1,154 @@
+# plugin-version-bump Specification
+
+## Purpose
+
+Skill that detects plugin modifications and guides the AI agent to bump versions and synchronize version files across plugin.json, package.json, and marketplace.json.
+
+## Requirements
+
+### Requirement: Skill File Structure
+
+The skill SHALL exist at `claude-plugins/experiments/skills/plugin-version-bump/SKILL.md`.
+
+The SKILL.md SHALL include frontmatter with:
+- `name`: "plugin-version-bump"
+- `description`: Trigger-optimized description for detecting plugin modification work
+
+#### Scenario: Skill file exists
+
+- **WHEN** examining `claude-plugins/experiments/skills/plugin-version-bump/`
+- **THEN** `SKILL.md` SHALL exist with valid frontmatter
+
+---
+
+### Requirement: Plugin Detection
+
+The skill SHALL identify a Claude Code plugin by the presence of `.claude-plugin/plugin.json` in the directory tree of any modified file. The skill SHALL NOT rely on a hardcoded directory path.
+
+#### Scenario: Plugin in standard location
+
+- **WHEN** agent modifies files under a directory containing `.claude-plugin/plugin.json`
+- **THEN** the skill SHALL recognize that directory as a plugin root
+
+#### Scenario: Plugin in non-standard location
+
+- **WHEN** agent modifies files under `tools/my-plugin/` which contains `.claude-plugin/plugin.json`
+- **THEN** the skill SHALL recognize `tools/my-plugin/` as a plugin root
+
+#### Scenario: No plugin structure present
+
+- **WHEN** agent modifies files in a directory without `.claude-plugin/plugin.json` in its tree
+- **THEN** the skill SHALL NOT activate
+
+---
+
+### Requirement: Trigger Conditions
+
+The skill SHALL activate when the agent completes modifications to any Claude Code plugin (any directory containing `.claude-plugin/plugin.json`).
+
+The skill SHALL NOT activate:
+- During ongoing work (mid-task)
+- For tasks that do not modify files within a plugin directory
+- For tasks that only affect non-plugin files (e.g., openspec/, packages/)
+
+#### Scenario: Agent finishes adding a new skill to a plugin
+
+- **WHEN** agent completes creating a new skill file under a plugin's `skills/` directory
+- **THEN** the skill SHALL activate and guide version bumping
+
+#### Scenario: Agent edits files outside any plugin
+
+- **WHEN** agent modifies files only in directories without `.claude-plugin/plugin.json`
+- **THEN** the skill SHALL NOT activate
+
+#### Scenario: Agent is mid-task in a plugin
+
+- **WHEN** agent has edited one skill file but is about to edit another as part of the same task
+- **THEN** the skill SHALL NOT activate until the task is complete
+
+---
+
+### Requirement: Semver Level Determination
+
+The skill SHALL instruct the agent to classify changes and determine the semver bump level:
+
+| Change Type | Semver Level |
+|---|---|
+| New skill, command, agent, or hook added | minor |
+| Existing component edited (content, description, fix) | patch |
+| Component removed or renamed (breaking) | major |
+| Metadata-only change (plugin.json fields, README) | patch |
+
+#### Scenario: New command added
+
+- **WHEN** agent has added a new command file to a plugin
+- **THEN** the skill SHALL guide the agent to apply a minor version bump
+
+#### Scenario: Existing skill content edited
+
+- **WHEN** agent has edited the content of an existing SKILL.md
+- **THEN** the skill SHALL guide the agent to apply a patch version bump
+
+#### Scenario: Command removed
+
+- **WHEN** agent has removed a command file from a plugin
+- **THEN** the skill SHALL guide the agent to apply a major version bump
+
+---
+
+### Requirement: Version File Synchronization
+
+The skill SHALL instruct the agent to update ALL version-bearing files for the affected plugin:
+
+1. `.claude-plugin/plugin.json` — `version` field (source of truth, always present)
+2. `package.json` — `version` field (if present in plugin root)
+3. Marketplace `marketplace.json` — `plugins[].version` for the matching entry (if a marketplace.json exists and contains the plugin, matched by `name` field)
+
+All updated files SHALL contain the same version string after the bump.
+
+#### Scenario: All files updated after bump
+
+- **WHEN** agent bumps experiments plugin from 0.2.1 to 0.3.0
+- **THEN** `claude-plugins/experiments/.claude-plugin/plugin.json` version SHALL be "0.3.0"
+- **AND** `claude-plugins/experiments/package.json` version SHALL be "0.3.0"
+- **AND** `.claude-plugin/marketplace.json` experiments entry version SHALL be "0.3.0"
+
+#### Scenario: Marketplace entry matched by name
+
+- **WHEN** agent bumps a plugin named "expo-developer"
+- **THEN** the agent SHALL find the marketplace entry where `name` equals "expo-developer"
+- **AND** update that entry's `version` field
+
+#### Scenario: Plugin not in marketplace
+
+- **WHEN** agent bumps a plugin that has no entry in marketplace.json
+- **THEN** the agent SHALL add a new entry to the `plugins` array with `name`, `source`, `version`, and `description`
+
+---
+
+### Requirement: Multi-Plugin Independence
+
+When a task modifies multiple plugins, the skill SHALL guide the agent to bump each plugin's version independently.
+
+#### Scenario: Two plugins modified in same task
+
+- **WHEN** agent modifies files in two different plugin directories (each containing `.claude-plugin/plugin.json`)
+- **THEN** the skill SHALL guide separate version bumps for each plugin
+- **AND** each bump SHALL reflect only that plugin's changes
+
+---
+
+### Requirement: Multiple Independent Tasks
+
+When the agent performs multiple independent tasks on the same plugin in one session, the skill SHALL guide a version bump after each logical unit of work completes.
+
+#### Scenario: Two independent changes to same plugin
+
+- **WHEN** agent adds a new skill to experiments, then later fixes a command in experiments (separate tasks)
+- **THEN** the skill SHALL guide a bump after the first task (minor)
+- **AND** a second bump after the second task (patch)
+
+#### Scenario: Related changes grouped
+
+- **WHEN** agent adds a new skill and its supporting command as part of a single feature
+- **THEN** the skill SHALL guide a single bump (minor, since new component added)


### PR DESCRIPTION
## Summary

- New `plugin-version-bump` skill in experiments plugin — guides AI agent to bump plugin versions after completing modifications, classify semver level, and sync version across plugin.json/package.json/marketplace.json
- Bumps experiments plugin 0.2.1 → 0.3.0 (minor — new skill added)
- Updates specs: version consistency requirement in claude-code-plugins, skill registration in experiments-plugin, new plugin-version-bump spec

## Test plan

- [ ] Verify skill appears in Claude Code available skills list after plugin reload
- [ ] Test skill triggers when completing plugin modifications
- [ ] Verify version files stay in sync after a bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a plugin-version-bump skill to automate and standardize plugin version updates.

* **Documentation**
  * Added/updated specs enforcing version consistency and a workflow for synchronizing plugin metadata and marketplace entries.

* **Chores**
  * Bumped the experiments plugin version to 0.3.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->