### PR TITLE
fix(release): drop setup-node registry-url for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -153,6 +153,8 @@ jobs:
                   done
 
             - name: Build and publish packages to npm
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
               run: |
                   # Get list of packages
                   PACKAGES="${{ steps.released-packages.outputs.packages }}"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -61,7 +61,6 @@ jobs:
               with:
                   node-version: "24.12.0"
                   cache: "pnpm"
-                  registry-url: "https://registry.npmjs.org"
 
             - name: Setup Deno
               uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
@@ -153,8 +152,6 @@ jobs:
                   done
 
             - name: Build and publish packages to npm
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
               run: |
                   # Get list of packages
                   PACKAGES="${{ steps.released-packages.outputs.packages }}"


### PR DESCRIPTION
Removes registry-url from actions/setup-node so npm CLI falls back to OIDC trusted publishing (configured on npm with provenance) instead of using the placeholder _authToken in the .npmrc that setup-node generates.