### PR TITLE
fix(http-client): enable Deno sloppy-imports for JSR publish

### DIFF
--- a/packages/http-client/deno.json
+++ b/packages/http-client/deno.json
@@ -2,5 +2,6 @@
     "name": "@m0n0lab/http-client",
     "version": "0.2.0",
     "license": "MIT",
-    "exports": "./src/index.ts"
+    "exports": "./src/index.ts",
+    "unstable": ["sloppy-imports"]
 }


### PR DESCRIPTION
## Summary
Adds `"unstable": ["sloppy-imports"]` to `packages/http-client/deno.json` so `deno publish` resolves `.js` import specifiers to `.ts` source files. Without it, type-check fails on 47 imports.

Per-package opt-in — other packages remain strict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)