### PR TITLE
fix(release): skip Nx build when package has no build target

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -175,9 +175,13 @@ jobs:
 
                     echo "Processing package: $PACKAGE_NAME@$VERSION"
 
-                    # Build the package using Nx (NX_NO_CLOUD disables cloud)
-                    echo "Building $PACKAGE_NAME..."
-                    pnpm nx run $PKG_DIR:build
+                    # Build the package using Nx (skip if no build target — e.g. config-only packages)
+                    if pnpm exec nx show project "$PACKAGE_NAME" --json 2>/dev/null | jq -e '.targets.build' >/dev/null; then
+                      echo "Building $PACKAGE_NAME..."
+                      pnpm nx run $PKG_DIR:build
+                    else
+                      echo "No build target for $PACKAGE_NAME — skipping build"
+                    fi
 
                     # Publish to npm using pnpm (transforms workspace:* to semver)
                     echo "Publishing $PACKAGE_NAME to npm..."


### PR DESCRIPTION
Adds 'nx show project' check so config-only packages (ts-configs) can publish to npm without a build step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Enhanced the release workflow to intelligently handle different package types by checking build requirements before attempting to build packages. Packages without build requirements are now skipped gracefully instead of causing failures, improving overall release reliability and robustness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pabloimrik17/monolab/pull/217?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->