### PR TITLE
feat(experiments): monorepo-aware npm-changelog + tagFormat cache

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
         {
             "name": "experiments",
             "source": "./claude-plugins/experiments",
-            "version": "0.6.0",
+            "version": "0.7.0",
             "description": "Beta skills and commands staging area for monolab"
         }
     ]

--- a/claude-plugins/experiments/.claude-plugin/plugin.json
+++ b/claude-plugins/experiments/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "experiments",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "description": "Beta skills and commands staging area for monolab",
     "author": {
         "name": "Pablo F.G.",

--- a/claude-plugins/experiments/README.md
+++ b/claude-plugins/experiments/README.md
@@ -45,6 +45,20 @@ Scan the current project for patch-level npm updates and interactively apply the
 
 Tip: pair with `/experiments:npm-changelog <pkg> <from>..<to>` before accepting if you want to skim the changelog for any listed patch.
 
+### `/experiments:npm-changelog`
+
+Retrieve, cache, and verify changelogs for any npm package across a version range. Caches under `~/.claude/changelogs/` and only re-fetches when SHA256 verification fails or TTL expires — repeated queries are effectively free.
+
+```bash
+/experiments:npm-changelog react 18.0.0..19.0.0
+/experiments:npm-changelog @tanstack/query-core 5.90.0..5.90.20
+/experiments:npm-changelog @angular/core latest
+```
+
+Monorepo-aware: when `repository.directory` is present in npm metadata, the command probes `{directory}/CHANGELOG.md` first, then falls back to the repo root, then to scoped GitHub release tags (`@scope/pkg@{version}`, `{packageBasename}@{version}`, hyphenated variants). The discovered `tagFormat` is cached per-package for subsequent versions.
+
+Authoritative spec: `openspec/specs/npm-changelog-retrieval/spec.md`.
+
 ## Skills
 
 ### `skills-update-check`

--- a/claude-plugins/experiments/commands/npm-changelog.md
+++ b/claude-plugins/experiments/commands/npm-changelog.md
@@ -6,6 +6,8 @@ description: Retrieve, cache, and verify npm package changelogs locally for a ve
 
 Retrieve changelogs for any npm package across a version range. Caches locally at `~/.claude/changelogs/` so repeated queries never re-fetch verified versions. Output is a summary with file paths — never paste changelog content into chat.
 
+> Authoritative spec: `openspec/specs/npm-changelog-retrieval/spec.md` — Strategy A (raw CHANGELOG with monorepo subdirectory cascade) and Strategy B (GitHub Releases with scoped tag-format probe chain and cached `tagFormat` short-circuit).
+
 ## Arguments
 
 **ARGUMENTS variable contains**: `{package} {from}..{to}` (range), `{package} {version}` (single), `{package} latest`, or empty.
@@ -115,6 +117,17 @@ Write/update with:
 }
 ```
 
+`tagFormat` is a templated string once discovered (Strategy B, Step 6). Valid templates:
+
+- `"v{version}"` — v-prefixed (most common)
+- `"{version}"` — bare
+- `"{package}@{version}"` — scoped monorepo (Changesets convention, e.g., `@tanstack/query-core@5.90.20`)
+- `"{packageBasename}@{version}"` — scope-stripped (e.g., `query-core@5.90.20`)
+- `"{package}-v{version}"` — hyphenated variant
+- `"{packageBasename}-v{version}"` — hyphenated + scope-stripped
+
+`changelogFiles` is a union of filenames (repo-root) or path-qualified filenames (e.g., `packages/query-core/CHANGELOG.md`) that returned HTTP 200.
+
 Preserve existing `tagFormat`, `changelogSource`, and `changelogFiles` values if already set — only overwrite with new non-null discoveries. For `changelogFiles`, union new filenames into the existing array.
 
 ### Cache Lookup
@@ -135,16 +148,20 @@ Store the fetch list as `FETCH_VERSIONS`. If `FETCH_VERSIONS` is empty, skip to 
 
 If Strategy A will be used (first attempt), check the raw source cache:
 
-For each known changelog filename in `_meta.json.changelogFiles` (or defaults: `CHANGELOG.md`, `CHANGELOG`, `History.md`, `CHANGES.md` in order):
+For each known changelog entry in `_meta.json.changelogFiles` (or defaults: `CHANGELOG.md`, `CHANGELOG`, `History.md`, `CHANGES.md` in order):
 
-- If `_source/{filename}` exists:
-    - Check file modification time. If **less than 24 hours old**:
-        - Recompute SHA256: `shasum -a 256 "$CACHE_DIR/_source/{filename}" | cut -d' ' -f1`
-        - Compare against `_source/{filename}.sha256`
-        - If match → **reuse** cached raw source (skip re-fetch)
-        - If mismatch or `.sha256` missing → **re-fetch**
-    - If **older than 24 hours** → **re-fetch**
-- If `_source/{filename}` does not exist → **fetch**
+1. Derive the **cache key**:
+    - Root-fetched file → `{filename}` (e.g., `CHANGELOG.md`)
+    - Subdirectory-fetched file (path-qualified, contains `/`) → replace every `/` with `__` (e.g., `packages/query-core/CHANGELOG.md` → `packages__query-core__CHANGELOG.md`)
+2. Look up `_source/{cacheKey}`:
+    - If `_source/{cacheKey}` exists:
+        - Check file modification time. If **less than 24 hours old**:
+            - Recompute SHA256: `shasum -a 256 "$CACHE_DIR/_source/{cacheKey}" | cut -d' ' -f1`
+            - Compare against `_source/{cacheKey}.sha256`
+            - If match → **reuse** cached raw source (skip re-fetch)
+            - If mismatch or `.sha256` missing → **re-fetch**
+        - If **older than 24 hours** → **re-fetch**
+    - If `_source/{cacheKey}` does not exist → **fetch**
 
 ## Step 4: Resolve Default Branch
 
@@ -160,37 +177,59 @@ Store as `DEFAULT_BRANCH`. If this fails, record the error and proceed to Strate
 
 **Goal:** Fetch the raw CHANGELOG from the GitHub repo and parse individual version sections.
 
-### Fetch
+### Fetch — Probe Order
 
-If raw source is not cached (per TTL check), try filenames in order:
+The probe path depends on whether `_meta.json.isMonorepo=true` AND `_meta.json.monorepoDirectory` is non-null.
+
+**Single-repo packages (no `monorepoDirectory`)** — preserve prior behavior, root only:
 
 1. `CHANGELOG.md`
 2. `CHANGELOG`
 3. `History.md`
 4. `CHANGES.md`
 
-For each filename:
+**Monorepo packages (`isMonorepo=true` AND `monorepoDirectory` set)** — subdirectory first, then root fallback:
+
+1. `{MONOREPO_DIR}/CHANGELOG.md`
+2. `{MONOREPO_DIR}/CHANGELOG`
+3. `{MONOREPO_DIR}/History.md`
+4. `{MONOREPO_DIR}/CHANGES.md`
+5. Fall through to root chain for versions not resolved by the subdirectory file:
+    - `CHANGELOG.md` → `CHANGELOG` → `History.md` → `CHANGES.md`
+
+For each candidate path in the applicable chain:
 
 ```bash
 RAW_TMP="$(mktemp)"
