### PR TITLE
feat(codecov): matrix-driven uploads + bundle tracking for apps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
             NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
             # Set to 'true' to disable Nx Cloud when monthly limit is reached
             NX_NO_CLOUD: ${{ vars.NX_NO_CLOUD }}
+        outputs:
+            # JSON map { "<flag>": true|false } consumed by the upload-codecov matrix job
+            # to gate per-package uploads. On push events, all flags are forced to true.
+            affected: ${{ steps.affected-codecov.outputs.json }}
         steps:
             - name: Checkout code
               uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -140,287 +144,60 @@ jobs:
               run: pnpm exec nx run-many -t test:types
               if: ${{ github.event_name == 'push' }}
 
-            # Detect which packages are affected by PR changes for conditional Codecov uploads
-            # This step only runs on PRs to optimize upload time and API usage
+            # Build an affected map consumed by the upload-codecov matrix job.
+            # PR: only affected packages upload. Push: force all to true (baseline run).
             - name: 🔍 Detect affected packages for Codecov
               id: affected-codecov
-              if: ${{ github.event_name == 'pull_request' }}
               run: |
-                  # Get list of affected projects from Nx
-                  AFFECTED_PROJECTS=$(pnpm exec nx show projects --affected)
-                  echo "Affected projects:"
-                  echo "$AFFECTED_PROJECTS"
+                  PACKAGES="react-hooks react-clean ts-configs ts-types http-client qup-api qup-data qup-domain solid-clean wealth-tracker-core green-beard qup-web wealth-react qup-shared"
+                  if [ "${{ github.event_name }}" = "pull_request" ]; then
+                    AFFECTED_PROJECTS=$(pnpm exec nx show projects --affected)
+                    echo "Affected projects:"
+                    echo "$AFFECTED_PROJECTS"
+                    JSON="{"
+                    for package in $PACKAGES; do
+                      if echo "$AFFECTED_PROJECTS" | grep -Fxq "@m0n0lab/$package"; then
+                        JSON="$JSON\"$package\":true,"
+                        echo "✓ $package is affected"
+                      else
+                        JSON="$JSON\"$package\":false,"
+                        echo "⏭️  $package is not affected"
+                      fi
+                    done
+                    JSON="${JSON%,}}"
+                  else
+                    # On push events upload all flags for full baseline.
+                    JSON="{"
+                    for package in $PACKAGES; do
+                      JSON="$JSON\"$package\":true,"
+                    done
+                    JSON="${JSON%,}}"
+                  fi
+                  echo "json=$JSON" >> $GITHUB_OUTPUT
+                  echo "Affected JSON: $JSON"
 
-                  # Check each package and set boolean output
-                  for package in react-hooks react-clean ts-configs ts-types http-client qup-api qup-data qup-domain solid-clean wealth-tracker-core green-beard qup-web wealth-react qup-shared; do
-                    if echo "$AFFECTED_PROJECTS" | grep -Fxq "@m0n0lab/$package"; then
-                      echo "$package=true" >> $GITHUB_OUTPUT
-                      echo "✓ $package is affected"
-                    else
-                      echo "$package=false" >> $GITHUB_OUTPUT
-                      echo "⏭️  $package is not affected"
-                    fi
-                  done
-
-            # Upload coverage per package with individual flags for isolated tracking
-            # In PRs: only upload affected packages. On main/develop/pre: upload all packages for baseline
-            - name: 📊 Upload coverage to Codecov - react-hooks
-              uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
-              if: ${{ !cancelled() && (github.event_name == 'push' || steps.affected-codecov.outputs.react-hooks == 'true') }}
+            # Upload lcov + junit artifacts for the downstream matrix job to consume.
+            # Single small artifact (<2MB typically); retention 1 day is enough for the
+            # follow-up job to download.
+            - name: 📦 Upload coverage artifacts
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+              if: ${{ !cancelled() }}
               with:
