### PR TITLE
feat(release): workflow_dispatch for manual publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,12 @@ on:
     push:
         branches:
             - main
+    workflow_dispatch:
+        inputs:
+            packages:
+                description: "Comma-separated package names to publish (e.g. http-client,react-clean). Required when running manually."
+                required: true
+                type: string
 
 permissions:
     contents: write
@@ -13,6 +19,7 @@ permissions:
 
 jobs:
     release-please:
+        if: ${{ github.event_name == 'push' }}
         runs-on: ubuntu-latest
         outputs:
             releases_created: ${{ steps.release.outputs.releases_created }}
@@ -30,7 +37,10 @@ jobs:
     publish:
         needs: release-please
         runs-on: ubuntu-latest
-        if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+        if: |
+            always() && !cancelled() &&
+            ((github.event_name == 'push' && needs.release-please.outputs.releases_created == 'true')
+              || github.event_name == 'workflow_dispatch')
         permissions:
             contents: read
             id-token: write
@@ -65,15 +75,21 @@ jobs:
               id: released-packages
               env:
                   PATHS_RELEASED: ${{ needs.release-please.outputs.paths_released }}
+                  DISPATCH_PACKAGES: ${{ inputs.packages }}
+                  EVENT_NAME: ${{ github.event_name }}
               run: |
-                  # Parse paths_released to get package names (using env var to prevent script injection)
-                  echo "Released paths: $PATHS_RELEASED"
+                  if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+                    # Manual run: read comma-separated input, normalize to space-separated
+                    PACKAGES=$(echo "$DISPATCH_PACKAGES" | tr ',' ' ' | tr -s ' ')
+                    echo "Manual dispatch packages: $PACKAGES"
+                  else
+                    # Push event: parse release-please paths_released
+                    echo "Released paths: $PATHS_RELEASED"
+                    PACKAGES=$(echo "$PATHS_RELEASED" | jq -r '.[] | select(startswith("packages/")) | sub("packages/"; "")' | tr '\n' ' ')
+                    echo "Released packages: $PACKAGES"
+                  fi
 
-                  # Extract package names from paths (packages/ts-types -> ts-types)
-                  # Convert to space-separated single line for GitHub Actions output
-                  PACKAGES=$(echo "$PATHS_RELEASED" | jq -r '.[] | select(startswith("packages/")) | sub("packages/"; "")' | tr '\n' ' ')
                   echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
-                  echo "Released packages: $PACKAGES"
 
             - name: Publish packages to JSR
               run: |


### PR DESCRIPTION
## Summary
Adds `workflow_dispatch` trigger to `release-please.yml` so the publish job (JSR + npm) can be run manually with a list of package names.

Needed to publish the tags created by PR #209 whose publish step failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release and publish workflows to support manual triggering, enabling developers to manually publish specific packages on demand alongside existing automated release processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pabloimrik17/monolab/pull/211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->