-curl -sL --connect-timeout 10 --max-time 30 -w "%{http_code}" -o "$RAW_TMP" "https://raw.githubusercontent.com/{OWNER}/{REPO}/{DEFAULT_BRANCH}/{filename}"
+curl -sL --connect-timeout 10 --max-time 30 -w "%{http_code}" -o "$RAW_TMP" "https://raw.githubusercontent.com/{OWNER}/{REPO}/{DEFAULT_BRANCH}/{path}"
 # Clean up after processing: rm -f "$RAW_TMP"
 ```
 
+Where `{path}` is either `{filename}` (single-repo / root fallback) or `{MONOREPO_DIR}/{filename}` (monorepo subdirectory probe).
+
 Capture both curl exit code and HTTP status:
 
-- If curl exit code != 0 OR HTTP is `000` / `5xx` / non-404 `4xx` → mark Strategy A attempt as `fetch_error` and continue to next strategy (do not finalize version failure yet)
+- If curl exit code != 0 OR HTTP is `000` / `5xx` / non-404 `4xx` → mark Strategy A attempt as `fetch_error` and continue to the next strategy (do not finalize version failure yet)
 - If HTTP `200` → use this file
-- If HTTP `404` → try next filename; if all filenames exhausted → proceed to split-archive check
+- If HTTP `404` → try the next candidate in the chain; if all candidates in the monorepo subdirectory chain return 404, fall through to the root chain; if the root chain also exhausts → proceed to split-archive check
 
-**Always fetch from repo root**, never from a monorepo subdirectory.
+### Cascade Semantics (monorepo only)
+
+The subdirectory file and the root file are **not** mutually exclusive — they cascade **per version**:
+
+1. Parse the subdirectory file (if 200) with the same pattern detection and section extraction rules described below. Versions whose heading is found in the subdirectory file are **resolved** via the subdirectory source.
+2. Versions in `FETCH_VERSIONS` **not** found in the subdirectory file (or when the subdirectory file is entirely absent / all candidates 404) fall through to the root chain.
+3. Parse the root file (if 200) with the same rules. Versions whose heading is found in the root file are **resolved** via the root source.
+4. Versions still unresolved after both the subdirectory and root chains are appended to `STRATEGY_B_VERSIONS` and handled by Step 6.
+
+Rationale: a subdirectory CHANGELOG may omit very old versions that were consolidated into the root CHANGELOG during a repo reorganization. The cascade preserves coverage cheaply (1 extra fetch) before escalating to Strategy B's per-version request cost.
 
 ### Split-Archive Handling
 
-If no standard filename worked, or if the fetched CHANGELOG doesn't contain entries for some requested versions:
+If no standard filename worked at either the subdirectory or root level, or if the fetched CHANGELOGs don't contain entries for some requested versions:
 
-1. **Vue-style splits:** Try `changelogs/CHANGELOG-{major}.{minor}.md` for each relevant major.minor in the version range
-2. **Angular-style archive:** Try `CHANGELOG_ARCHIVE.md`
+1. **Vue-style splits:** Try `changelogs/CHANGELOG-{major}.{minor}.md` (root only) for each relevant major.minor in the version range
+2. **Angular-style archive:** Try `CHANGELOG_ARCHIVE.md` (root only)
 
 Fetch each with the same `curl` pattern.
 
@@ -198,12 +237,22 @@ Fetch each with the same `curl` pattern.
 
 When a raw file is successfully fetched:
 
-1. Save the exact content 1:1 to `$CACHE_DIR/_source/{filename}`
-2. Compute SHA256: `shasum -a 256 "$CACHE_DIR/_source/{filename}" | cut -d' ' -f1`
-3. Save hash to `$CACHE_DIR/_source/{filename}.sha256`
-4. Update `_meta.json`: set `changelogSource` to `"raw_changelog"`, union this successfully fetched `{filename}` into `changelogFiles` (only filenames that returned HTTP 200)
+1. Derive the **cache key**:
+    - Root-fetched file → `{filename}` (e.g., `CHANGELOG.md`)
+    - Subdirectory-fetched file → `{MONOREPO_DIR}/{filename}` with `/` replaced by `__` (e.g., `packages/query-core/CHANGELOG.md` → `packages__query-core__CHANGELOG.md`)
+2. Save the exact content 1:1 to `$CACHE_DIR/_source/{cacheKey}`
+3. Compute SHA256: `shasum -a 256 "$CACHE_DIR/_source/{cacheKey}" | cut -d' ' -f1`
+4. Save hash to `$CACHE_DIR/_source/{cacheKey}.sha256`
+5. Update `_meta.json`:
+    - Set `changelogSource` to `"raw_changelog"`
+    - Union the **path-qualified filename** into `changelogFiles`:
+        - Root-fetched → bare filename (e.g., `CHANGELOG.md`)
+        - Subdirectory-fetched → `{MONOREPO_DIR}/{filename}` with forward slashes preserved (e.g., `packages/query-core/CHANGELOG.md`)
+    - Only entries that returned HTTP 200 are unioned
 
 ### Parse — Pattern Detection
+
+Parsing operates identically on subdirectory-fetched and root-fetched raw files — pattern detection, section extraction, and version matching are file-content-driven and make no assumptions about origin path. In the monorepo cascade, parse the subdirectory file first (resolving as many versions as possible), then parse the root file only for the versions still unresolved.
 
 Scan the first 50 lines of the raw changelog. Test these patterns **in priority order** and use the **first match**:
 
@@ -256,33 +305,85 @@ Versions in `FETCH_VERSIONS` not found in the parsed file → add to `STRATEGY_B
 
 - Max **30 requests per batch**
 - **100ms sleep** between each request
-- If more than 30 versions remain, batch in groups of 30
+- **Each tag-format probe counts as one request** — a single version whose first N probes 404 before the (N+1)th 200s consumes N+1 slots from the batch budget
+- If more than 30 requests total are projected, batch in groups of 30
 