-                  files: ./packages/react-hooks/coverage/lcov.info
-                  flags: react-hooks
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  fail_ci_if_error: false
-
-            - name: 📊 Upload coverage to Codecov - react-clean
-              uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
-              if: ${{ !cancelled() && (github.event_name == 'push' || steps.affected-codecov.outputs.react-clean == 'true') }}
-              with:
-                  files: ./packages/react-clean/coverage/lcov.info
-                  flags: react-clean
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  fail_ci_if_error: false
-
-            - name: 📊 Upload coverage to Codecov - ts-configs
-              uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
-              if: ${{ !cancelled() && (github.event_name == 'push' || steps.affected-codecov.outputs.ts-configs == 'true') }}
-              with:
-                  files: ./packages/ts-configs/coverage/lcov.info
-                  flags: ts-configs
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  fail_ci_if_error: false
-
-            - name: 📊 Upload coverage to Codecov - ts-types
-              uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
-              if: ${{ !cancelled() && (github.event_name == 'push' || steps.affected-codecov.outputs.ts-types == 'true') }}
-              with:
-                  files: ./packages/ts-types/coverage/lcov.info
-                  flags: ts-types
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  fail_ci_if_error: false
-
-            - name: 📊 Upload coverage to Codecov - http-client
-              uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
-              if: ${{ !cancelled() && (github.event_name == 'push' || steps.affected-codecov.outputs.http-client == 'true') }}
-              with:
-                  files: ./packages/http-client/coverage/lcov.info
-                  flags: http-client
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  fail_ci_if_error: false
-
-            - name: 📊 Upload coverage to Codecov - qup-api
-              uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
-              if: ${{ !cancelled() && (github.event_name == 'push' || steps.affected-codecov.outputs.qup-api == 'true') }}
-              with:
-                  files: ./apps/qup-api/coverage/lcov.info
-                  flags: qup-api
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  fail_ci_if_error: false
-
-            - name: 📊 Upload coverage to Codecov - qup-data
-              uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
-              if: ${{ !cancelled() && (github.event_name == 'push' || steps.affected-codecov.outputs.qup-data == 'true') }}
-              with:
-                  files: ./packages/qup-data/coverage/lcov.info
-                  flags: qup-data
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  fail_ci_if_error: false
-
-            - name: 📊 Upload coverage to Codecov - qup-domain
-              uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
-              if: ${{ !cancelled() && (github.event_name == 'push' || steps.affected-codecov.outputs.qup-domain == 'true') }}
-              with:
-                  files: ./packages/qup-domain/coverage/lcov.info
-                  flags: qup-domain
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  fail_ci_if_error: false
-
-            - name: 📊 Upload coverage to Codecov - solid-clean
-              uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
-              if: ${{ !cancelled() && (github.event_name == 'push' || steps.affected-codecov.outputs.solid-clean == 'true') }}
-              with:
-                  files: ./packages/solid-clean/coverage/lcov.info
-                  flags: solid-clean
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  fail_ci_if_error: false
-
-            - name: 📊 Upload coverage to Codecov - wealth-tracker-core
-              uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
-              if: ${{ !cancelled() && (github.event_name == 'push' || steps.affected-codecov.outputs.wealth-tracker-core == 'true') }}
-              with:
-                  files: ./packages/wealth-tracker-core/coverage/lcov.info
-                  flags: wealth-tracker-core
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  fail_ci_if_error: false
-
-            - name: 📊 Upload coverage to Codecov - green-beard
-              uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
-              if: ${{ !cancelled() && (github.event_name == 'push' || steps.affected-codecov.outputs.green-beard == 'true') }}
-              with:
-                  files: ./apps/green-beard/coverage/lcov.info
-                  flags: green-beard
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  fail_ci_if_error: false
-
-            - name: 📊 Upload coverage to Codecov - qup-web
-              uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
-              if: ${{ !cancelled() && (github.event_name == 'push' || steps.affected-codecov.outputs.qup-web == 'true') }}
-              with:
-                  files: ./apps/qup-web/coverage/lcov.info
-                  flags: qup-web
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  fail_ci_if_error: false
-
-            - name: 📊 Upload coverage to Codecov - wealth-react
-              uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
-              if: ${{ !cancelled() && (github.event_name == 'push' || steps.affected-codecov.outputs.wealth-react == 'true') }}
-              with:
-                  files: ./apps/wealth-react/coverage/lcov.info
-                  flags: wealth-react
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  fail_ci_if_error: false
-
-            - name: 📊 Upload coverage to Codecov - qup-shared
-              uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
-              if: ${{ !cancelled() && (github.event_name == 'push' || steps.affected-codecov.outputs.qup-shared == 'true') }}
-              with:
-                  files: ./packages/qup-shared/coverage/lcov.info
-                  flags: qup-shared
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  fail_ci_if_error: false
-
-            # Upload test results per package with individual flags
-            # Critical: runs even if tests fail (via !cancelled()) to capture failure data for Test Analytics
-            # In PRs: only upload affected packages. On main/develop/pre: upload all packages for baseline
-            - name: 📊 Upload test results to Codecov - react-hooks
-              uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-              if: ${{ !cancelled() && (github.event_name == 'push' || steps.affected-codecov.outputs.react-hooks == 'true') }}
-              with:
-                  files: ./packages/react-hooks/test-results.junit.xml
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  flags: react-hooks
-                  fail_ci_if_error: false
-
-            - name: 📊 Upload test results to Codecov - react-clean
-              uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-              if: ${{ !cancelled() && (github.event_name == 'push' || steps.affected-codecov.outputs.react-clean == 'true') }}
-              with:
-                  files: ./packages/react-clean/test-results.junit.xml
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  flags: react-clean
-                  fail_ci_if_error: false
-
-            - name: 📊 Upload test results to Codecov - ts-configs
-              uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-              if: ${{ !cancelled() && (github.event_name == 'push' || steps.affected-codecov.outputs.ts-configs == 'true') }}
-              with:
-                  files: ./packages/ts-configs/test-results.junit.xml
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  flags: ts-configs
-                  fail_ci_if_error: false
-
-            - name: 📊 Upload test results to Codecov - ts-types
-              uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-              if: ${{ !cancelled() && (github.event_name == 'push' || steps.affected-codecov.outputs.ts-types == 'true') }}
-              with:
-                  files: ./packages/ts-types/test-results.junit.xml
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  flags: ts-types
-                  fail_ci_if_error: false
-
-            - name: 📊 Upload test results to Codecov - http-client
-              uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-              if: ${{ !cancelled() && (github.event_name == 'push' || steps.affected-codecov.outputs.http-client == 'true') }}
-              with:
-                  files: ./packages/http-client/test-results.junit.xml
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  flags: http-client
-                  fail_ci_if_error: false
-
-            - name: 📊 Upload test results to Codecov - qup-api
-              uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-              if: ${{ !cancelled() && (github.event_name == 'push' || steps.affected-codecov.outputs.qup-api == 'true') }}
-              with:
-                  files: ./apps/qup-api/test-results.junit.xml
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  flags: qup-api
-                  fail_ci_if_error: false
-
-            - name: 📊 Upload test results to Codecov - qup-data
-              uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-              if: ${{ !cancelled() && (github.event_name == 'push' || steps.affected-codecov.outputs.qup-data == 'true') }}
-              with:
-                  files: ./packages/qup-data/test-results.junit.xml
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  flags: qup-data
-                  fail_ci_if_error: false
-
-            - name: 📊 Upload test results to Codecov - qup-domain
-              uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-              if: ${{ !cancelled() && (github.event_name == 'push' || steps.affected-codecov.outputs.qup-domain == 'true') }}
-              with:
-                  files: ./packages/qup-domain/test-results.junit.xml
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  flags: qup-domain
-                  fail_ci_if_error: false
-
-            - name: 📊 Upload test results to Codecov - solid-clean
-              uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-              if: ${{ !cancelled() && (github.event_name == 'push' || steps.affected-codecov.outputs.solid-clean == 'true') }}
-              with:
-                  files: ./packages/solid-clean/test-results.junit.xml
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  flags: solid-clean
-                  fail_ci_if_error: false
-
-            - name: 📊 Upload test results to Codecov - wealth-tracker-core
-              uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-              if: ${{ !cancelled() && (github.event_name == 'push' || steps.affected-codecov.outputs.wealth-tracker-core == 'true') }}
-              with:
-                  files: ./packages/wealth-tracker-core/test-results.junit.xml
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  flags: wealth-tracker-core
-                  fail_ci_if_error: false
-
-            - name: 📊 Upload test results to Codecov - green-beard
-              uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-              if: ${{ !cancelled() && (github.event_name == 'push' || steps.affected-codecov.outputs.green-beard == 'true') }}
-              with:
-                  files: ./apps/green-beard/test-results.junit.xml
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  flags: green-beard
-                  fail_ci_if_error: false
-
-            - name: 📊 Upload test results to Codecov - qup-web
-              uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-              if: ${{ !cancelled() && (github.event_name == 'push' || steps.affected-codecov.outputs.qup-web == 'true') }}
-              with:
-                  files: ./apps/qup-web/test-results.junit.xml
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  flags: qup-web
-                  fail_ci_if_error: false
-
-            - name: 📊 Upload test results to Codecov - wealth-react
-              uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-              if: ${{ !cancelled() && (github.event_name == 'push' || steps.affected-codecov.outputs.wealth-react == 'true') }}
-              with:
-                  files: ./apps/wealth-react/test-results.junit.xml
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  flags: wealth-react
-                  fail_ci_if_error: false
-
-            - name: 📊 Upload test results to Codecov - qup-shared
-              uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-              if: ${{ !cancelled() && (github.event_name == 'push' || steps.affected-codecov.outputs.qup-shared == 'true') }}
-              with:
-                  files: ./packages/qup-shared/test-results.junit.xml
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  flags: qup-shared
-                  fail_ci_if_error: false
+                  name: codecov-artifacts
+                  path: |
+                      packages/*/coverage/lcov.info
+                      apps/*/coverage/lcov.info
+                      packages/*/test-results.junit.xml
+                      apps/*/test-results.junit.xml
+                  if-no-files-found: warn
+                  retention-days: 1
 
             - name: 🏗 Execute build checks
