### PR TITLE
feat(openspec): green-beard-supplies change artifacts

### DIFF
--- a/openspec/changes/green-beard-supplies/design.md
+++ b/openspec/changes/green-beard-supplies/design.md
@@ -87,7 +87,7 @@ On update, the existing `sustrato_materiales` rows are replaced entirely (delete
 
 ### 6. Decimal handling — Drizzle `numeric` type
 
-Prices, volumes, margins stored as `numeric(10,2)` in PostgreSQL. In TypeScript, Drizzle returns these as strings. Domain entities parse to `number` in `toDomain()` mappers.
+Prices, volumes, dimensions stored as `numeric(10,2)` in PostgreSQL. Margins stored as `numeric(5,2)` (0-1 range). In TypeScript, Drizzle returns these as strings. Domain entities parse to `number` in `toDomain()` mappers.
 
 **Why**: Avoids floating-point precision issues in DB. JavaScript `number` is fine for display/calculation at this scale.
 

--- a/openspec/changes/green-beard-supplies/design.md
+++ b/openspec/changes/green-beard-supplies/design.md
@@ -1,0 +1,99 @@
+## Context
+
+Green Beard foundation (Change 1) provides the clean architecture packages, DI wiring, Drizzle+PostgreSQL, and two simple CRUDs (Familia, Planta). This change adds supply entities that model the physical inputs for preparing plants for sale: raw materials, pots, and substrates.
+
+Key complexity: Sustrato has a N:M relationship with Material via a junction table with quantities (litros), and its cost is computed dynamically from the sum of its materials' costs.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Material CRUD — simple entity with per-liter pricing
+- Maceta CRUD — dimensions, enum material type, cost+margin→pvp
+- Sustrato CRUD — N:M material composition, dynamic cost, margin→pvp
+- All following foundation's established patterns (entities, ports, use cases, routes, BFF)
+
+**Non-Goals:**
+
+- PlantaVenta / inventory (next change)
+- Photo uploads
+- Stock tracking / purchase orders
+- Bulk import/export of supplies
+
+## Decisions
+
+### 1. MacetaMaterial as string enum value object
+
+```typescript
+type MacetaMaterial = "terracota" | "plastico" | "ceramica" | "fibra_coco" | "tela";
+```
+
+**Why**: Finite, known set. No need for a DB table. Value object in domain, VARCHAR in Drizzle. Easy to extend later by adding to the union type + migration.
+
+**Alternative**: Separate `materiales_maceta` table. Overkill — these values rarely change and don't need CRUD.
+
+### 2. Sustrato ↔ Material junction table with litros
+
+```
+sustratos          sustrato_materiales         materiales
+┌──────┐          ┌──────────────────┐         ┌──────────┐
+│ id   │◄────────│ sustrato_id (FK) │         │ id       │
+│ nombre│         │ material_id (FK) │────────▶│ nombre   │
+│ margen│         │ litros (decimal) │         │ precio_L │
+└──────┘          └──────────────────┘         └──────────┘
+                   PK: (sustrato_id, material_id)
+```
+
+**Why**: Classic N:M with quantity. Composite PK prevents duplicate material entries per sustrato. `litros` is the quantity of that material in the mix.
+
+### 3. Sustrato cost computed dynamically, not stored
+
+`coste_sustrato = Σ(material.precio_litro × sustrato_material.litros)`
+
+Computed at read time by joining sustrato_materiales + materiales. NOT stored in the sustratos table.
+
+**Why**: If a material's price changes, all sustratos using it reflect the new cost immediately. Storing cost would require cache invalidation on material price changes — unnecessary complexity.
+
+**Trade-off**: Read queries are slightly more complex (need JOIN + SUM). Acceptable for the expected data volume (tens of sustratos, not millions).
+
+### 4. PVP computation: `pvp = coste × (1 + margen)`
+
+Both Maceta and Sustrato store `margen` as a decimal (0-1, e.g., 0.3 for 30%). PVP is computed:
+- **Maceta**: `pvp = coste × (1 + margen)` — coste is stored directly
+- **Sustrato**: `pvp = coste_dinamico × (1 + margen)` — coste is computed from materials
+
+PVP is NOT stored in DB — always derived. Returned in DTOs.
+
+**Why**: Same reasoning as sustrato cost. Margin changes should immediately reflect in PVP without cache invalidation.
+
+### 5. Sustrato CRUD manages composition atomically
+
+When creating/updating a Sustrato, the materials array is sent as a whole:
+
+```typescript
+{
+    nombre: "Tropical Mix",
+    margen: 0.25,
+    materiales: [
+        { materialId: "<uuid>", litros: 2.5 },
+        { materialId: "<uuid>", litros: 1.0 }
+    ]
+}
+```
+
+On update, the existing `sustrato_materiales` rows are replaced entirely (delete all for sustrato_id, insert new set).
+
+**Why**: Simpler than individual add/remove operations. The materials list is always small. Atomic replacement avoids partial states.
+
+### 6. Decimal handling — Drizzle `numeric` type
+
+Prices, volumes, margins stored as `numeric(10,2)` in PostgreSQL. In TypeScript, Drizzle returns these as strings. Domain entities parse to `number` in `toDomain()` mappers.
+
+**Why**: Avoids floating-point precision issues in DB. JavaScript `number` is fine for display/calculation at this scale.
+
+## Risks / Trade-offs
+
+- **[Dynamic cost = slower reads for Sustrato]** → Acceptable. Data volume is tiny. Can add materialized view or cached column later if needed.
+- **[Deleting a Material used by Sustratos]** → FK constraint prevents deletion. Use case should check and return clear error. Alternative: soft delete (not needed for v1).
+- **[Deleting a Maceta/Sustrato used by PlantaVenta]** → Future concern (inventory change). FK will be added then. For now, these entities are standalone.
+- **[Margen as 0-1 decimal]** → Could confuse users expecting percentage. UI should display as "25%" while storing 0.25. Validation: 0 ≤ margen ≤ 1.

--- a/openspec/changes/green-beard-supplies/proposal.md
+++ b/openspec/changes/green-beard-supplies/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Supply entities (Material, Maceta, Sustrato) model the inputs used to prepare plants for sale. Each has pricing logic: Material has a per-liter cost, Maceta has cost+margin→pvp, Sustrato computes cost dynamically from its material composition. These are independent from Planta/Familia but prerequisite for PlantaVenta (inventory).
+
+Depends on: `green-beard-foundation` (packages, DB, DI wiring)
+
+## What Changes
+
+- Material CRUD: id (uuid), nombre (string), precio_litro (decimal). Simple entity, no FKs
+- Maceta CRUD: id (uuid), nombre (string), material (enum: terracota, plastico, ceramica, fibra_coco, tela), diametro_cm (decimal), alto_cm (decimal), volumen_litros (decimal), coste (decimal), margen (decimal 0-1), pvp (computed: coste × (1 + margen))
+- Sustrato CRUD: id (uuid), nombre (string), margen (decimal 0-1). Has N:M relation to Material via junction table `sustrato_materiales` (sustrato_id, material_id, litros). Coste computed dynamically: Σ(material.precio_litro × litros). PVP computed: coste × (1 + margen)
+- New Drizzle schema tables: `materiales`, `macetas`, `sustratos`, `sustrato_materiales`
+- New domain entities, ports, use cases, DTOs following foundation patterns
+- New Hono route groups: `/materiales`, `/macetas`, `/sustratos`
+- SvelteKit pages for each CRUD
+
+## Capabilities
+
+### New Capabilities
+- `green-beard-material-crud`: Material entity CRUD — manage substrate raw materials with per-liter pricing
+- `green-beard-maceta-crud`: Maceta entity CRUD — manage pots with dimensions, material enum, cost+margin pricing
+- `green-beard-sustrato-crud`: Sustrato entity CRUD — manage substrates with N:M material composition, dynamic cost calculation, margin pricing
+
+### Modified Capabilities
+<!-- None -->
+
+## Impact
+
+- **New tables**: `materiales`, `macetas`, `sustratos`, `sustrato_materiales` (junction)
+- **New routes**: 3 route groups in green-beard-api
+- **New pages**: 3 CRUD sections in SvelteKit app
+- **Domain complexity**: Sustrato introduces computed aggregates (cost from related materials) — first entity with derived pricing
+- **Enum**: MacetaMaterial value object (terracota, plastico, ceramica, fibra_coco, tela)

--- a/openspec/changes/green-beard-supplies/specs/green-beard-maceta-crud/spec.md
+++ b/openspec/changes/green-beard-supplies/specs/green-beard-maceta-crud/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: MacetaMaterial value object
+
+The system SHALL define a `MacetaMaterial` type as a string union: `"terracota" | "plastico" | "ceramica" | "fibra_coco" | "tela"`. A validation function SHALL verify input is one of the allowed values.
+
+#### Scenario: Valid material
+- **WHEN** "terracota" is validated as MacetaMaterial
+- **THEN** it is accepted
+
+#### Scenario: Invalid material
+- **WHEN** "madera" is validated as MacetaMaterial
+- **THEN** a ValidationError is returned
+
+### Requirement: Maceta entity
+
+The system SHALL model Maceta as a domain entity with: id (UUID), nombre (string, non-empty), material (MacetaMaterial), diametroCm (number, positive), altoCm (number, positive), volumenLitros (number, positive), coste (number, positive), margen (number, 0-1 inclusive). Private constructor with `create()`, `reconstitute()`, `update()`.
+
+PVP is a computed getter: `coste × (1 + margen)`, rounded to 2 decimals. NOT stored.
+
+#### Scenario: Create valid maceta
+- **WHEN** `Maceta.create({ nombre: "Maceta 15cm", material: "terracota", diametroCm: 15, altoCm: 12, volumenLitros: 1.5, coste: 3.00, margen: 0.30 })` is called
+- **THEN** it returns `Ok<Maceta>` with pvp = 3.90
+
+#### Scenario: Margen out of range
+- **WHEN** `Maceta.create()` is called with margen = 1.5
+- **THEN** it returns `Err<ValidationError>` (margen must be 0-1)
+
+#### Scenario: Negative dimensions
+- **WHEN** `Maceta.create()` is called with diametroCm = -5
+- **THEN** it returns `Err<ValidationError>`
+
+### Requirement: MacetaRepository port
+
+The system SHALL define a `MacetaRepository` interface with `ResultAsync` methods: `save`, `findById`, `findAll` (ordered by nombre), `update`, `delete`, `existsByNombre`.
+
+#### Scenario: Find all macetas
+- **WHEN** `findAll()` is called
+- **THEN** it returns `Ok<Maceta[]>` ordered by nombre
+
+### Requirement: Maceta CRUD use cases
+
+The system SHALL provide injectable use cases: `CreateMacetaUseCase` (validates nombre uniqueness), `GetMacetasUseCase`, `GetMacetaByIdUseCase`, `UpdateMacetaUseCase`, `DeleteMacetaUseCase`.
+
+#### Scenario: Create maceta with duplicate nombre
+- **WHEN** `CreateMacetaUseCase` is executed with an existing nombre
+- **THEN** it returns `Err<DuplicateError>`
+
+### Requirement: Drizzle macetas table
+
+The system SHALL define a `macetas` table: `id` (UUID PK), `nombre` (VARCHAR 100, NOT NULL, UNIQUE), `material` (VARCHAR 20, NOT NULL), `diametro_cm` (NUMERIC(10,2), NOT NULL), `alto_cm` (NUMERIC(10,2), NOT NULL), `volumen_litros` (NUMERIC(10,2), NOT NULL), `coste` (NUMERIC(10,2), NOT NULL), `margen` (NUMERIC(5,2), NOT NULL).
+
+#### Scenario: Table schema correct
+- **WHEN** macetas table is inspected
+- **THEN** it has the specified columns with correct types
+
+### Requirement: Maceta DTOs
+
+The system SHALL define: `MacetaDto` (`{ id, nombre, material, diametroCm, altoCm, volumenLitros, coste, margen, pvp }`). Note: `pvp` is computed and included in the DTO. `CreateMacetaRequest`, `UpdateMacetaRequest`.
+
+#### Scenario: DTO includes computed pvp
+- **WHEN** API returns a maceta with coste=3.00, margen=0.30
+- **THEN** the DTO includes pvp=3.90
+
+### Requirement: Maceta API routes
+
+The system SHALL expose: `GET /macetas`, `POST /macetas`, `PATCH /macetas/:id`, `DELETE /macetas/:id`.
+
+#### Scenario: Create maceta via API
+- **WHEN** `POST /macetas` with valid body
+- **THEN** returns 201 with MacetaDto including computed pvp

--- a/openspec/changes/green-beard-supplies/specs/green-beard-maceta-crud/spec.md
+++ b/openspec/changes/green-beard-supplies/specs/green-beard-maceta-crud/spec.md
@@ -64,7 +64,7 @@ The system SHALL define: `MacetaDto` (`{ id, nombre, material, diametroCm, altoC
 
 ### Requirement: Maceta API routes
 
-The system SHALL expose: `GET /macetas`, `POST /macetas`, `PATCH /macetas/:id`, `DELETE /macetas/:id`.
+The system SHALL expose: `GET /macetas`, `GET /macetas/:id`, `POST /macetas`, `PATCH /macetas/:id`, `DELETE /macetas/:id`.
 
 #### Scenario: Create maceta via API
 - **WHEN** `POST /macetas` with valid body

--- a/openspec/changes/green-beard-supplies/specs/green-beard-material-crud/spec.md
+++ b/openspec/changes/green-beard-supplies/specs/green-beard-material-crud/spec.md
@@ -56,7 +56,7 @@ The system SHALL define in `green-beard-shared`: `MaterialDto` (`{ id, nombre, p
 
 ### Requirement: Material API routes
 
-The system SHALL expose: `GET /materiales`, `POST /materiales`, `PATCH /materiales/:id`, `DELETE /materiales/:id`.
+The system SHALL expose: `GET /materiales`, `GET /materiales/:id`, `POST /materiales`, `PATCH /materiales/:id`, `DELETE /materiales/:id`.
 
 #### Scenario: Create material via API
 - **WHEN** `POST /materiales` with `{ "nombre": "Perlita", "precioLitro": 2.50 }`

--- a/openspec/changes/green-beard-supplies/specs/green-beard-material-crud/spec.md
+++ b/openspec/changes/green-beard-supplies/specs/green-beard-material-crud/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: Material entity
+
+The system SHALL model Material as a domain entity in `green-beard-domain` with: id (UUID), nombre (string, non-empty, trimmed), precioLitro (number, positive). Private constructor with `static create()` returning `Result<Material, ValidationError>` and `static reconstitute()`.
+
+#### Scenario: Create valid material
+- **WHEN** `Material.create({ nombre: "Perlita", precioLitro: 2.50 })` is called
+- **THEN** it returns `Ok<Material>` with trimmed nombre and precioLitro
+
+#### Scenario: Create material with zero price
+- **WHEN** `Material.create({ nombre: "Perlita", precioLitro: 0 })` is called
+- **THEN** it returns `Err<ValidationError>` (price must be positive)
+
+#### Scenario: Create material with negative price
+- **WHEN** `Material.create({ nombre: "Perlita", precioLitro: -1 })` is called
+- **THEN** it returns `Err<ValidationError>`
+
+### Requirement: MaterialRepository port
+
+The system SHALL define a `MaterialRepository` interface with `ResultAsync` methods: `save`, `findById`, `findAll` (ordered by nombre), `findByIds(ids[])`, `update`, `delete`, `existsByNombre`.
+
+#### Scenario: Find materials by IDs
+- **WHEN** `findByIds(["id1", "id2"])` is called
+- **THEN** it returns `Ok<Material[]>` containing only the matching materials
+
+### Requirement: Material CRUD use cases
+
+The system SHALL provide injectable use cases: `CreateMaterialUseCase` (validates nombre uniqueness), `GetMaterialesUseCase`, `GetMaterialByIdUseCase`, `UpdateMaterialUseCase`, `DeleteMaterialUseCase`.
+
+`DeleteMaterialUseCase` SHALL check if the material is used by any sustrato and return `DomainError` if so.
+
+#### Scenario: Delete material used by sustrato
+- **WHEN** `DeleteMaterialUseCase` is executed for a material referenced in sustrato_materiales
+- **THEN** it returns an error indicating the material is in use
+
+#### Scenario: Create material with duplicate nombre
+- **WHEN** `CreateMaterialUseCase` is executed with an existing nombre
+- **THEN** it returns `Err<DuplicateError>`
+
+### Requirement: Drizzle materiales table
+
+The system SHALL define a `materiales` table: `id` (UUID PK, default random), `nombre` (VARCHAR 100, NOT NULL, UNIQUE), `precio_litro` (NUMERIC(10,2), NOT NULL).
+
+#### Scenario: Unique nombre constraint
+- **WHEN** two materials with the same nombre are inserted
+- **THEN** the database rejects the second insert
+
+### Requirement: Material DTOs
+
+The system SHALL define in `green-beard-shared`: `MaterialDto` (`{ id, nombre, precioLitro }`), `CreateMaterialRequest` (`{ nombre, precioLitro }`), `UpdateMaterialRequest` (`{ nombre?, precioLitro? }`).
+
+#### Scenario: DTO precioLitro is a number
+- **WHEN** API returns a material
+- **THEN** precioLitro is a number, not a string
+
+### Requirement: Material API routes
+
+The system SHALL expose: `GET /materiales`, `POST /materiales`, `PATCH /materiales/:id`, `DELETE /materiales/:id`.
+
+#### Scenario: Create material via API
+- **WHEN** `POST /materiales` with `{ "nombre": "Perlita", "precioLitro": 2.50 }`
+- **THEN** returns 201 with MaterialDto
+
+#### Scenario: Delete material in use
+- **WHEN** `DELETE /materiales/:id` for a material used by a sustrato
+- **THEN** returns 409 with error DTO

--- a/openspec/changes/green-beard-supplies/specs/green-beard-sustrato-crud/spec.md
+++ b/openspec/changes/green-beard-supplies/specs/green-beard-sustrato-crud/spec.md
@@ -1,0 +1,102 @@
+## ADDED Requirements
+
+### Requirement: Sustrato entity
+
+The system SHALL model Sustrato as a domain entity with: id (UUID), nombre (string, non-empty), margen (number, 0-1), materiales (array of `{ materialId: string, litros: number }`). Private constructor with `create()`, `reconstitute()`, `update()`.
+
+`create()` SHALL validate: non-empty nombre, margen 0-1, at least one material, all litros positive.
+
+Coste and PVP are NOT stored — they are computed at the API/DTO layer where material prices are available.
+
+#### Scenario: Create valid sustrato
+- **WHEN** `Sustrato.create({ nombre: "Tropical Mix", margen: 0.25, materiales: [{ materialId: "...", litros: 2.5 }] })` is called
+- **THEN** it returns `Ok<Sustrato>`
+
+#### Scenario: Create sustrato without materiales
+- **WHEN** `Sustrato.create()` is called with empty materiales array
+- **THEN** it returns `Err<ValidationError>`
+
+#### Scenario: Create sustrato with zero litros
+- **WHEN** a material entry has litros = 0
+- **THEN** it returns `Err<ValidationError>`
+
+#### Scenario: Margen out of range
+- **WHEN** `Sustrato.create()` is called with margen = -0.1
+- **THEN** it returns `Err<ValidationError>`
+
+### Requirement: SustratoRepository port
+
+The system SHALL define a `SustratoRepository` interface with `ResultAsync` methods:
+- `save(sustrato)`: persists sustrato + sustrato_materiales rows
+- `findById(id)`: returns sustrato with its materiales composition
+- `findAll()`: returns all sustratos with materiales, ordered by nombre
+- `update(sustrato)`: replaces sustrato + sustrato_materiales atomically
+- `delete(id)`: deletes sustrato + cascade sustrato_materiales
+- `existsByNombre(nombre)`: checks uniqueness
+- `existsMaterialUsage(materialId)`: checks if a material is used by any sustrato
+
+#### Scenario: Save persists junction rows
+- **WHEN** `save()` is called with a sustrato having 3 materials
+- **THEN** 1 row in sustratos + 3 rows in sustrato_materiales are persisted
+
+#### Scenario: Update replaces junction rows
+- **WHEN** `update()` is called changing materials from [A, B] to [B, C]
+- **THEN** sustrato_materiales for this sustrato contains only B and C
+
+### Requirement: Sustrato CRUD use cases
+
+The system SHALL provide injectable use cases:
+- `CreateSustratoUseCase`: validates nombre uniqueness, validates all materialIds exist (via MaterialRepository.findByIds), persists
+- `GetSustratosUseCase`: returns all sustratos
+- `GetSustratoByIdUseCase`: returns sustrato or NotFoundError
+- `UpdateSustratoUseCase`: validates existence, validates materialIds, atomic update
+- `DeleteSustratoUseCase`: validates existence, deletes
+
+#### Scenario: Create sustrato with non-existent material
+- **WHEN** `CreateSustratoUseCase` is executed with a materialId that doesn't exist
+- **THEN** it returns `Err<NotFoundError>` referencing "Material"
+
+#### Scenario: Create sustrato with duplicate nombre
+- **WHEN** `CreateSustratoUseCase` is executed with an existing nombre
+- **THEN** it returns `Err<DuplicateError>`
+
+### Requirement: Drizzle sustratos and sustrato_materiales tables
+
+The system SHALL define:
+- `sustratos` table: `id` (UUID PK), `nombre` (VARCHAR 100, NOT NULL, UNIQUE), `margen` (NUMERIC(5,2), NOT NULL)
+- `sustrato_materiales` table: `sustrato_id` (UUID, FK→sustratos, ON DELETE CASCADE), `material_id` (UUID, FK→materiales), `litros` (NUMERIC(10,2), NOT NULL). Composite PK: (sustrato_id, material_id)
+
+#### Scenario: Cascade delete
+- **WHEN** a sustrato is deleted
+- **THEN** its sustrato_materiales rows are also deleted
+
+#### Scenario: Composite PK prevents duplicates
+- **WHEN** the same material_id is inserted twice for the same sustrato_id
+- **THEN** the database rejects the second insert
+
+### Requirement: Sustrato DTOs
+
+The system SHALL define:
+- `SustratoMaterialDto`: `{ materialId, materialNombre, litros, costeParcial }` (costeParcial = precioLitro × litros)
+- `SustratoDto`: `{ id, nombre, margen, materiales: SustratoMaterialDto[], coste, pvp }` (coste = Σ costeParcial, pvp = coste × (1 + margen))
+- `SustratoMaterialInput`: `{ materialId, litros }`
+- `CreateSustratoRequest`: `{ nombre, margen, materiales: SustratoMaterialInput[] }`
+- `UpdateSustratoRequest`: `{ nombre?, margen?, materiales?: SustratoMaterialInput[] }`
+
+#### Scenario: DTO includes computed costs
+- **WHEN** API returns a sustrato with materials [Perlita 2L @ 2.50€/L, Turba 3L @ 1.00€/L] and margen=0.25
+- **THEN** coste = 8.00, pvp = 10.00, and each material has its costeParcial
+
+### Requirement: Sustrato API routes
+
+The system SHALL expose: `GET /sustratos`, `GET /sustratos/:id`, `POST /sustratos`, `PATCH /sustratos/:id`, `DELETE /sustratos/:id`.
+
+The GET endpoints SHALL return DTOs with computed coste and pvp by joining material prices.
+
+#### Scenario: Create sustrato via API
+- **WHEN** `POST /sustratos` with `{ "nombre": "Tropical", "margen": 0.25, "materiales": [{ "materialId": "...", "litros": 2.5 }] }`
+- **THEN** returns 201 with SustratoDto including computed costs
+
+#### Scenario: Get sustrato includes material details
+- **WHEN** `GET /sustratos/:id`
+- **THEN** response includes materiales array with materialNombre, litros, and costeParcial for each

--- a/openspec/changes/green-beard-supplies/tasks.md
+++ b/openspec/changes/green-beard-supplies/tasks.md
@@ -1,0 +1,69 @@
+## 1. Domain entities and ports
+
+- [ ] 1.1 Create `MacetaMaterial` value object (string union + validation function)
+- [ ] 1.2 Create `Material` entity — create(), reconstitute(), update(), precioLitro validation (positive)
+- [ ] 1.3 Create `MaterialRepository` port (includes `findByIds`, `existsByNombre`)
+- [ ] 1.4 Create `Maceta` entity — create(), reconstitute(), update(), margen validation (0-1), computed `pvp` getter
+- [ ] 1.5 Create `MacetaRepository` port
+- [ ] 1.6 Create `Sustrato` entity — create(), reconstitute(), update(), materiales array validation (non-empty, positive litros)
+- [ ] 1.7 Create `SustratoRepository` port (includes `existsMaterialUsage`, atomic save/update with junction rows)
+- [ ] 1.8 Add new error types if needed (e.g., `MaterialInUseError`)
+- [ ] 1.9 Add new tokens to `tokens.ts` for all new repos and use cases
+
+## 2. Domain use cases
+
+- [ ] 2.1 Create Material use cases: Create, GetAll, GetById, Update, Delete (delete checks sustrato usage)
+- [ ] 2.2 Create Maceta use cases: Create, GetAll, GetById, Update, Delete
+- [ ] 2.3 Create Sustrato use cases: Create (validates materialIds via MaterialRepository.findByIds), GetAll, GetById, Update (atomic), Delete
+- [ ] 2.4 Update `domainModule` ContainerModule with all new bindings
+- [ ] 2.5 Write unit tests for Material entity (validation, create, update)
+- [ ] 2.6 Write unit tests for Maceta entity (pvp computation, margen bounds)
+- [ ] 2.7 Write unit tests for Sustrato entity (materiales validation)
+- [ ] 2.8 Write unit tests for key use cases (delete material in use, create sustrato with invalid materialId)
+- [ ] 2.9 Verify `pnpm nx run @m0n0lab/green-beard-domain:test:unit` passes
+
+## 3. Shared DTOs
+
+- [ ] 3.1 Create `MaterialDto`, `CreateMaterialRequest`, `UpdateMaterialRequest`
+- [ ] 3.2 Create `MacetaDto` (includes pvp), `CreateMacetaRequest`, `UpdateMacetaRequest`
+- [ ] 3.3 Create `SustratoDto`, `SustratoMaterialDto`, `SustratoMaterialInput`, `CreateSustratoRequest`, `UpdateSustratoRequest`
+- [ ] 3.4 Verify `pnpm nx run @m0n0lab/green-beard-shared:build` succeeds
+
+## 4. Data layer
+
+- [ ] 4.1 Create `materiales` Drizzle schema — id, nombre (UNIQUE), precio_litro NUMERIC(10,2)
+- [ ] 4.2 Create `macetas` Drizzle schema — id, nombre (UNIQUE), material VARCHAR, diametro_cm, alto_cm, volumen_litros, coste, margen — all NUMERIC(10,2)
+- [ ] 4.3 Create `sustratos` Drizzle schema — id, nombre (UNIQUE), margen NUMERIC(5,2)
+- [ ] 4.4 Create `sustrato_materiales` schema — composite PK (sustrato_id, material_id), litros NUMERIC(10,2), FK with ON DELETE CASCADE on sustrato_id
+- [ ] 4.5 Generate migration via `pnpm nx run @m0n0lab/green-beard-data:db:generate`
+- [ ] 4.6 Create Material mapper (toDomain/toRow — parse NUMERIC strings to numbers)
+- [ ] 4.7 Create Maceta mapper
+- [ ] 4.8 Create Sustrato mapper (includes junction table handling)
+- [ ] 4.9 Create `PgMaterialRepository` (includes `findByIds` with `inArray`)
+- [ ] 4.10 Create `PgMacetaRepository`
+- [ ] 4.11 Create `PgSustratoRepository` — save/update atomically manage sustrato_materiales (delete+insert in transaction)
+- [ ] 4.12 Update `dataModule` with new repository bindings
+- [ ] 4.13 Verify `pnpm nx run @m0n0lab/green-beard-data:build` succeeds
+
+## 5. API layer
+
+- [ ] 5.1 Add error mapping for new error types (MaterialInUseError → 409)
+- [ ] 5.2 Create DTO serializers (toMaterialDto, toMacetaDto — includes pvp, toSustratoDto — includes computed costs from material prices)
+- [ ] 5.3 Create `materialRoutes(container)` — GET /, POST /, PATCH /:id, DELETE /:id
+- [ ] 5.4 Create `macetaRoutes(container)` — GET /, POST /, PATCH /:id, DELETE /:id
+- [ ] 5.5 Create `sustratoRoutes(container)` — GET /, GET /:id, POST /, PATCH /:id, DELETE /:id. GET endpoints join material prices for computed fields
+- [ ] 5.6 Register new routes in app.ts
+- [ ] 5.7 Verify `pnpm nx run @m0n0lab/green-beard-api:dev` — new endpoints respond
+
+## 6. SvelteKit BFF pages
+
+- [ ] 6.1 Create Material pages: list, create form, edit form, delete action
+- [ ] 6.2 Create Maceta pages: list (showing pvp), create form (material enum select), edit form, delete action
+- [ ] 6.3 Create Sustrato pages: list (showing coste+pvp), create/edit form with dynamic material rows (add/remove material + litros), delete action
+- [ ] 6.4 Verify full flow: create materials → create maceta → create sustrato with materials → verify computed costs
+
+## 7. Verification
+
+- [ ] 7.1 `pnpm nx run-many -t build` — all projects build
+- [ ] 7.2 `pnpm nx run @m0n0lab/green-beard-domain:test:unit` — all tests pass
+- [ ] 7.3 Manual E2E: material CRUD → maceta CRUD → sustrato CRUD with computed prices

--- a/openspec/changes/green-beard-supplies/tasks.md
+++ b/openspec/changes/green-beard-supplies/tasks.md
@@ -32,7 +32,7 @@
 ## 4. Data layer
 
 - [ ] 4.1 Create `materiales` Drizzle schema — id, nombre (UNIQUE), precio_litro NUMERIC(10,2)
-- [ ] 4.2 Create `macetas` Drizzle schema — id, nombre (UNIQUE), material VARCHAR, diametro_cm, alto_cm, volumen_litros, coste, margen — all NUMERIC(10,2)
+- [ ] 4.2 Create `macetas` Drizzle schema — id, nombre (UNIQUE), material VARCHAR, diametro_cm, alto_cm, volumen_litros, coste NUMERIC(10,2), margen NUMERIC(5,2)
 - [ ] 4.3 Create `sustratos` Drizzle schema — id, nombre (UNIQUE), margen NUMERIC(5,2)
 - [ ] 4.4 Create `sustrato_materiales` schema — composite PK (sustrato_id, material_id), litros NUMERIC(10,2), FK with ON DELETE CASCADE on sustrato_id
 - [ ] 4.5 Generate migration via `pnpm nx run @m0n0lab/green-beard-data:db:generate`


### PR DESCRIPTION
## Summary
- Supply entities artifacts (proposal, design, specs, tasks)
- Material CRUD (per-liter pricing)
- Maceta CRUD (enum material, dimensions, cost+margin→pvp)
- Sustrato CRUD (N:M material composition, dynamic cost, margin→pvp)

**Depends on**: `feature/green-beard-foundation`

## Artifacts
- `proposal.md` — scope and capabilities
- `design.md` — 6 decisions (junction table, dynamic cost, decimal handling)
- `specs/green-beard-material-crud/spec.md`
- `specs/green-beard-maceta-crud/spec.md`
- `specs/green-beard-sustrato-crud/spec.md`
- `tasks.md` — 7 task groups, 34 tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added design, proposal, spec and task docs for supply management: Material, Maceta (pots) and Sustrato (substrates).
  * Defined end-to-end CRUD behaviors, REST API expectations and UI flows for each entity.
  * Specified dynamic cost & PVP calculations (composition-based substrate costing and pot pricing), validation rules, and atomic update semantics for substrate compositions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->