-### Fetch Releases
+### Derive `{packageBasename}`
 
-For each version in `STRATEGY_B_VERSIONS`, use `--include` to capture the HTTP status line:
+For scope-stripped tag-format variants, derive the basename from `PKG`:
+
+- **Scoped** (`@scope/name`) → `{packageBasename}` = `name` (e.g., `@tanstack/query-core` → `query-core`)
+- **Unscoped** (`name`) → `{packageBasename}` equals `PKG`; scope-stripped probes are **skipped** because they duplicate the non-stripped form
+
+### Cached-Format Short-Circuit
+
+On entry to Strategy B, read `_meta.json.tagFormat`. If set (non-null), resolve the template against the current version's context to produce the first probe URL:
+
+| Template                         | Resolves to (example for `@tanstack/query-core@5.90.20`) |
+| -------------------------------- | -------------------------------------------------------- |
+| `"v{version}"`                   | `v5.90.20`                                               |
+| `"{version}"`                    | `5.90.20`                                                |
+| `"{package}@{version}"`          | `@tanstack/query-core@5.90.20`                           |
+| `"{packageBasename}@{version}"`  | `query-core@5.90.20`                                     |
+| `"{package}-v{version}"`         | `@tanstack/query-core-v5.90.20`                          |
+| `"{packageBasename}-v{version}"` | `query-core-v5.90.20`                                    |
+
+Probe that URL first:
 
 ```bash
-gh api --include /repos/{OWNER}/{REPO}/releases/tags/v{ver}
+gh api --include /repos/{OWNER}/{REPO}/releases/tags/{RESOLVED_TAG}
 ```
 
-The response contains HTTP headers, then a blank line, then the JSON body. Parse the first line for HTTP status code, then extract the JSON body (everything after the first blank line):
+- HTTP **2xx** with non-empty `body` → success (skip the standard chain, skip the `_meta.json` write — value is unchanged)
+- HTTP **404** → fall through **silently** to the standard probe chain below. **Do NOT invalidate `_meta.json.tagFormat`** — a stale hint costs at most one 100ms request per invocation and avoids churn on transient misses.
 
-- If HTTP **2xx** and valid JSON body after header separator → success (use `body` field from JSON)
-- If HTTP **404** → retry without `v` prefix:
+### Standard Probe Chain
 
-    ```bash
-    gh api --include /repos/{OWNER}/{REPO}/releases/tags/{ver}
-    ```
+If `tagFormat` is null, or the cached-format probe missed, probe tag formats in this order and stop at the first success:
 
-- If **other error** (rate limit 403/429, 5xx, network failure) → mark `fetch_error` (retryable)
+1. `v{version}`
+2. `{version}` (no prefix)
+3. **Monorepo only** (`_meta.json.isMonorepo=true`) — continue with scoped variants:
+    - `{PKG}@{version}` — e.g., `@tanstack/query-core@5.90.20` (Changesets convention — most common)
+    - `{PKG-basename}@{version}` — e.g., `query-core@5.90.20` (Lerna-style scope-stripped; **skipped for unscoped packages**)
+    - `{PKG}-v{version}` — hyphenated variant
+    - `{PKG-basename}-v{version}` — hyphenated + scope-stripped (**skipped for unscoped packages**)
 
-- On first successful tag format, update `_meta.json.tagFormat` (e.g., `"v{version}"` or `"{version}"`)
-- Sleep 100ms between requests:
+For each probe:
 
-    ```bash
-    sleep 0.1
-    ```
+```bash
+gh api --include /repos/{OWNER}/{REPO}/releases/tags/{TAG}
+```
+
+The response contains HTTP headers, then a blank line, then the JSON body. Parse the first line for HTTP status code, then extract the JSON body:
+
+- HTTP **2xx** with valid JSON body → success (use `body` field from JSON); stop probing this version
+- HTTP **404** → try the next format in the chain
+- **Other error** (rate limit 403/429, 5xx, network failure) → mark `fetch_error` (retryable); stop probing this version
+
+Sleep 100ms between every request (including between probes for the same version):
+
+```bash
+sleep 0.1
+```
+
+### Persist `tagFormat`
+
+On first successful probe (cached-format or standard-chain), determine the **template string** that produced the hit:
+
+| Successful tag matches      | Templated form                   |
+| --------------------------- | -------------------------------- |
+| `v{version}`                | `"v{version}"`                   |
+| `{version}`                 | `"{version}"`                    |
+| `{PKG}@{version}`           | `"{package}@{version}"`          |
+| `{PKG-basename}@{version}`  | `"{packageBasename}@{version}"`  |
+| `{PKG}-v{version}`          | `"{package}-v{version}"`         |
+| `{PKG-basename}-v{version}` | `"{packageBasename}-v{version}"` |
+
+Persist to `_meta.json.tagFormat` **only if** the new template differs from the currently cached value:
+
+- Cached value is `null` or a different template → write the new template
+- Cached value equals the new template (steady state) → **skip the write** to avoid `_meta.json` churn
 
 ### Body Extraction
 
@@ -292,6 +393,8 @@ From the JSON response, extract the `body` field.
 - If `body` is empty or null → add version to `STRATEGY_C_VERSIONS` with note `empty_release_body`
 
 ## Step 7: Strategy C — CDN Fallback
+
+Strategy C fetches from unpkg by **published package identity** (`{PKG}@{ver}`), which is already implicitly monorepo-aware — unpkg serves each subpackage of a monorepo under its own npm coordinates, so no subdirectory-aware branching is needed here.
 
 For each version in `STRATEGY_C_VERSIONS`:
 

--- a/claude-plugins/experiments/package.json
+++ b/claude-plugins/experiments/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@m0n0lab/plugin-experiments",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "private": true,
     "description": "Beta skills and commands staging area for monolab"
 }

--- a/openspec/changes/add-npm-changelog-monorepo-support/.openspec.yaml
+++ b/openspec/changes/add-npm-changelog-monorepo-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-20