-              # Builds all packages; Nx cache optimizes by skipping rebuild of non-affected packages
+              # Builds all packages; Nx cache optimizes by skipping rebuild of non-affected packages.
+              # CODECOV_TOKEN is propagated so app bundler plugins (@codecov/vite-plugin,
+              # @codecov/sveltekit-plugin, @codecov/rollup-plugin) upload bundle stats during build.
+              env:
+                  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
               run: pnpm exec nx run-many -t build
 
             - name: 🧬 Execute mutation testing (All)
@@ -470,3 +247,68 @@ jobs:
               with:
                   path: .nx
                   key: ${{ steps.cache-nx-restore.outputs.cache-primary-key }}
+
+    # Fan-out coverage + test-results uploads to Codecov.
+    # One matrix entry per flag; the gate step skips entries not affected by the PR.
+    # Single source of truth for the package list: this matrix block.
+    upload-codecov:
+        needs: main
+        if: ${{ !cancelled() }}
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                package:
+                    - { name: react-hooks, path: packages/react-hooks }
+                    - { name: react-clean, path: packages/react-clean }
+                    - { name: ts-configs, path: packages/ts-configs }
+                    - { name: ts-types, path: packages/ts-types }
+                    - { name: http-client, path: packages/http-client }
+                    - { name: qup-api, path: apps/qup-api }
+                    - { name: qup-data, path: packages/qup-data }
+                    - { name: qup-domain, path: packages/qup-domain }
+                    - { name: solid-clean, path: packages/solid-clean }
+                    - { name: wealth-tracker-core, path: packages/wealth-tracker-core }
+                    - { name: green-beard, path: apps/green-beard }
+                    - { name: qup-web, path: apps/qup-web }
+                    - { name: wealth-react, path: apps/wealth-react }
+                    - { name: qup-shared, path: packages/qup-shared }
+        steps:
+            - name: Download coverage artifacts
+              uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+              with:
+                  name: codecov-artifacts
+
+            - name: Gate by affected map
+              id: gate
+              run: |
+                  AFFECTED='${{ needs.main.outputs.affected }}'
+                  if [ -z "$AFFECTED" ] || [ "$AFFECTED" = "null" ]; then
+                    # If the upstream job didn't emit the map (e.g. early failure),
+                    # skip upload rather than crashing the matrix.
+                    echo "should_upload=false" >> $GITHUB_OUTPUT
+                    exit 0
+                  fi
+                  if echo "$AFFECTED" | jq -e '.["${{ matrix.package.name }}"] == true' > /dev/null; then
+                    echo "should_upload=true" >> $GITHUB_OUTPUT
+                  else
+                    echo "should_upload=false" >> $GITHUB_OUTPUT
+                  fi
+
+            - name: 📊 Upload coverage to Codecov
+              uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
+              if: ${{ !cancelled() && steps.gate.outputs.should_upload == 'true' }}
+              with:
+                  files: ./${{ matrix.package.path }}/coverage/lcov.info
+                  flags: ${{ matrix.package.name }}
+                  token: ${{ secrets.CODECOV_TOKEN }}
+                  fail_ci_if_error: false
+
+            - name: 📊 Upload test results to Codecov
+              uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+              if: ${{ !cancelled() && steps.gate.outputs.should_upload == 'true' }}
+              with:
+                  files: ./${{ matrix.package.path }}/test-results.junit.xml
+                  flags: ${{ matrix.package.name }}
+                  token: ${{ secrets.CODECOV_TOKEN }}
+                  fail_ci_if_error: false

--- a/apps/demo/vite.config.ts
+++ b/apps/demo/vite.config.ts
@@ -1,6 +1,17 @@
-import { defineConfig } from "vite";
+import { codecovVitePlugin } from "@codecov/vite-plugin";
+import { defineConfig, type PluginOption } from "vite";
 import solid from "vite-plugin-solid";
 
+// codecovVitePlugin still declares vite@^6 in peerDependencies; cast keeps the
+// plugin usable until @codecov/vite-plugin advertises vite@7 support. Drop the
+// cast once the upstream peer range widens.
+const codecovPlugin = codecovVitePlugin({
+    enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
+    bundleName: "demo",
+    uploadToken: process.env.CODECOV_TOKEN,
+    gitService: "github",
+}) as PluginOption;
+
 export default defineConfig({
-    plugins: [solid()],
+    plugins: [solid(), codecovPlugin],
 });

--- a/apps/demo/vite.config.ts
+++ b/apps/demo/vite.config.ts
@@ -5,10 +5,11 @@ import solid from "vite-plugin-solid";
 // codecovVitePlugin still declares vite@^6 in peerDependencies; cast keeps the
 // plugin usable until @codecov/vite-plugin advertises vite@7 support. Drop the
 // cast once the upstream peer range widens.
+const codecovToken = process.env.CODECOV_TOKEN?.trim();
 const codecovPlugin = codecovVitePlugin({
-    enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
+    enableBundleAnalysis: Boolean(codecovToken),
     bundleName: "demo",
-    uploadToken: process.env.CODECOV_TOKEN,
+    uploadToken: codecovToken,
     gitService: "github",
 }) as PluginOption;
 

--- a/apps/green-beard/vite.config.ts
+++ b/apps/green-beard/vite.config.ts
@@ -4,10 +4,11 @@ import { defineConfig, type PluginOption } from "vite";
 
 // Cast: see note in apps/demo/vite.config.ts — @codecov/sveltekit-plugin
 // inherits the same vite@^6 peer range constraint.
+const codecovToken = process.env.CODECOV_TOKEN?.trim();
 const codecovPlugin = codecovSvelteKitPlugin({
-    enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
+    enableBundleAnalysis: Boolean(codecovToken),
     bundleName: "green-beard",
-    uploadToken: process.env.CODECOV_TOKEN,
+    uploadToken: codecovToken,
     gitService: "github",
 }) as PluginOption;
 

--- a/apps/green-beard/vite.config.ts
+++ b/apps/green-beard/vite.config.ts
@@ -1,6 +1,16 @@
+import { codecovSvelteKitPlugin } from "@codecov/sveltekit-plugin";
 import { sveltekit } from "@sveltejs/kit/vite";
