### PR TITLE
fix(release): http-client deno workspace + JSR skip for npm-only packages

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -103,6 +103,11 @@ jobs:
                       PKG_PATH="packages/$PKG_DIR"
                       PACKAGE_NAME="@m0n0lab/$PKG_DIR"
 
+                      if [ ! -f "$PKG_PATH/deno.json" ]; then
+                        echo "Skipping $PACKAGE_NAME for JSR — no deno.json"
+                        continue
+                      fi
+
                       echo "Publishing $PACKAGE_NAME to JSR..."
                       cd $PKG_PATH
                       deno publish
@@ -118,6 +123,11 @@ jobs:
                     if ! echo "$ORDERED_PACKAGES" | grep -q "$PKG_DIR"; then
                       PKG_PATH="packages/$PKG_DIR"
                       PACKAGE_NAME="@m0n0lab/$PKG_DIR"
+
+                      if [ ! -f "$PKG_PATH/deno.json" ]; then
+                        echo "Skipping standalone $PACKAGE_NAME for JSR — no deno.json"
+                        continue
+                      fi
 
                       echo "Publishing standalone package $PACKAGE_NAME to JSR..."
                       cd $PKG_PATH

--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,6 @@
 {
     "workspace": [
+        "./packages/http-client",
         "./packages/react-clean",
         "./packages/react-hooks",
         "./packages/ts-configs",


### PR DESCRIPTION
## Summary
- Add `./packages/http-client` to root `deno.json` workspace (was missing → JSR publish error: *Config file must be a member of the workspace*)
- Workflow now skips `deno publish` when package lacks `deno.json` (e.g. `solid-clean`)

Follow-up to the failed publish in run 26002419124. The release-please run on PR #209 created the tags + GitHub releases correctly; only the publish step failed.

Note: existing tags (http-client@0.2.0, react-clean@3.2.0, ...) will NOT be re-published by merging this — they need to be published manually or via a forced re-bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to validate Deno configuration before publishing to JSR
  * Integrated `http-client` package into the workspace

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pabloimrik17/monolab/pull/210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->