--- a/openspec/changes/add-npm-changelog-monorepo-support/design.md
+++ b/openspec/changes/add-npm-changelog-monorepo-support/design.md
@@ -1,0 +1,120 @@
+## Context
+
+The archived `2026-04-12-npm-changelog-skill` change, in decision **D8 Monorepo handling**, made an empirical generalization based on a 4-monorepo sample (Angular, Babel, React, Vue): *"All major monorepos keep a single root CHANGELOG (never per-package)."* That generalization drove the rule *"always fetch from repo root, never from a monorepo subdirectory."*
+
+A 136-fetch batch across 38 npm packages surfaced a counter-sample of 9 packages failing with `failReason: "no_changelog_source"`. Reproducible verification against those 9 (see **Evidence** below) reveals two distinct monorepo families the original design did not distinguish:
+
+- **Aggregator-family** (Angular, Babel, React, Vue): root `CHANGELOG.md` contains entries grouped by module. The original rule fits this family.
+- **Per-package family** (TanStack Query, Vitejs, Microsoft TSDoc): no root `CHANGELOG.md`, or a root one that does not list the published package's versions. Changelog lives at `{repository.directory}/CHANGELOG.md`. Releases tagged as `@scope/pkg@{ver}` (Changesets/Lerna convention), not `v{ver}`.
+
+The original rule is not wrong — it is incomplete. It needs to branch on family. Detection is already possible: the `repository.directory` field from `npm view {pkg} repository --json` is already captured into `_meta.json.monorepoDirectory`, but never read.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Resolve changelogs for per-package-family monorepos that advertise `repository.directory` in their npm metadata and host their changelog at the subdirectory.
+- Resolve changelogs for monorepos using scoped release-tag formats (`@scope/pkg@{ver}` and variants).
+- Preserve existing behavior for single-repo packages and aggregator-family monorepos.
+- Close the feedback loop on `_meta.json.tagFormat`: write it *and* read it.
+
+**Non-Goals:**
+- Detecting monorepos via heuristics when `repository.directory` is absent (e.g., `@ant-design/icons` publishes from a monorepo but does not expose `directory` — see **Evidence**). Out of scope for this iteration.
+- Supporting non-GitHub hosts.
+- Diagnosing orthogonal Strategy B regressions surfaced during verification (e.g., `vite-tsconfig-paths` has a populated `v5.1.4` release body yet appeared in the failure batch — separate issue).
+- Per-package filtering of aggregator-family CHANGELOG sections. Original D8 non-goal preserved.
+
+## Decisions
+
+### D1: Reformulate original D8 rather than contradict it
+
+**Choice:** The spec for `npm-changelog-retrieval` MODIFIES the Strategy A requirement. The new rule is *"for monorepos (i.e., `repository.directory` present), try the subdirectory chain first; fall back to the repo root chain; for single repos, root only."* Aggregator-family monorepos (which have a root `CHANGELOG.md`) continue to resolve via the root fallback — their behavior is unchanged in practice, only the order of probes differs.
+
+**Why:** The original rule was based on a partial sample. We are not rejecting its intent; we are extending its scope. Framing this as a reformulation (not a reversal) preserves the logic of the archived design and keeps the rationale discoverable.
+
+**Alternative considered:** Branch by monorepo family (root vs subdir). Rejected — the skill has no way to classify the family without a probe, so "try subdir first with root fallback" is operationally equivalent and simpler.
+
+### D2: Strategy A+ uses subdir-then-root cascade, per-version
+
+**Choice:** When `isMonorepo` and `monorepoDirectory` are set:
+1. Probe the filename chain (`CHANGELOG.md` → `CHANGELOG` → `History.md` → `CHANGES.md`) at `{MONOREPO_DIR}/` first.
+2. For versions not parsed from the subdir file (or if the subdir file is absent), fall through to the root chain.
+3. Union the filenames that returned 200 into `_meta.json.changelogFiles`, keyed to their full path when subdir.
+
+**Why cascade, not strict subdir-only:** A subdirectory CHANGELOG in a per-package monorepo may omit very old versions that were consolidated into the root CHANGELOG during a repo reorganization. Strategy B is more expensive (N requests vs 1 fetch). Trying the already-available root fallback is cheap and strictly increases coverage.
+
+**Alternative considered:** Strict subdir-only on detection. Rejected — unnecessary regression for packages that legitimately have both a subdir file for recent history and a root file for archived history.
+
+### D3: Strategy B+ scoped-tag chain for monorepos
+
+**Choice:** For monorepo packages where `v{ver}` and `{ver}` both 404, try additional tag formats in order:
+1. `{PKG}@{ver}` — full package name including scope (e.g., `@tanstack/query-core@5.90.20`). Verified working against TanStack Query: `gh api /repos/TanStack/query/releases/tags/@tanstack/query-core@5.90.20` returns a 176-byte body. **First probe because Changesets (the most common scoped-monorepo release tool) emits this format.**
+2. `{PKG-basename}@{ver}` — scope stripped (e.g., `query-core@5.90.20`). Covers Lerna-style per-package tags without scope prefix. For unscoped packages, identical to `{PKG}@{ver}` — skip to avoid a redundant probe.
+3. `{PKG}-v{ver}` — hyphenated variant used by some Changesets configurations.
+4. `{PKG-basename}-v{ver}` — scope-stripped hyphenated variant. Skip for unscoped packages.
+
+**Why this order:** Empirical — Changesets is the dominant release tool for scoped npm monorepos in 2024–2026. The hyphenated variants are long-tail fallbacks observed in a few older Lerna repos.
+
+**Alternative considered:** Probe all four unconditionally. Rejected — doubles worst-case request count for all-version batches. The cached `tagFormat` short-circuit (D4) mitigates this after the first success.
+
+### D4: Short-circuit via cached `tagFormat` with silent fallthrough
+
+**Choice:** Strategy B reads `_meta.json.tagFormat` on entry. If set, probe that format first. On miss, silently fall through the full probe chain (`v{ver}` → `{ver}` → [if monorepo] scoped variants). Update `tagFormat` only if a *different* format succeeds.
+
+**Templated form:** Persist `tagFormat` as a self-describing template string:
+- `"v{version}"` — v-prefixed
+- `"{version}"` — bare
+- `"{package}@{version}"` — scoped
+- `"{packageBasename}@{version}"` — scope-stripped
+- `"{package}-v{version}"`, `"{packageBasename}-v{version}"` — hyphenated
+
+**Why fallthrough (not invalidate):** A stale `tagFormat` means at most one wasted 100ms request per invocation — cheaper than invalidating and re-probing every format from scratch. In the steady state (most versions share a format within a package's lifetime), the cached hint is a near-free optimization.
+
+**Why update only on different format:** Avoids `_meta.json` churn. Writing the same value back on every hit is wasted I/O.
+
+**Alternative considered:** Invalidate `tagFormat` on miss. Rejected — generates churn on edge cases (e.g., one odd version), and the skill already treats cache misses as cheap. No user-visible benefit.
+
+### D5: `repository.directory` is the monorepo contract
+
+**Choice:** The subdir probing logic fires only when `_meta.json.isMonorepo=true` AND `_meta.json.monorepoDirectory` is non-null. Those fields are populated from `npm view {pkg} repository.directory`. If the field is absent, the package is treated as single-repo regardless of whether the underlying GitHub repository is physically a monorepo.
+
+**Why explicit:** The alternative is heuristic detection (e.g., GitHub API listing of `packages/` at repo root, fuzzy-match against package name). That is a substantially larger scope, introduces API-cost and false-positive risk, and is not necessary for the target cohort. The fixable failures all advertise `directory` correctly.
+
+**Known limitation:** Packages that are physically in a monorepo but omit `directory` from their published `package.json` (verified case: `@ant-design/icons` — published from `ant-design/ant-design-icons` at `packages/icons-react/` but ships no `repository.directory` in npm metadata) will continue to fail. This is correct behavior under the contract. A future iteration may add heuristic detection.
+
+### D6: Subdir raw-source cache key includes path
+
+**Choice:** When Strategy A+ stores a successfully fetched subdir file, the `_source/` filename encodes the path: e.g., `_source/packages__query-core__CHANGELOG.md` (path separators replaced with `__`). `.sha256` sidecar follows the same key.
+
+**Why:** A monorepo could conceivably have a `CHANGELOG.md` both at root and at `{dir}/`. Treating them as the same cache entry would corrupt TTL and verification. Encoding the path in the key avoids collision while keeping all raw sources under `_source/`.
+
+## Evidence
+
+Verified 2026-04-20 against the 9 failure-batch packages:
+
+| Package | `repository.directory` | Subdir CHANGELOG.md | Scoped release tag (sample) | Resolved by this change |
+|---|---|---|---|---|
+| `@tanstack/query-core` | `packages/query-core` | 200 OK | `@tanstack/query-core@5.90.20` → body 176 bytes | ✅ |
+| `@tanstack/eslint-plugin-query` | `packages/eslint-plugin-query` | 200 OK | (same tagging convention) | ✅ |
+| `@vitejs/plugin-react-swc` | `packages/plugin-react-swc` | 200 OK | — | ✅ |
+| `eslint-plugin-tsdoc` | `eslint-plugin` | 200 OK | — | ✅ |
+| `@types/node` | (DefinitelyTyped) | — | — | ❌ Out of scope (structural) |
+| `@types/react` | (DefinitelyTyped) | — | — | ❌ Out of scope (structural) |
+| `i18next-resources-for-ts` | *absent* | N/A (single-repo) | No releases with body | ❌ Out of scope (no changelog source anywhere) |
+| `vite-tsconfig-paths` | *absent* | N/A (single-repo) | `v5.1.4` → body 97 bytes | ⚠️ Should already resolve via current Strategy B; needs orthogonal investigation |
+| `@ant-design/icons` | *absent* | — (no per-package file) | No `@ant-design/icons@6.1.1` release | ❌ Out of scope (monorepo without `directory` + no source) |
+
+Commands used for reproduction:
+```bash
+npm view {PKG} repository --json
+curl -sI "https://raw.githubusercontent.com/{OWNER}/{REPO}/{BRANCH}/{MONOREPO_DIR}/CHANGELOG.md"
+gh api "/repos/{OWNER}/{REPO}/releases/tags/{TAG_FORMAT}"
+```
+
+## Risks / Trade-offs
+
+- **[Subdir file may be a partial changelog]** → Cascade fallback to root (D2) covers the gap. If root also lacks the version, Strategy B takes over as today.
+- **[Stale `tagFormat` after repo tagging-convention change]** → Fallthrough on miss (D4) adds at most one 100ms wasted request per invocation. No invalidation needed.
+- **[False positive: monorepo advertises `directory` but changelog is at root]** → Cascade fallback (D2) still finds it at the root chain. One wasted 404 probe at the subdir path.
+- **[Monorepos without `directory` field]** → Documented as a known limitation (D5). `@ant-design/icons` is the verified example. Future heuristic detection is a separate iteration.
+- **[Unscoped packages probing scope-stripped variants]** → Avoided by gating the probe on scope presence (D3).
+- **[Orthogonal Strategy B bug surfaced during verification]** → `vite-tsconfig-paths@5.1.4` has a populated release body that the current skill should already retrieve but did not in the failure batch. This design does not address that case; a separate issue should track it.

--- a/openspec/changes/add-npm-changelog-monorepo-support/proposal.md
+++ b/openspec/changes/add-npm-changelog-monorepo-support/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The `experiments:npm-changelog` command captures monorepo metadata (`repository.directory`) into `_meta.json.monorepoDirectory` but never reads it. Monorepo packages whose changelog lives at `{MONOREPO_DIR}/CHANGELOG.md` or whose releases are tagged with a scoped format (`@scope/pkg@{ver}`, Lerna-style) exhaust all three retrieval strategies and terminate with `failReason: "no_changelog_source"` despite the changelog existing in a predictable location.
+
+Empirical trigger: a 136-fetch batch across 38 packages returned 42 `no_changelog_source` failures concentrated in 9 packages. Verification against those 9 (see `design.md` — **Evidence**) confirms 4 are genuinely fixable by the new logic; the rest have distinct structural causes out of scope.
+
+This also invalidates an assumption that underpinned the original `npm-changelog-skill` design (archived `2026-04-12-npm-changelog-skill/design.md`, **D8 Monorepo handling**): *"All major monorepos keep a single root CHANGELOG (never per-package)."* That generalization was based on a 4-monorepo sample (Angular, Babel, React, Vue) — all aggregator-family. New evidence surfaces a per-package family (TanStack, Vitejs, Microsoft TSDoc) where the root CHANGELOG is absent or does not cover the published package.
+
+## What Changes
+
+- **Strategy A becomes monorepo-aware.** When `_meta.json.isMonorepo=true` and `monorepoDirectory` is set, probe `{MONOREPO_DIR}/{filename}` for the standard filename chain (`CHANGELOG.md` → `CHANGELOG` → `History.md` → `CHANGES.md`) **before** falling back to the repo root. Subdirectory raw-source cache keys include the full path to avoid colliding with a potential root CHANGELOG of the same filename.
+- **Strategy B learns scoped tag formats.** For monorepo packages where `v{ver}` and `{ver}` both 404, probe additional tag formats in order: `{PKG}@{ver}`, `{PKG-basename}@{ver}`, `{PKG}-v{ver}`, `{PKG-basename}-v{ver}`. First hit wins and is persisted to `_meta.json.tagFormat`.
+- **Strategy B reads cached `tagFormat`.** The field is already written after a successful probe but never read back. Strategy B now tries the cached format first; on miss, silently falls through the standard probe chain and only updates `tagFormat` if a different format hits.
+- **`_meta.json.tagFormat` uses templated form** (e.g., `"{package}@{version}"`, `"{packageBasename}@{version}"`, `"v{version}"`, `"{version}"`) so it is self-describing and reusable across versions.
+- **Strategy A fallback semantics for monorepos.** If the subdirectory chain yields no file or the file does not cover some requested versions, fall back to the root chain for the remaining versions before proceeding to Strategy B.
+
+Non-changes (preserved by design):
+- Single-repo packages (no `repository.directory`) continue to fetch from root only. No behavior change.
+- Packages without any discoverable changelog source (DefinitelyTyped `@types/*`, repos with no CHANGELOG and empty release bodies) still terminate with `no_changelog_source`. That is the correct terminal state.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `npm-changelog-retrieval`: Strategy A requirement changes from "always fetch from repo root" to a monorepo-aware subdir-first-with-root-fallback rule. Strategy B requirement extends the tag-format probe chain with scoped formats for monorepos and adds a cached-format short-circuit.
+
+## Impact
+
+- `claude-plugins/experiments/commands/npm-changelog.md` — Steps 5 and 6 rewritten; Step 3 `_meta.json` schema note for `tagFormat` templated values.
+- `openspec/specs/npm-changelog-retrieval/spec.md` — MODIFIED requirements for Strategy A and Strategy B.
+- No change to: caching layout, SHA256 verification flow, version enumeration, Strategy C (unpkg), output summary, or rate limiting.
+- No code (skill is a markdown instruction file). No dependency, lockfile, or build changes.
+- Plugin version bump required (experiments plugin) when this proposal's implementation ships — handled by the implementation change, not this proposal.

--- a/openspec/changes/add-npm-changelog-monorepo-support/specs/npm-changelog-retrieval/spec.md
+++ b/openspec/changes/add-npm-changelog-monorepo-support/specs/npm-changelog-retrieval/spec.md
@@ -1,0 +1,124 @@
+## MODIFIED Requirements
+
+### Requirement: Strategy A — Raw CHANGELOG.md
+
+The skill SHALL attempt to fetch the raw CHANGELOG file from the GitHub repository as the first retrieval strategy.
+
+The skill SHALL try filenames in order: `CHANGELOG.md`, `CHANGELOG`, `History.md`, `CHANGES.md`.
+
+For repos with known split patterns (Vue-style), the skill SHALL also try `changelogs/CHANGELOG-{major}.{minor}.md`.
+
+For repos with archive files (Angular-style), the skill SHALL also try `CHANGELOG_ARCHIVE.md`.
+
+The skill SHALL resolve `{default_branch}` via `gh api /repos/{owner}/{repo}` → `default_branch` field before Strategy A requests. If resolution fails, the version SHALL proceed to Strategy B with failure context recorded.
+
+The skill SHALL fetch via `curl -sL https://raw.githubusercontent.com/{owner}/{repo}/{default_branch}/{path}`.
+
+For monorepo packages (`_meta.json.isMonorepo=true` AND `_meta.json.monorepoDirectory` is non-null), the skill SHALL probe the subdirectory path `{monorepoDirectory}/{filename}` for the full filename chain BEFORE falling back to the repo root. Versions not found at the subdirectory SHALL fall through to the root chain; versions still unresolved SHALL proceed to Strategy B.
+
+For single-repo packages (no `monorepoDirectory`), the skill SHALL fetch from the repo root only, preserving prior behavior.
+
+Successfully fetched subdirectory files SHALL be cached under `_source/` using a key that encodes the full path (path separators replaced with `__`), so a subdirectory file does not collide with a root file of the same name.
+
+#### Scenario: CHANGELOG.md found
+
+- **WHEN** fetching raw CHANGELOG.md for `react` (facebook/react, no `repository.directory`)
+- **THEN** the skill SHALL successfully retrieve the file from the repo root and proceed to parsing
+
+#### Scenario: Filename fallback
+
+- **WHEN** `CHANGELOG.md` returns 404 but `History.md` exists (e.g., Express)
+- **THEN** the skill SHALL use `History.md` as the changelog source
+
+#### Scenario: Vue-style split archives
+
+- **WHEN** `CHANGELOG.md` does not contain entries for the requested version range
+- **THEN** the skill SHALL try `changelogs/CHANGELOG-{major}.{minor}.md` for the relevant minor version
+
+#### Scenario: Monorepo subdirectory fetch
+
+- **WHEN** resolving `@tanstack/query-core` whose `repository.directory` is `packages/query-core`
+- **THEN** the skill SHALL first probe `https://raw.githubusercontent.com/TanStack/query/{branch}/packages/query-core/CHANGELOG.md` and use it when the response is 200
+
+#### Scenario: Monorepo fallback to root
+
+- **WHEN** a monorepo's subdirectory CHANGELOG does not contain entries for all requested versions (e.g., older versions consolidated into the root CHANGELOG)
+- **THEN** the skill SHALL fall through to the repo-root filename chain for the versions still unresolved before proceeding to Strategy B
+
+#### Scenario: Aggregator-family monorepo
+
+- **WHEN** resolving `@angular/core` whose `repository.directory` is `packages/core` but the project maintains a single root `CHANGELOG.md`
+- **THEN** the skill SHALL probe the subdirectory path (which 404s), fall through to the root chain (which 200s), and proceed with the root file
+
+#### Scenario: Subdirectory cache isolation
+
+- **WHEN** a successful subdirectory fetch returns a file named `CHANGELOG.md`
+- **THEN** the skill SHALL store it at `_source/packages__query-core__CHANGELOG.md` (or equivalent path-encoded key) so it does not collide with any root `CHANGELOG.md` cache entry
+
+---
+
+### Requirement: Strategy B — GitHub Releases API
+
+If Strategy A fails or does not cover all requested versions, the skill SHALL fall back to GitHub Releases API.
+
+The skill SHALL use `gh api /repos/{owner}/{repo}/releases/tags/{tag}` to fetch individual releases.
+
+On entry, the skill SHALL read `_meta.json.tagFormat`. If set, the skill SHALL attempt that format first. On miss, the skill SHALL fall through to the standard probe chain below without invalidating the cached value.
+
+The skill SHALL probe tag formats in order, stopping at the first success:
+1. `v{version}`
+2. `{version}` (no prefix)
+3. For monorepo packages (`_meta.json.isMonorepo=true`), also probe: `{package}@{version}`, then `{packageBasename}@{version}` when the package is scoped, then `{package}-v{version}`, then `{packageBasename}-v{version}` when the package is scoped.
+
+On first success, the skill SHALL persist the successful format to `_meta.json.tagFormat` as a templated string (e.g., `"v{version}"`, `"{package}@{version}"`, `"{packageBasename}@{version}"`, `"{package}-v{version}"`, `"{packageBasename}-v{version}"`). The skill SHALL update `tagFormat` only when the successful format differs from the currently cached value, to avoid redundant writes.
+
+For unscoped packages, the scope-stripped variants (`{packageBasename}@{version}`, `{packageBasename}-v{version}`) SHALL be skipped because they are identical to the non-stripped variants.
+
+The skill SHALL extract the `body` field as the changelog content. For Strategy B, the fetched release `body` corresponds to the requested tag/version and SHALL be treated as the final version entry directly — no heading-pattern detection or section extraction is required. If `body` is non-empty, the version is considered retrieved.
+
+The skill SHALL rate-limit requests: max 30 per batch with 100ms delay between requests. Each tag-format probe counts as one request against this budget.
+
+#### Scenario: Release found with v prefix
+
+- **WHEN** fetching release for react v19.0.0
+- **THEN** `gh api /repos/facebook/react/releases/tags/v19.0.0` SHALL return the release body
+
+#### Scenario: Release found without v prefix
+
+- **WHEN** fetching release for nx 22.5.0 and `v22.5.0` returns 404
+- **THEN** the skill SHALL retry with `gh api /repos/nrwl/nx/releases/tags/22.5.0`
+
+#### Scenario: Scoped monorepo release tag
+
+- **WHEN** fetching release for `@tanstack/query-core` version `5.90.20` and both `v5.90.20` and `5.90.20` return 404
+- **THEN** the skill SHALL probe `gh api /repos/TanStack/query/releases/tags/@tanstack/query-core@5.90.20` and use its body on 200
+
+#### Scenario: Scope-stripped fallback
+
+- **WHEN** `{package}@{version}` returns 404 for a scoped monorepo package
+- **THEN** the skill SHALL probe `{packageBasename}@{version}` (e.g., `query-core@5.90.20`) before moving on to hyphenated variants
+
+#### Scenario: tagFormat cache short-circuit
+
+- **WHEN** `_meta.json.tagFormat` is `"{package}@{version}"` from a prior successful fetch of `@tanstack/query-core@5.90.19`
+- **THEN** on a fresh request for `5.90.20`, the skill SHALL probe `@tanstack/query-core@5.90.20` first and SHALL NOT probe `v5.90.20` or `5.90.20` unless the cached-format probe misses
+
+#### Scenario: tagFormat cache fallthrough on miss
+
+- **WHEN** the cached `tagFormat` probe returns 404 (e.g., repo changed tagging convention mid-history)
+- **THEN** the skill SHALL silently fall through the standard probe chain and SHALL NOT invalidate the cached `tagFormat`. If a different format succeeds, the skill SHALL update `tagFormat` to the new value.
+
+#### Scenario: tagFormat no-op write skip
+
+- **WHEN** the successful format equals the currently cached `tagFormat`
+- **THEN** the skill SHALL NOT rewrite `_meta.json` for this field
+
+#### Scenario: Empty release body
+
+- **WHEN** the release exists but `body` is empty or null
+- **THEN** the version SHALL be passed to Strategy C
+
+#### Scenario: Rate limiting
+
+- **WHEN** fetching releases for 40 versions, each potentially probing multiple tag formats
+- **THEN** the skill SHALL batch into groups of 30 total requests, with a 100ms delay between each request within and across batches

--- a/openspec/changes/add-npm-changelog-monorepo-support/tasks.md
+++ b/openspec/changes/add-npm-changelog-monorepo-support/tasks.md
@@ -1,0 +1,63 @@
+## 1. Command file — Strategy A+ (subdir probing)
+
+- [x] 1.1 In `claude-plugins/experiments/commands/npm-changelog.md`, rewrite the Step 5 guidance: keep single-repo behavior (root only), add monorepo branch (subdir chain first, then root fallback, then Strategy B)
+- [x] 1.2 Specify the exact probe order for monorepos: `{MONOREPO_DIR}/CHANGELOG.md` → `{MONOREPO_DIR}/CHANGELOG` → `{MONOREPO_DIR}/History.md` → `{MONOREPO_DIR}/CHANGES.md`, then fall through to root chain for unresolved versions
+- [x] 1.3 Document the cascade semantics: versions successfully parsed from the subdirectory file are marked resolved; versions absent from the subdir file fall through to the root chain before Strategy B
+- [x] 1.4 Update the raw-source cache key rule: subdirectory files stored at `_source/{path-encoded-filename}` where `/` is replaced by `__` (e.g., `_source/packages__query-core__CHANGELOG.md`). Matching `.sha256` sidecar uses the same key.
+- [x] 1.5 Update the 24h TTL check to use the path-encoded key for subdirectory files
+- [x] 1.6 Remove the blanket statement *"Always fetch from repo root, never from a monorepo subdirectory"* and replace with the branched rule
+- [x] 1.7 Update `_meta.json.changelogFiles` union rule: for subdirectory-fetched files, store the path-qualified filename (e.g., `packages/query-core/CHANGELOG.md`) not just the bare name
+
+## 2. Command file — Strategy B+ (scoped tag formats + cached tagFormat)
+
+- [x] 2.1 Update Step 6 entry point: read `_meta.json.tagFormat` first; if set, resolve the template against `{package}`, `{packageBasename}`, `{version}` and probe that URL before the standard chain
+- [x] 2.2 On cached-format miss (HTTP 404), fall through silently to the standard probe chain; do not invalidate `_meta.json.tagFormat`
+- [x] 2.3 Document the standard probe chain: `v{ver}` → `{ver}` → (if `isMonorepo`) `{PKG}@{ver}` → (if scoped) `{PKG-basename}@{ver}` → `{PKG}-v{ver}` → (if scoped) `{PKG-basename}-v{ver}`
+- [x] 2.4 Specify `{PKG-basename}` derivation: for scoped `@scope/name`, basename is `name`; for unscoped, scope-stripped variants are skipped entirely
+- [x] 2.5 On first success, persist the templated form to `_meta.json.tagFormat`. Valid templates: `"v{version}"`, `"{version}"`, `"{package}@{version}"`, `"{packageBasename}@{version}"`, `"{package}-v{version}"`, `"{packageBasename}-v{version}"`
+- [x] 2.6 Skip the `_meta.json` write when the successful format equals the already-cached `tagFormat` value
+- [x] 2.7 Confirm each tag-format probe counts as one request against the 30-per-batch / 100ms rate limit and that the probe loop for a single version can consume multiple budget slots
+
+## 3. Command file — metadata & parsing touch-ups
+
+- [x] 3.1 Step 3 `_meta.json` schema note: add the templated `tagFormat` examples next to the existing field placeholder
+- [x] 3.2 Step 5 Parse section: confirm that section extraction logic (pattern detection, heading boundaries) is unchanged and operates identically on subdir vs root files
+- [x] 3.3 Verify Strategy C (unpkg) guidance needs no change — it is already package-URL-based and implicitly monorepo-aware
+
+## 4. Spec sync
+
+- [ ] 4.1 After implementation merges, run `openspec sync` (or `/opsx:sync add-npm-changelog-monorepo-support`) to apply the MODIFIED Strategy A and Strategy B requirements into `openspec/specs/npm-changelog-retrieval/spec.md`
+- [ ] 4.2 Validate via `openspec spec validate npm-changelog-retrieval`
+
+## 5. Plugin version bump
+
+- [x] 5.1 Bump `claude-plugins/experiments/.claude-plugin/plugin.json` version (minor bump — new capability, no breaking change)
+- [x] 5.2 Bump `claude-plugins/experiments/package.json` to match
+- [x] 5.3 Bump the `experiments` entry in `.claude-plugin/marketplace.json` to match
+- [x] 5.4 Verify all three files report the same new version
+
+## 6. Manual verification — positive cases
+
+- [ ] 6.1 Clear local cache for the 4 target packages: `rm -rf ~/.claude/changelogs/@tanstack__query-core ~/.claude/changelogs/@tanstack__eslint-plugin-query ~/.claude/changelogs/@vitejs__plugin-react-swc ~/.claude/changelogs/eslint-plugin-tsdoc`
+- [x] 6.2 Run `/experiments:npm-changelog @tanstack/query-core 5.90.0..5.90.20`; verify `changelogSource: "raw_changelog"` with subdir path in `changelogFiles`, OR `github_releases` with `tagFormat: "{package}@{version}"` — either is acceptable per cascade order
+- [x] 6.3 Run `/experiments:npm-changelog @tanstack/eslint-plugin-query latest`; verify success
+- [x] 6.4 Run `/experiments:npm-changelog @vitejs/plugin-react-swc latest`; verify success
+- [x] 6.5 Run `/experiments:npm-changelog eslint-plugin-tsdoc latest`; verify success
+- [x] 6.6 Re-run the same commands back-to-back; verify the all-cached fast path fires (0 network requests)
+
+## 7. Manual verification — preserved behavior
+
+- [x] 7.1 Run `/experiments:npm-changelog react 19.0.0`; verify root CHANGELOG still resolves (single-repo path unchanged)
+- [x] 7.2 Run `/experiments:npm-changelog @angular/core latest`; verify aggregator-family monorepo resolves via subdir-then-root fallback (expected: subdir 404 → root 200)
+- [x] 7.3 Run `/experiments:npm-changelog nx latest`; verify Strategy B resolves via `{version}` (no-prefix) tag format; confirm `_meta.json.tagFormat` is set to `"{version}"`
+
+## 8. Manual verification — correct terminal failures
+
+- [x] 8.1 Run `/experiments:npm-changelog @types/node latest`; verify `failReason: "no_changelog_source"` persists (DefinitelyTyped is structurally out of scope)
+- [x] 8.2 Run `/experiments:npm-changelog @ant-design/icons 6.1.1`; verify still fails (no `repository.directory` in npm metadata — D5 contract)
+- [x] 8.3 Confirm `i18next-resources-for-ts` also still fails with `no_changelog_source` (single-repo, no CHANGELOG, releases without body)
+
+## 9. Documentation
+
+- [x] 9.1 Update `claude-plugins/experiments/README.md` if it enumerates command capabilities — note monorepo support for `npm-changelog`
+- [x] 9.2 Cross-reference: add a pointer in the command file's preamble to `openspec/specs/npm-changelog-retrieval/spec.md` Strategy A and Strategy B requirements


### PR DESCRIPTION
## Summary

- **Strategy A+**: for monorepo packages (`repository.directory` present), probe `{dir}/CHANGELOG.md` chain before the repo root, cascading per-version so aggregator-family monorepos still resolve at root. Subdir raw-source cached under `_source/` with path-encoded keys; `changelogFiles` stores path-qualified names.
- **Strategy B+**: learn scoped tag formats (`{package}@{version}`, `{packageBasename}@{version}`, hyphenated variants) for Changesets-style monorepos; read and write `_meta.json.tagFormat` as a self-describing template; silently fall through on cached-format miss without invalidating the cached hint.
- Plugin bumped 0.6.0 → 0.7.0 across `plugin.json`, `package.json`, `marketplace.json`.
- Includes OpenSpec change `add-npm-changelog-monorepo-support` (proposal, design, delta spec, tasks).

## Test plan

Runtime-verified against an overlay of the edited command over `~/.claude/plugins/cache/monolab/experiments/0.6.0/`.

- [x] Positive: `@tanstack/query-core 5.90.0..5.90.20` (subdir raw_changelog resolves 18/20; 2 via Strategy B with cached `v{version}`), `@tanstack/eslint-plugin-query`, `@vitejs/plugin-react-swc`, `eslint-plugin-tsdoc` — all `raw_changelog` from `packages/**/CHANGELOG.md`
- [x] Fast-path: re-running the four back-to-back yields "0 network requests"
- [x] Non-regression: `react 19.0.0` (root CHANGELOG), `@angular/core latest` (subdir 404 → root), `nx latest` (`tagFormat: "{version}"`)
- [x] Correct terminal failures: `@types/node`, `@ant-design/icons`, `i18next-resources-for-ts` — all `failReason: "no_changelog_source"` per D5 contract
- [ ] Post-merge: run `openspec sync add-npm-changelog-monorepo-support` + `openspec spec validate npm-changelog-retrieval` + archive

## Notes

Two minor agent-interpretation bugs observed during verification (not fixed here): scoped `tagFormat` occasionally persisted as the resolved value rather than the template; `no_changelog_source` sometimes marked `retryable: true`. Follow-up trackers can address these at the interpretation layer without touching the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `npm-changelog` command with monorepo support: automatically detects and retrieves changelogs from subdirectories for scoped packages.
  * Improved changelog discovery with intelligent caching and smart tag-format detection to reduce redundant lookups.

* **Chores**
  * Bumped experiments plugin version to 0.7.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->