-import { defineConfig } from "vite";
+import { defineConfig, type PluginOption } from "vite";
+
+// Cast: see note in apps/demo/vite.config.ts — @codecov/sveltekit-plugin
+// inherits the same vite@^6 peer range constraint.
+const codecovPlugin = codecovSvelteKitPlugin({
+    enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
+    bundleName: "green-beard",
+    uploadToken: process.env.CODECOV_TOKEN,
+    gitService: "github",
+}) as PluginOption;
 
 export default defineConfig({
-    plugins: [sveltekit()],
+    plugins: [sveltekit(), codecovPlugin],
 });

--- a/apps/investlab/tsdown.config.ts
+++ b/apps/investlab/tsdown.config.ts
@@ -1,3 +1,4 @@
+import { codecovRollupPlugin } from "@codecov/rollup-plugin";
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
@@ -23,4 +24,12 @@ export default defineConfig({
     clean: true,
     minify: false,
     target: "ES2023",
+    plugins: [
+        codecovRollupPlugin({
+            enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
+            bundleName: "investlab",
+            uploadToken: process.env.CODECOV_TOKEN,
+            gitService: "github",
+        }),
+    ],
 });

--- a/apps/investlab/tsdown.config.ts
+++ b/apps/investlab/tsdown.config.ts
@@ -1,6 +1,8 @@
 import { codecovRollupPlugin } from "@codecov/rollup-plugin";
 import { defineConfig } from "tsdown";
 
