### PR TITLE
fix(release): enable Deno sloppy-imports at workspace root + CLI flag

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -126,7 +126,7 @@ jobs:
 
                       echo "Publishing $PACKAGE_NAME to JSR..."
                       cd $PKG_PATH
-                      deno publish
+                      deno publish --unstable-sloppy-imports
                       cd ../..
 
                       echo "Successfully published $PACKAGE_NAME to JSR"
@@ -147,7 +147,7 @@ jobs:
 
                       echo "Publishing standalone package $PACKAGE_NAME to JSR..."
                       cd $PKG_PATH
-                      deno publish
+                      deno publish --unstable-sloppy-imports
                       cd ../..
 
                       echo "Successfully published $PACKAGE_NAME to JSR"

--- a/deno.json
+++ b/deno.json
@@ -6,6 +6,7 @@
         "./packages/ts-configs",
         "./packages/ts-types"
     ],
+    "unstable": ["sloppy-imports"],
     "fmt": {
         "files": {
             "exclude": ["**/*"]


### PR DESCRIPTION
Per-package flag didn't apply during deno publish. Promotes the unstable flag to workspace root and adds --unstable-sloppy-imports to the publish call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled Deno's unstable sloppy-imports feature in project configuration to improve import compatibility.
  * Updated the package publishing workflow to utilize sloppy-imports during JSR distribution, enhancing compatibility for users importing the package.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pabloimrik17/monolab/pull/214?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->