+const codecovToken = process.env.CODECOV_TOKEN?.trim();
+
 export default defineConfig({
     name: "@m0n0lab/investlab",
     entry: ["src/index.ts"],
@@ -26,9 +28,9 @@ export default defineConfig({
     target: "ES2023",
     plugins: [
         codecovRollupPlugin({
-            enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
+            enableBundleAnalysis: Boolean(codecovToken),
             bundleName: "investlab",
-            uploadToken: process.env.CODECOV_TOKEN,
+            uploadToken: codecovToken,
             gitService: "github",
         }),
     ],

--- a/apps/qup-api/tsdown.config.ts
+++ b/apps/qup-api/tsdown.config.ts
@@ -1,3 +1,4 @@
+import { codecovRollupPlugin } from "@codecov/rollup-plugin";
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
@@ -23,4 +24,12 @@ export default defineConfig({
     clean: true,
     minify: false,
     target: "ES2023",
+    plugins: [
+        codecovRollupPlugin({
+            enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
+            bundleName: "qup-api",
+            uploadToken: process.env.CODECOV_TOKEN,
+            gitService: "github",
+        }),
+    ],
 });

--- a/apps/qup-api/tsdown.config.ts
+++ b/apps/qup-api/tsdown.config.ts
@@ -1,6 +1,8 @@
 import { codecovRollupPlugin } from "@codecov/rollup-plugin";
 import { defineConfig } from "tsdown";
 
+const codecovToken = process.env.CODECOV_TOKEN?.trim();
+
 export default defineConfig({
     name: "@m0n0lab/qup-api",
     entry: ["src/index.ts"],
@@ -26,9 +28,9 @@ export default defineConfig({
     target: "ES2023",
     plugins: [
         codecovRollupPlugin({
-            enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
+            enableBundleAnalysis: Boolean(codecovToken),
             bundleName: "qup-api",
-            uploadToken: process.env.CODECOV_TOKEN,
+            uploadToken: codecovToken,
             gitService: "github",
         }),
     ],

--- a/apps/qup-web/app.config.ts
+++ b/apps/qup-web/app.config.ts
@@ -1,6 +1,8 @@
 import { codecovVitePlugin } from "@codecov/vite-plugin";
 import { defineConfig } from "@solidjs/start/config";
 
+const codecovToken = process.env.CODECOV_TOKEN?.trim();
+
 export default defineConfig({
     server: {
         preset: "node-server",
@@ -17,9 +19,9 @@ export default defineConfig({
             router === "client"
                 ? [
                       codecovVitePlugin({
-                          enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
+                          enableBundleAnalysis: Boolean(codecovToken),
                           bundleName: "qup-web",
-                          uploadToken: process.env.CODECOV_TOKEN,
+                          uploadToken: codecovToken,
                           gitService: "github",
                       }),
                   ]

--- a/apps/qup-web/app.config.ts
+++ b/apps/qup-web/app.config.ts
@@ -1,3 +1,4 @@
+import { codecovVitePlugin } from "@codecov/vite-plugin";
 import { defineConfig } from "@solidjs/start/config";
 
 export default defineConfig({
@@ -9,4 +10,19 @@ export default defineConfig({
             plugins: [["@babel/plugin-syntax-decorators", { version: "legacy" }]],
         },
     },
+    // Codecov bundle analysis runs only on the client router; the server bundle
+    // is not user-shipped so its size delta isn't useful to track here.
+    vite: ({ router }) => ({
+        plugins:
+            router === "client"
+                ? [
+                      codecovVitePlugin({
+                          enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
+                          bundleName: "qup-web",
+                          uploadToken: process.env.CODECOV_TOKEN,
+                          gitService: "github",
+                      }),
+                  ]
+                : [],
+    }),
 });

--- a/apps/wealth-react/vite.config.ts
+++ b/apps/wealth-react/vite.config.ts
@@ -1,6 +1,16 @@
+import { codecovVitePlugin } from "@codecov/vite-plugin";
 import { reactRouter } from "@react-router/dev/vite";
-import { defineConfig } from "vite";
+import { defineConfig, type PluginOption } from "vite";
+
+// Cast: see note in apps/demo/vite.config.ts — drop once @codecov/vite-plugin
+// advertises vite@7 in peerDependencies.
+const codecovPlugin = codecovVitePlugin({
+    enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
+    bundleName: "wealth-react",
+    uploadToken: process.env.CODECOV_TOKEN,
+    gitService: "github",
+}) as PluginOption;
 
 export default defineConfig({
-    plugins: [reactRouter()],
+    plugins: [reactRouter(), codecovPlugin],
 });

--- a/apps/wealth-react/vite.config.ts
+++ b/apps/wealth-react/vite.config.ts
@@ -4,10 +4,11 @@ import { defineConfig, type PluginOption } from "vite";
 
 // Cast: see note in apps/demo/vite.config.ts — drop once @codecov/vite-plugin
 // advertises vite@7 in peerDependencies.
+const codecovToken = process.env.CODECOV_TOKEN?.trim();
 const codecovPlugin = codecovVitePlugin({
-    enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
+    enableBundleAnalysis: Boolean(codecovToken),
     bundleName: "wealth-react",
-    uploadToken: process.env.CODECOV_TOKEN,
+    uploadToken: codecovToken,
     gitService: "github",
 }) as PluginOption;
 

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -227,16 +227,22 @@ ignore:
     - "**/coverage/"
     - "**/.nx/"
     - "**/*.config.ts"
+    - "**/*.config.tsx"
     - "**/*.config.js"
     - "**/*.config.cjs"
     - "**/*.config.mjs"
     - "**/vite.config.ts"
     - "**/vitest.config.ts"
+    - "**/vitest.setup.ts"
     - "**/eslint.config.ts"
+    - "**/stryker.config.*"
+    - "**/tsdown.config.*"
+    - "**/drizzle.config.*"
+    - "**/setup.ts"
 
 # Enable inline annotations on pull requests
 comment:
-    layout: "header, diff, flags,  files, footer"
+    layout: "header, diff, flags, files, footer"
     behavior: default # Update existing comment
     require_changes: false # Always comment, even if no coverage changes
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,10 @@
         "test:unit:watch": "nx run-many --target=test:unit:watch"
     },
     "devDependencies": {
-        "@codecov/bundle-analyzer": "1.9.1",
+        "@codecov/bundle-analyzer": "2.0.1",
+        "@codecov/rollup-plugin": "2.0.1",
+        "@codecov/sveltekit-plugin": "2.0.1",
+        "@codecov/vite-plugin": "2.0.1",
         "@commitlint/cli": "19.8.1",
         "@commitlint/config-conventional": "19.8.1",
         "@commitlint/types": "19.8.1",

--- a/packages/react-clean/deno.json
+++ b/packages/react-clean/deno.json
@@ -4,9 +4,6 @@
     "license": "MIT",
     "exports": "./src/index.ts",
     "compilerOptions": {
-        "lib": [
-            "ES2023",
-            "DOM"
-        ]
+        "lib": ["ES2023", "DOM"]
     }
 }

--- a/packages/react-hooks/deno.json
+++ b/packages/react-hooks/deno.json
@@ -4,9 +4,6 @@
     "license": "MIT",
     "exports": "./src/index.ts",
     "compilerOptions": {
-        "lib": [
-            "ES2023",
-            "DOM"
-        ]
+        "lib": ["ES2023", "DOM"]
     }
 }

--- a/packages/react-hooks/vitest.config.ts
+++ b/packages/react-hooks/vitest.config.ts
@@ -5,7 +5,16 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
     plugins: [react()],
     test: {
-        include: ["**/*.{test,spec}.{ts,tsx}", "**/*.browser.test.{ts,tsx}", "**/*.integration.ts"],
+        include: ["**/*.{test,spec}.{ts,tsx}"],
+        exclude: [
+            "**/*.browser.test.{ts,tsx}",
+            "**/*.integration.ts",
+            "**/node_modules/**",
+            "**/dist/**",
+            "**/.idea/**",
+            "**/.git/**",
+            "**/.cache/**",
+        ],
         reporters: ["default", "junit"],
         outputFile: {
             junit: "./test-results.junit.xml",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,17 @@ importers:
   .:
     devDependencies:
       '@codecov/bundle-analyzer':
-        specifier: 1.9.1
-        version: 1.9.1
+        specifier: 2.0.1
+        version: 2.0.1
+      '@codecov/rollup-plugin':
+        specifier: 2.0.1
+        version: 2.0.1(rollup@4.59.0)
+      '@codecov/sveltekit-plugin':
+        specifier: 2.0.1
+        version: 2.0.1(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.55.5)(typescript@5.9.3)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.55.5)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      '@codecov/vite-plugin':
+        specifier: 2.0.1
+        version: 2.0.1(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
       '@commitlint/cli':
         specifier: 19.8.1
         version: 19.8.1(@types/node@22.18.13)(typescript@5.9.3)
@@ -702,20 +711,23 @@ importers:
 
 packages:
 
-  '@actions/core@1.11.1':
-    resolution: {integrity: sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==}
+  '@actions/core@3.0.1':
+    resolution: {integrity: sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==}
 
-  '@actions/exec@1.1.1':
-    resolution: {integrity: sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==}
+  '@actions/exec@3.0.0':
+    resolution: {integrity: sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==}
 
-  '@actions/github@6.0.1':
-    resolution: {integrity: sha512-xbZVcaqD4XnQAe35qSQqskb3SqIAfRyLBrHMd/8TuL7hJSz2QtbDwnNM8zWx4zO5l2fnGtseNE3MbEvD7BxVMw==}
+  '@actions/github@9.1.1':
+    resolution: {integrity: sha512-tL5JbYOBZHc0ngEnCsaDcryUizIUIlQyIMwy1Wkx93H5HzbBJ7TbiPx2PnFjBwZW0Vh05JmfFZhecE6gglYegA==}
 
-  '@actions/http-client@2.2.3':
-    resolution: {integrity: sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==}
+  '@actions/http-client@3.0.2':
+    resolution: {integrity: sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==}
 
-  '@actions/io@1.1.3':
-    resolution: {integrity: sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==}
+  '@actions/http-client@4.0.1':
+    resolution: {integrity: sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==}
+
+  '@actions/io@3.0.2':
+    resolution: {integrity: sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -1383,15 +1395,34 @@ packages:
     resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
     engines: {node: '>=18.0.0'}
 
-  '@codecov/bundle-analyzer@1.9.1':
-    resolution: {integrity: sha512-WVWZIV0v09RueL0L2x8pgaWzGsJsKMsMFjsFgzfjeApq9cE6bZ+0fQC3f/pTQ8h40Y3D5Gk9o4W6jd/if3ohSA==}
-    engines: {node: '>=18.0.0'}
+  '@codecov/bundle-analyzer@2.0.1':
+    resolution: {integrity: sha512-SkL0+Ccs6VuHIA9Bxb8/J110CffRXpqtKt7m18FTWC0P6gDKEsoieUerDdcd6K9BFKujj6gaUdTt5i4I/v8GTA==}
+    engines: {node: '>=20.0.0'}
     os: [darwin, linux]
     hasBin: true
 
-  '@codecov/bundler-plugin-core@1.9.1':
-    resolution: {integrity: sha512-dt3ic7gMswz4p/qdkYPVJwXlLiLsz55rBBn2I7mr0HTG8pCoLRqnANJIwo5WrqGBZgPyVSMPBqBra6VxLWfDyA==}
-    engines: {node: '>=18.0.0'}
+  '@codecov/bundler-plugin-core@2.0.1':
+    resolution: {integrity: sha512-TkdKn/rEwZQ723M7DDUmHe5r0IJa23rUT4TAx5jXmg12wGZGAHGWWU7LKeQsYCsKdLMxK7bLaGk9M++4wSRD5w==}
+    engines: {node: '>=20.0.0'}
+
+  '@codecov/rollup-plugin@2.0.1':
+    resolution: {integrity: sha512-psw9wzLGKyKfQU2rszJwtnmEqlbvaptGzg36RRkKKv3Sib0swLojhgXRFeeUe8nXIFwwTwCKsnAY9/ypaMcv8w==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      rollup: 3.x || 4.x
+
+  '@codecov/sveltekit-plugin@2.0.1':
+    resolution: {integrity: sha512-Dh3NnuT1lvys/NMb26W6j/EZ5aIdgIyPCN4oAGME4AIOrhqOe+eDNLxqDzzYZGHBT6F5LJHyCnWfCblNju9hjQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@sveltejs/kit': 2.x
+      svelte: 4.x || 5.x
+
+  '@codecov/vite-plugin@2.0.1':
+    resolution: {integrity: sha512-w7nGA9SSc0WECzn05yRrw3uN8293I620Kd9x97I0kyyxUjtWxCMmlgmAbS364gJZYvljd0A6iQyAigVV2dOX9A==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      vite: 4.x || 5.x || 6.x
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -2033,10 +2064,6 @@ packages:
     resolution: {integrity: sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@fastify/busboy@2.1.1':
-    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
-    engines: {node: '>=14'}
-
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
 
@@ -2406,53 +2433,47 @@ packages:
   '@nx/workspace@22.5.4':
     resolution: {integrity: sha512-TZeuCDy+VN/5zqMYxHw15HKe2Ppcb9WBOebz4bmXE206c8Aop3S9QeLfys00Uobt9ZaYh9QUeN0iFsZm7TNv0w==}
 
-  '@octokit/auth-token@4.0.0':
-    resolution: {integrity: sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==}
-    engines: {node: '>= 18'}
+  '@octokit/auth-token@6.0.0':
+    resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
+    engines: {node: '>= 20'}
 
-  '@octokit/core@5.2.2':
-    resolution: {integrity: sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==}
-    engines: {node: '>= 18'}
+  '@octokit/core@7.0.6':
+    resolution: {integrity: sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==}
+    engines: {node: '>= 20'}
 
-  '@octokit/endpoint@9.0.6':
-    resolution: {integrity: sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==}
-    engines: {node: '>= 18'}
+  '@octokit/endpoint@11.0.3':
+    resolution: {integrity: sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==}
+    engines: {node: '>= 20'}
 
-  '@octokit/graphql@7.1.1':
-    resolution: {integrity: sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==}
-    engines: {node: '>= 18'}
+  '@octokit/graphql@9.0.3':
+    resolution: {integrity: sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==}
+    engines: {node: '>= 20'}
 
-  '@octokit/openapi-types@20.0.0':
-    resolution: {integrity: sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==}
+  '@octokit/openapi-types@27.0.0':
+    resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
 
-  '@octokit/openapi-types@24.2.0':
-    resolution: {integrity: sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==}
-
-  '@octokit/plugin-paginate-rest@9.2.2':
-    resolution: {integrity: sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==}
-    engines: {node: '>= 18'}
+  '@octokit/plugin-paginate-rest@14.0.0':
+    resolution: {integrity: sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==}
+    engines: {node: '>= 20'}
     peerDependencies:
-      '@octokit/core': '5'
+      '@octokit/core': '>=6'
 
-  '@octokit/plugin-rest-endpoint-methods@10.4.1':
-    resolution: {integrity: sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==}
-    engines: {node: '>= 18'}
+  '@octokit/plugin-rest-endpoint-methods@17.0.0':
+    resolution: {integrity: sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==}
+    engines: {node: '>= 20'}
     peerDependencies:
-      '@octokit/core': '5'
+      '@octokit/core': '>=6'
 
-  '@octokit/request-error@5.1.1':
-    resolution: {integrity: sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==}
-    engines: {node: '>= 18'}
+  '@octokit/request-error@7.1.0':
+    resolution: {integrity: sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==}
+    engines: {node: '>= 20'}
 
-  '@octokit/request@8.4.1':
-    resolution: {integrity: sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==}
-    engines: {node: '>= 18'}
+  '@octokit/request@10.0.9':
+    resolution: {integrity: sha512-o8Bi3f608eyM+7BmBiUWxFsdjLb3/ym1cQek5LZOv9KkZcxRrHCPhhRzm6xjO6HVZ85ItD6+sTsjxo821SVa/A==}
+    engines: {node: '>= 20'}
 
-  '@octokit/types@12.6.0':
-    resolution: {integrity: sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==}
-
-  '@octokit/types@13.10.0':
-    resolution: {integrity: sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==}
+  '@octokit/types@16.0.0':
+    resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
@@ -3656,6 +3677,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vercel/nft@1.3.2':
     resolution: {integrity: sha512-HC8venRc4Ya7vNeBsJneKHHMDDWpQie7VaKhAIOst3MKO+DES+Y/SbzSp8mFkD7OzwAE2HhHkeSuSmwS20mz3A==}
@@ -4046,8 +4068,8 @@ packages:
     resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
     engines: {node: '>= 0.8'}
 
-  before-after-hook@2.2.3:
-    resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
+  before-after-hook@4.0.0:
+    resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -4364,6 +4386,10 @@ packages:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
 
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   conventional-changelog-angular@7.0.0:
     resolution: {integrity: sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==}
     engines: {node: '>=16'}
@@ -4629,9 +4655,6 @@ packages:
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
-
-  deprecation@2.3.1:
-    resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -5051,6 +5074,9 @@ packages:
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
+
+  fast-content-type-parse@3.0.0:
+    resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -5725,6 +5751,9 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json-with-bigint@3.5.8:
+    resolution: {integrity: sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -7660,9 +7689,9 @@ packages:
   undici-types@7.10.0:
     resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
 
-  undici@5.29.0:
-    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
-    engines: {node: '>=14.0'}
+  undici@6.25.0:
+    resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
+    engines: {node: '>=18.17'}
 
   unenv@1.10.0:
     resolution: {integrity: sha512-wY5bskBQFL9n3Eca5XnhH6KbUo/tfvkwm9OpcdCvLaeA7piBNbavbOKJySEwQ1V0RH6HvNlSAFRTpvTqgKRQXQ==}
@@ -7721,8 +7750,8 @@ packages:
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
-  universal-user-agent@6.0.1:
-    resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==}
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -8228,31 +8257,36 @@ packages:
 
 snapshots:
 
-  '@actions/core@1.11.1':
+  '@actions/core@3.0.1':
     dependencies:
-      '@actions/exec': 1.1.1
-      '@actions/http-client': 2.2.3
+      '@actions/exec': 3.0.0
+      '@actions/http-client': 4.0.1
 
-  '@actions/exec@1.1.1':
+  '@actions/exec@3.0.0':
     dependencies:
-      '@actions/io': 1.1.3
+      '@actions/io': 3.0.2
 
-  '@actions/github@6.0.1':
+  '@actions/github@9.1.1':
     dependencies:
-      '@actions/http-client': 2.2.3
-      '@octokit/core': 5.2.2
-      '@octokit/plugin-paginate-rest': 9.2.2(@octokit/core@5.2.2)
-      '@octokit/plugin-rest-endpoint-methods': 10.4.1(@octokit/core@5.2.2)
-      '@octokit/request': 8.4.1
-      '@octokit/request-error': 5.1.1
-      undici: 5.29.0
+      '@actions/http-client': 3.0.2
+      '@octokit/core': 7.0.6
+      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)
+      '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
+      '@octokit/request': 10.0.9
+      '@octokit/request-error': 7.1.0
+      undici: 6.25.0
 
-  '@actions/http-client@2.2.3':
+  '@actions/http-client@3.0.2':
     dependencies:
       tunnel: 0.0.6
-      undici: 5.29.0
+      undici: 6.25.0
 
-  '@actions/io@1.1.3': {}
+  '@actions/http-client@4.0.1':
+    dependencies:
+      tunnel: 0.0.6
+      undici: 6.25.0
+
+  '@actions/io@3.0.2': {}
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -9288,20 +9322,42 @@ snapshots:
 
   '@cloudflare/kv-asset-handler@0.4.2': {}
 
-  '@codecov/bundle-analyzer@1.9.1':
+  '@codecov/bundle-analyzer@2.0.1':
     dependencies:
-      '@codecov/bundler-plugin-core': 1.9.1
+      '@codecov/bundler-plugin-core': 2.0.1
       micromatch: 4.0.8
       yargs: 17.7.2
 
-  '@codecov/bundler-plugin-core@1.9.1':
+  '@codecov/bundler-plugin-core@2.0.1':
     dependencies:
-      '@actions/core': 1.11.1
-      '@actions/github': 6.0.1
+      '@actions/core': 3.0.1
+      '@actions/github': 9.1.1
       chalk: 4.1.2
       semver: 7.7.3
       unplugin: 1.16.1
       zod: 3.25.76
+
+  '@codecov/rollup-plugin@2.0.1(rollup@4.59.0)':
+    dependencies:
+      '@codecov/bundler-plugin-core': 2.0.1
+      rollup: 4.59.0
+      unplugin: 1.16.1
+
+  '@codecov/sveltekit-plugin@2.0.1(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.55.5)(typescript@5.9.3)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.55.5)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))':
+    dependencies:
+      '@codecov/bundler-plugin-core': 2.0.1
+      '@codecov/vite-plugin': 2.0.1(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      '@sveltejs/kit': 2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.55.5)(typescript@5.9.3)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      svelte: 5.55.5
+      unplugin: 1.16.1
+    transitivePeerDependencies:
+      - vite
+
+  '@codecov/vite-plugin@2.0.1(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))':
+    dependencies:
+      '@codecov/bundler-plugin-core': 2.0.1
+      unplugin: 1.16.1
+      vite: 7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
 
   '@colors/colors@1.5.0':
     optional: true
@@ -9756,8 +9812,6 @@ snapshots:
     dependencies:
       '@eslint/core': 0.15.1
       levn: 0.4.1
-
-  '@fastify/busboy@2.1.1': {}
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -10299,63 +10353,58 @@ snapshots:
       - '@swc/core'
       - debug
 
-  '@octokit/auth-token@4.0.0': {}
+  '@octokit/auth-token@6.0.0': {}
 
-  '@octokit/core@5.2.2':
+  '@octokit/core@7.0.6':
     dependencies:
-      '@octokit/auth-token': 4.0.0
-      '@octokit/graphql': 7.1.1
-      '@octokit/request': 8.4.1
-      '@octokit/request-error': 5.1.1
-      '@octokit/types': 13.10.0
-      before-after-hook: 2.2.3
-      universal-user-agent: 6.0.1
+      '@octokit/auth-token': 6.0.0
+      '@octokit/graphql': 9.0.3
+      '@octokit/request': 10.0.9
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      before-after-hook: 4.0.0
+      universal-user-agent: 7.0.3
 
-  '@octokit/endpoint@9.0.6':
+  '@octokit/endpoint@11.0.3':
     dependencies:
-      '@octokit/types': 13.10.0
-      universal-user-agent: 6.0.1
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
 
-  '@octokit/graphql@7.1.1':
+  '@octokit/graphql@9.0.3':
     dependencies:
-      '@octokit/request': 8.4.1
-      '@octokit/types': 13.10.0
-      universal-user-agent: 6.0.1
+      '@octokit/request': 10.0.9
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
 
-  '@octokit/openapi-types@20.0.0': {}
+  '@octokit/openapi-types@27.0.0': {}
 
-  '@octokit/openapi-types@24.2.0': {}
-
-  '@octokit/plugin-paginate-rest@9.2.2(@octokit/core@5.2.2)':
+  '@octokit/plugin-paginate-rest@14.0.0(@octokit/core@7.0.6)':
     dependencies:
-      '@octokit/core': 5.2.2
-      '@octokit/types': 12.6.0
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
 
-  '@octokit/plugin-rest-endpoint-methods@10.4.1(@octokit/core@5.2.2)':
+  '@octokit/plugin-rest-endpoint-methods@17.0.0(@octokit/core@7.0.6)':
     dependencies:
-      '@octokit/core': 5.2.2
-      '@octokit/types': 12.6.0
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
 
-  '@octokit/request-error@5.1.1':
+  '@octokit/request-error@7.1.0':
     dependencies:
-      '@octokit/types': 13.10.0
-      deprecation: 2.3.1
-      once: 1.4.0
+      '@octokit/types': 16.0.0
 
-  '@octokit/request@8.4.1':
+  '@octokit/request@10.0.9':
     dependencies:
-      '@octokit/endpoint': 9.0.6
-      '@octokit/request-error': 5.1.1
-      '@octokit/types': 13.10.0
-      universal-user-agent: 6.0.1
+      '@octokit/endpoint': 11.0.3
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      content-type: 2.0.0
+      fast-content-type-parse: 3.0.0
+      json-with-bigint: 3.5.8
+      universal-user-agent: 7.0.3
 
-  '@octokit/types@12.6.0':
+  '@octokit/types@16.0.0':
     dependencies:
-      '@octokit/openapi-types': 20.0.0
-
-  '@octokit/types@13.10.0':
-    dependencies:
-      '@octokit/openapi-types': 24.2.0
+      '@octokit/openapi-types': 27.0.0
 
   '@open-draft/deferred-promise@2.2.0':
     optional: true
@@ -11111,6 +11160,26 @@ snapshots:
     dependencies:
       '@sveltejs/kit': 2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.55.5)(typescript@5.9.3)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
 
+  '@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.55.5)(typescript@5.9.3)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))':
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      '@types/cookie': 0.6.0
+      acorn: 8.16.0
+      cookie: 0.6.0
+      devalue: 5.6.4
+      esm-env: 1.2.2
+      kleur: 4.1.5
+      magic-string: 0.30.21
+      mrmime: 2.0.1
+      set-cookie-parser: 3.1.0
+      sirv: 3.0.2
+      svelte: 5.55.5
+      vite: 7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.55.5)(typescript@5.9.3)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
       '@standard-schema/spec': 1.0.0
@@ -11131,12 +11200,29 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.55.5)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      obug: 2.1.1
+      svelte: 5.55.5
+      vite: 7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+
   '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.55.5)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
       obug: 2.1.1
       svelte: 5.55.5
       vite: 7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+
+  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.55.5)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      deepmerge: 4.3.1
+      magic-string: 0.30.21
+      obug: 2.1.1
+      svelte: 5.55.5
+      vite: 7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      vitefu: 1.1.1(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
 
   '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
@@ -11833,7 +11919,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.18(@types/node@22.18.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
 
   '@vitest/utils@4.0.18':
     dependencies:
@@ -12151,7 +12237,7 @@ snapshots:
     dependencies:
       safe-buffer: 5.1.2
 
-  before-after-hook@2.2.3: {}
+  before-after-hook@4.0.0: {}
 
   binary-extensions@2.3.0: {}
 
@@ -12486,6 +12572,8 @@ snapshots:
 
   content-type@1.0.5: {}
 
+  content-type@2.0.0: {}
+
   conventional-changelog-angular@7.0.0:
     dependencies:
       compare-func: 2.0.0
@@ -12644,8 +12732,6 @@ snapshots:
   denque@2.1.0: {}
 
   depd@2.0.0: {}
-
-  deprecation@2.3.1: {}
 
   dequal@2.0.3: {}
 
@@ -13063,6 +13149,8 @@ snapshots:
       - supports-color
 
   exsolve@1.0.8: {}
+
+  fast-content-type-parse@3.0.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -13740,6 +13828,8 @@ snapshots:
   json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json-with-bigint@3.5.8: {}
 
   json5@2.2.3: {}
 
@@ -15987,9 +16077,7 @@ snapshots:
   undici-types@7.10.0:
     optional: true
 
-  undici@5.29.0:
-    dependencies:
-      '@fastify/busboy': 2.1.1
+  undici@6.25.0: {}
 
   unenv@1.10.0:
     dependencies:
@@ -16062,7 +16150,7 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  universal-user-agent@6.0.1: {}
+  universal-user-agent@7.0.3: {}
 
   unpipe@1.0.0: {}
 
@@ -16413,6 +16501,10 @@ snapshots:
   vitefu@1.1.1(vite@7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)):
     optionalDependencies:
       vite: 7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+
+  vitefu@1.1.1(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)):
+    optionalDependencies:
+      vite: 7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
 
   vitefu@1.1.1(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)):
     optionalDependencies:


### PR DESCRIPTION
## Summary

Refactor del setup Codecov en tres frentes, tras auditoría de cómo se está trackeando coverage y bundle en las PRs.

- **CI**: 28 steps hand-rolled de `codecov/codecov-action` + `codecov/test-results-action` → un solo job `upload-codecov` con `strategy.matrix`. Lista de paquetes vive en un único sitio. `ci.yml` pasa de 473 → 314 líneas.
- **Bundle tracking en apps**: las apps (`demo`, `wealth-react`, `green-beard`, `qup-web`, `qup-api`, `investlab`) no se medían. Integrados los plugins oficiales de Codecov por stack: `@codecov/vite-plugin`, `@codecov/sveltekit-plugin`, `@codecov/rollup-plugin`. Plugins son no-op si `CODECOV_TOKEN` no está definido (dev local intacto).
- **`react-hooks` falsa-negativa**: en últimas PRs el flag `react-hooks` aparecía "no coverage info on head" pese a tener tests. Causa: `vitest.config.ts` incluía `.browser.test.*` e `.integration.ts` en el mismo `include`, así que `test:unit:coverage` los recogía sin `--browser.enabled`. Restringido el `include` por defecto a unit tests; los scripts `test:browser` y `test:integration` siguen funcionando porque pasan el pattern por CLI.

Detalles:
- `codecov.yaml` extendido con ignore patterns que faltaban (`vitest.setup.ts`, `stryker.config.*`, `tsdown.config.*`, `drizzle.config.*`, `*.config.tsx`, `setup.ts`).
- `CODECOV_TOKEN` propagado al step `🏗 Execute build checks` para que los plugins de apps puedan uploadear durante el build.
- `@codecov/bundle-analyzer` bumpeado 1.9.1 → 2.0.1 por consistencia con los nuevos plugins.

## Trade-offs / a tener en cuenta

- **Branch protection**: el split job cambia los nombres de los GH Actions status checks (antes `main`, ahora `main` + 14 `upload-codecov (<flag>)`). Si tienes "Require status checks" en Settings → Branches, hay que actualizarlo tras mergear.
- **Peer-dep skew**: `@codecov/vite-plugin@2.0.1` declara `vite@^6` pero el workspace tiene también `vite@7` (green-beard). Cast a `PluginOption` con comentario; dropear cuando upstream amplíe peer range.
- **+20–40s wall clock** por el upload/download de artifacts entre el job `main` y `upload-codecov`. Aceptable.

## Test plan

- [ ] Verificar que el job `main` corre y emite el artifact `codecov-artifacts`.
- [ ] Verificar que el job `upload-codecov` ejecuta 14 matrix entries; en esta PR (no toca paquetes con tests), todos los gate steps deben dar `should_upload=false` o el upload de los afectados.
- [ ] Confirmar que aparecen los status checks `codecov/project/*`, `codecov/patch/*`, `codecov/bundles` igual que antes.
- [ ] Tras merge, abrir PR de prueba tocando `apps/wealth-react/app/*` y verificar que aparece `wealth-react` en el dashboard de bundles de Codecov.
- [ ] Verificar que `react-hooks` deja de mostrar "no coverage info on head" en próximas PRs que la toquen.
- [ ] Actualizar branch protection rules si aplica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now generates a single affected map, stores a short-lived artifact, and fans out per-package coverage/test uploads via a matrix
  * Added conditional bundle-analysis plugins to multiple app build configs (enabled when a token is present)
  * Upgraded Codecov tooling to 2.0.1
  * Refined coverage ignore patterns and PR comment layout
  * Normalized test exclude and build config formatting for consistency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pabloimrik17/monolab/pull/219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->