### PR TITLE
chore(deps): patch-level dependency updates

### DIFF
--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -16,7 +16,7 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "solid-js": "1.9.12"
+        "solid-js": "1.9.13"
     },
     "devDependencies": {
         "typescript": "5.9.3",

--- a/apps/green-beard/package.json
+++ b/apps/green-beard/package.json
@@ -20,10 +20,10 @@
         "@sveltejs/kit": "2.55.0",
         "@sveltejs/vite-plugin-svelte": "6.2.4",
         "@vitest/coverage-v8": "catalog:",
-        "svelte": "5.55.5",
-        "svelte-check": "4.4.6",
+        "svelte": "5.55.9",
+        "svelte-check": "4.4.8",
         "typescript": "5.9.3",
-        "vite": "7.3.2",
+        "vite": "7.3.3",
         "vitest": "catalog:"
     }
 }

--- a/apps/qup-api/package.json
+++ b/apps/qup-api/package.json
@@ -19,14 +19,14 @@
         "@m0n0lab/qup-domain": "workspace:*",
         "@m0n0lab/qup-shared": "workspace:*",
         "drizzle-orm": "0.44.7",
-        "hono": "4.12.15",
+        "hono": "4.12.22",
         "inversify": "7.11.0",
         "pg": "8.16.3"
     },
     "devDependencies": {
         "@types/node": "22.18.13",
         "tsdown": "0.15.12",
-        "tsx": "4.21.0",
+        "tsx": "4.21.1",
         "typescript": "5.9.3",
         "vitest": "catalog:"
     },

--- a/apps/qup-web/package.json
+++ b/apps/qup-web/package.json
@@ -18,14 +18,14 @@
         "@solidjs/router": "0.15.4",
         "@solidjs/start": "1.3.2",
         "inversify": "7.11.0",
-        "solid-js": "1.9.12",
+        "solid-js": "1.9.13",
         "vinxi": "0.5.11"
     },
     "devDependencies": {
         "@types/node": "22.18.13",
         "@vitest/coverage-v8": "catalog:",
         "autoprefixer": "10.4.27",
-        "postcss": "8.5.12",
+        "postcss": "8.5.15",
         "tailwindcss": "3.4.19",
         "typescript": "5.9.3",
         "vitest": "catalog:"

--- a/apps/wealth-react/package.json
+++ b/apps/wealth-react/package.json
@@ -17,8 +17,8 @@
     },
     "dependencies": {
         "@m0n0lab/wealth-tracker-core": "workspace:*",
-        "react": "19.2.5",
-        "react-dom": "19.2.5",
+        "react": "19.2.6",
+        "react-dom": "19.2.6",
         "react-router": "7.13.2"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "@stryker-mutator/typescript-checker": "9.3.0",
         "@stryker-mutator/vitest-runner": "9.3.0",
         "@swc-node/register": "1.11.1",
-        "@swc/core": "1.15.32",
+        "@swc/core": "1.15.40",
         "@swc/helpers": "0.5.21",
         "@types/node": "22.18.13",
         "@vitejs/plugin-react-swc": "4.2.3",

--- a/packages/react-clean/package.json
+++ b/packages/react-clean/package.json
@@ -65,7 +65,7 @@
         "@arethetypeswrong/cli": "0.18.2",
         "@m0n0lab/ts-types": "workspace:*",
         "@testing-library/react": "catalog:",
-        "@types/react": "18.3.28",
+        "@types/react": "18.3.29",
         "inversify": "7.11.0",
         "jsdom": "catalog:",
         "react": "18.3.1",

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -63,7 +63,7 @@
     "devDependencies": {
         "@arethetypeswrong/cli": "0.18.2",
         "@testing-library/react": "catalog:",
-        "@types/react": "18.3.28",
+        "@types/react": "18.3.29",
         "jsdom": "catalog:",
         "react": "18.3.1",
         "react-dom": "18.3.1",

--- a/packages/solid-clean/package.json
+++ b/packages/solid-clean/package.json
@@ -49,7 +49,7 @@
         "@stryker-mutator/typescript-checker": "9.3.0",
         "@stryker-mutator/vitest-runner": "9.3.0",
         "jsdom": "catalog:",
-        "solid-js": "1.9.12",
+        "solid-js": "1.9.13",
         "tsdown": "0.15.12",
         "typescript": "5.9.3",
         "vite-plugin-solid": "2.11.12",

--- a/packages/solid-clean/package.json
+++ b/packages/solid-clean/package.json
@@ -56,7 +56,7 @@
         "vitest": "catalog:"
     },
     "peerDependencies": {
-        "solid-js": "1.9.12"
+        "solid-js": ">=1.0.0 <2.0.0"
     },
     "engines": {
         "node": ">=22.0.0",

--- a/patches/@codecov__sveltekit-plugin@2.0.1.patch
+++ b/patches/@codecov__sveltekit-plugin@2.0.1.patch
@@ -1,0 +1,38 @@
+diff --git a/dist/index.cjs b/dist/index.cjs
+index 32a1eb15b52ffe4607d402e263515e56c2982a8c..0c8c76014e5de4004c939a212fec5d160d7b6d81 100644
+--- a/dist/index.cjs
++++ b/dist/index.cjs
+@@ -5,6 +5,14 @@ const bundlerPluginCore = require('@codecov/bundler-plugin-core');
+ const vitePlugin = require('@codecov/vite-plugin');
+ 
+ function getBundleName(initialName = "", initialDir = "", format, name) {
++  // monolab patch: SvelteKit's internal rollup outputs carry names like
++  // `__sveltekit_<hash>.app` where <hash> rotates on every dep bump, so the
++  // upstream bundle id ends up unstable. Strip the prefix so Codecov sees a
++  // stable identifier across builds. Upstream context: getBundleName has no
++  // hook for customizing this concat, and codecovSvelteKitPlugin's Options
++  // surface (apiUrl, gitService, uploadToken, bundleName, ...) doesn't expose
++  // anything for it either.
++  if (typeof name === "string") name = name.replace(/^__sveltekit_[a-z0-9]+\./, "");
+   let bundleName = name ? `${initialName}-${name}` : initialName;
+   const dir = initialDir.includes("server") ? "server" : initialDir.includes("client") ? "client" : void 0;
+   if (dir) {
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 28cbe2d5b73463e933235462036c6ce5f49dcd7e..d69f6d1f755d92e70b81fc647a53bdb0ff24d84f 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -3,6 +3,14 @@ import { red, checkNodeVersion, normalizeOptions, handleErrors, createSentryInst
+ import { _internal_viteBundleAnalysisPlugin } from '@codecov/vite-plugin';
+ 
+ function getBundleName(initialName = "", initialDir = "", format, name) {
++  // monolab patch: SvelteKit's internal rollup outputs carry names like
++  // `__sveltekit_<hash>.app` where <hash> rotates on every dep bump, so the
++  // upstream bundle id ends up unstable. Strip the prefix so Codecov sees a
++  // stable identifier across builds. Upstream context: getBundleName has no
++  // hook for customizing this concat, and codecovSvelteKitPlugin's Options
++  // surface (apiUrl, gitService, uploadToken, bundleName, ...) doesn't expose
++  // anything for it either.
++  if (typeof name === "string") name = name.replace(/^__sveltekit_[a-z0-9]+\./, "");
+   let bundleName = name ? `${initialName}-${name}` : initialName;
+   const dir = initialDir.includes("server") ? "server" : initialDir.includes("client") ? "client" : void 0;
+   if (dir) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,11 @@ catalogs:
       specifier: 4.0.18
       version: 4.0.18
 
+patchedDependencies:
+  '@codecov/sveltekit-plugin@2.0.1':
+    hash: 23c48f14215f2705cce4626826df1c47ba96d7f2b702ba7bfac4f3d0a9b97438
+    path: patches/@codecov__sveltekit-plugin@2.0.1.patch
+
 importers:
 
   .:
@@ -37,7 +42,7 @@ importers:
         version: 2.0.1(rollup@4.59.0)
       '@codecov/sveltekit-plugin':
         specifier: 2.0.1
-        version: 2.0.1(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)))(svelte@5.55.9(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)))(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
+        version: 2.0.1(patch_hash=23c48f14215f2705cce4626826df1c47ba96d7f2b702ba7bfac4f3d0a9b97438)(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)))(svelte@5.55.9(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)))(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
       '@codecov/vite-plugin':
         specifier: 2.0.1
         version: 2.0.1(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
@@ -9405,7 +9410,7 @@ snapshots:
       rollup: 4.59.0
       unplugin: 1.16.1
 
-  '@codecov/sveltekit-plugin@2.0.1(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)))(svelte@5.55.9(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)))(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))':
+  '@codecov/sveltekit-plugin@2.0.1(patch_hash=23c48f14215f2705cce4626826df1c47ba96d7f2b702ba7bfac4f3d0a9b97438)(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)))(svelte@5.55.9(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)))(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))':
     dependencies:
       '@codecov/bundler-plugin-core': 2.0.1
       '@codecov/vite-plugin': 2.0.1(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,10 +37,10 @@ importers:
         version: 2.0.1(rollup@4.59.0)
       '@codecov/sveltekit-plugin':
         specifier: 2.0.1
-        version: 2.0.1(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.55.5)(typescript@5.9.3)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.55.5)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+        version: 2.0.1(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)))(svelte@5.55.9(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)))(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
       '@codecov/vite-plugin':
         specifier: 2.0.1
-        version: 2.0.1(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+        version: 2.0.1(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
       '@commitlint/cli':
         specifier: 19.8.1
         version: 19.8.1(@types/node@22.18.13)(typescript@5.9.3)
@@ -55,7 +55,7 @@ importers:
         version: 9.32.0
       '@nx/js':
         specifier: 22.5.4
-        version: 22.5.4(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.32(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.32(@swc/helpers@0.5.21))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.32(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.32(@swc/helpers@0.5.21)))
+        version: 22.5.4(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.21))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.21)))
       '@stryker-mutator/core':
         specifier: 9.3.0
         version: 9.3.0(@types/node@22.18.13)
@@ -67,10 +67,10 @@ importers:
         version: 9.3.0(@stryker-mutator/core@9.3.0(@types/node@22.18.13))(vitest@4.0.18)
       '@swc-node/register':
         specifier: 1.11.1
-        version: 1.11.1(@swc/core@1.15.32(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3)
+        version: 1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3)
       '@swc/core':
-        specifier: 1.15.32
-        version: 1.15.32(@swc/helpers@0.5.21)
+        specifier: 1.15.40
+        version: 1.15.40(@swc/helpers@0.5.21)
       '@swc/helpers':
         specifier: 0.5.21
         version: 0.5.21
@@ -79,16 +79,16 @@ importers:
         version: 22.18.13
       '@vitejs/plugin-react-swc':
         specifier: 4.2.3
-        version: 4.2.3(@swc/helpers@0.5.21)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+        version: 4.2.3(@swc/helpers@0.5.21)(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
       '@vitest/browser':
         specifier: 4.0.18
-        version: 4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
+        version: 4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vitest@4.0.18)
       '@vitest/browser-playwright':
         specifier: 4.0.18
-        version: 4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(playwright@1.56.1)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
+        version: 4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(playwright@1.56.1)(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vitest@4.0.18)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.0.18(@vitest/browser@4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18))(vitest@4.0.18)
+        version: 4.0.18(@vitest/browser@4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vitest@4.0.18))(vitest@4.0.18)
       '@vitest/ui':
         specifier: 'catalog:'
         version: 4.0.18(vitest@4.0.18)
@@ -118,7 +118,7 @@ importers:
         version: runtime:24.12.0
       nx:
         specifier: 22.5.4
-        version: 22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.32(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.32(@swc/helpers@0.5.21))
+        version: 22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.21))
       oxfmt:
         specifier: 0.36.0
         version: 0.36.0
@@ -145,29 +145,29 @@ importers:
         version: 1.3.2(typescript@5.9.3)
       vite-tsconfig-paths:
         specifier: 'catalog:'
-        version: 5.1.4(typescript@5.9.3)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+        version: 5.1.4(typescript@5.9.3)(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@22.18.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.18(@types/node@22.18.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
       vitest-browser-react:
         specifier: 2.0.5
-        version: 2.0.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.18)
+        version: 2.0.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.0.18)
 
   apps/demo:
     dependencies:
       solid-js:
-        specifier: 1.9.12
-        version: 1.9.12
+        specifier: 1.9.13
+        version: 1.9.13
     devDependencies:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
       vite:
         specifier: 6.4.2
-        version: 6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
       vite-plugin-solid:
         specifier: 2.11.12
-        version: 2.11.12(solid-js@1.9.12)(vite@6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+        version: 2.11.12(solid-js@1.9.13)(vite@6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
 
   apps/green-beard:
     devDependencies:
@@ -176,31 +176,31 @@ importers:
         version: link:../../packages/ts-configs
       '@sveltejs/adapter-auto':
         specifier: 7.0.1
-        version: 7.0.1(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.55.5)(typescript@5.9.3)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)))
+        version: 7.0.1(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)))(svelte@5.55.9(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)))
       '@sveltejs/kit':
         specifier: 2.55.0
-        version: 2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.55.5)(typescript@5.9.3)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+        version: 2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)))(svelte@5.55.9(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
       '@sveltejs/vite-plugin-svelte':
         specifier: 6.2.4
-        version: 6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+        version: 6.2.4(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.0.18(@vitest/browser@4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18))(vitest@4.0.18)
+        version: 4.0.18(@vitest/browser@4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vitest@4.0.18))(vitest@4.0.18)
       svelte:
-        specifier: 5.55.5
-        version: 5.55.5
+        specifier: 5.55.9
+        version: 5.55.9(@typescript-eslint/types@8.56.1)
       svelte-check:
-        specifier: 4.4.6
-        version: 4.4.6(picomatch@4.0.3)(svelte@5.55.5)(typescript@5.9.3)
+        specifier: 4.4.8
+        version: 4.4.8(picomatch@4.0.3)(svelte@5.55.9(@typescript-eslint/types@8.56.1))(typescript@5.9.3)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: 7.3.2
-        version: 7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        specifier: 7.3.3
+        version: 7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
 
   apps/investlab:
     dependencies:
@@ -240,13 +240,13 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
 
   apps/qup-api:
     dependencies:
       '@hono/node-server':
         specifier: 1.14.4
-        version: 1.14.4(hono@4.12.15)
+        version: 1.14.4(hono@4.12.22)
       '@m0n0lab/qup-data':
         specifier: workspace:*
         version: link:../../packages/qup-data
@@ -260,8 +260,8 @@ importers:
         specifier: 0.44.7
         version: 0.44.7(@types/pg@8.15.6)(pg@8.16.3)
       hono:
-        specifier: 4.12.15
-        version: 4.12.15
+        specifier: 4.12.22
+        version: 4.12.22
       inversify:
         specifier: 7.11.0
         version: 7.11.0(reflect-metadata@0.2.2)
@@ -276,20 +276,20 @@ importers:
         specifier: 0.15.12
         version: 0.15.12(@arethetypeswrong/core@0.18.2)(oxc-resolver@11.6.1)(typescript@5.9.3)
       tsx:
-        specifier: 4.21.0
-        version: 4.21.0
+        specifier: 4.21.1
+        version: 4.21.1
       typescript:
         specifier: 5.9.3
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@22.18.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.18(@types/node@22.18.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
 
   apps/qup-web:
     dependencies:
       '@kobalte/core':
         specifier: 0.13.11
-        version: 0.13.11(solid-js@1.9.12)
+        version: 0.13.11(solid-js@1.9.13)
       '@m0n0lab/qup-shared':
         specifier: workspace:*
         version: link:../../packages/qup-shared
@@ -298,41 +298,41 @@ importers:
         version: link:../../packages/solid-clean
       '@solidjs/router':
         specifier: 0.15.4
-        version: 0.15.4(solid-js@1.9.12)
+        version: 0.15.4(solid-js@1.9.13)
       '@solidjs/start':
         specifier: 1.3.2
-        version: 1.3.2(solid-js@1.9.12)(vinxi@0.5.11(@types/node@22.18.13)(db0@0.3.4(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3)))(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3))(ioredis@5.10.0)(jiti@1.21.7)(rolldown@1.0.0-beta.45)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vite@7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+        version: 1.3.2(solid-js@1.9.13)(vinxi@0.5.11(@types/node@22.18.13)(db0@0.3.4(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3)))(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3))(ioredis@5.10.0)(jiti@1.21.7)(rolldown@1.0.0-beta.45)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vite@7.3.3(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
       inversify:
         specifier: 7.11.0
         version: 7.11.0(reflect-metadata@0.2.2)
       solid-js:
-        specifier: 1.9.12
-        version: 1.9.12
+        specifier: 1.9.13
+        version: 1.9.13
       vinxi:
         specifier: 0.5.11
-        version: 0.5.11(@types/node@22.18.13)(db0@0.3.4(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3)))(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3))(ioredis@5.10.0)(jiti@1.21.7)(rolldown@1.0.0-beta.45)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 0.5.11(@types/node@22.18.13)(db0@0.3.4(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3)))(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3))(ioredis@5.10.0)(jiti@1.21.7)(rolldown@1.0.0-beta.45)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
     devDependencies:
       '@types/node':
         specifier: 22.18.13
         version: 22.18.13
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.0.18(@vitest/browser@4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18))(vitest@4.0.18)
+        version: 4.0.18(@vitest/browser@4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.3(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vitest@4.0.18))(vitest@4.0.18)
       autoprefixer:
         specifier: 10.4.27
-        version: 10.4.27(postcss@8.5.12)
+        version: 10.4.27(postcss@8.5.15)
       postcss:
-        specifier: 8.5.12
-        version: 8.5.12
+        specifier: 8.5.15
+        version: 8.5.15
       tailwindcss:
         specifier: 3.4.19
-        version: 3.4.19(tsx@4.21.0)(yaml@2.8.1)
+        version: 3.4.19(tsx@4.21.1)(yaml@2.8.1)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@22.18.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@1.21.7)(jsdom@25.0.1)(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.18(@types/node@22.18.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@1.21.7)(jsdom@25.0.1)(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
 
   apps/wealth-react:
     dependencies:
@@ -340,24 +340,24 @@ importers:
         specifier: workspace:*
         version: link:../../packages/wealth-tracker-core
       react:
-        specifier: 19.2.5
-        version: 19.2.5
+        specifier: 19.2.6
+        version: 19.2.6
       react-dom:
-        specifier: 19.2.5
-        version: 19.2.5(react@19.2.5)
+        specifier: 19.2.6
+        version: 19.2.6(react@19.2.6)
       react-router:
         specifier: 7.13.2
-        version: 7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 7.13.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
       '@react-router/dev':
         specifier: 7.13.2
-        version: 7.13.2(@react-router/serve@7.13.2(react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3))(@types/node@24.2.0)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(yaml@2.8.1)
+        version: 7.13.2(@react-router/serve@7.13.2(react-router@7.13.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3))(@types/node@24.2.0)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(react-router@7.13.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(terser@5.46.0)(tsx@4.21.1)(typescript@5.9.3)(vite@6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(yaml@2.8.1)
       '@react-router/node':
         specifier: 7.13.2
-        version: 7.13.2(react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
+        version: 7.13.2(react-router@7.13.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
       '@react-router/serve':
         specifier: 7.13.2
-        version: 7.13.2(react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
+        version: 7.13.2(react-router@7.13.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
       '@types/react':
         specifier: ^19.0.14
         version: 19.2.14
@@ -366,16 +366,16 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.0.18(@vitest/browser@4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18))(vitest@4.0.18)
+        version: 4.0.18(@vitest/browser@4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vitest@4.0.18))(vitest@4.0.18)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
       vite:
         specifier: 6.4.2
-        version: 6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
 
   claude-plugins/experiments: {}
 
@@ -392,7 +392,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
 
   packages/investlab-core:
     dependencies:
@@ -420,7 +420,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
 
   packages/investlab-data:
     dependencies:
@@ -451,7 +451,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
 
   packages/investlab-domain:
     dependencies:
@@ -470,7 +470,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
 
   packages/qup-data:
     dependencies:
@@ -501,7 +501,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
 
   packages/qup-domain:
     dependencies:
@@ -529,7 +529,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
 
   packages/qup-shared:
     devDependencies:
@@ -538,7 +538,7 @@ importers:
         version: 0.18.2
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.0.18(@vitest/browser@4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18))(vitest@4.0.18)
+        version: 4.0.18(@vitest/browser@4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vitest@4.0.18))(vitest@4.0.18)
       tsdown:
         specifier: 0.15.12
         version: 0.15.12(@arethetypeswrong/core@0.18.2)(oxc-resolver@11.6.1)(typescript@5.9.3)
@@ -547,7 +547,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
 
   packages/react-clean:
     dependencies:
@@ -566,10 +566,10 @@ importers:
         version: link:../ts-types
       '@testing-library/react':
         specifier: 'catalog:'
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
-        specifier: 18.3.28
-        version: 18.3.28
+        specifier: 18.3.29
+        version: 18.3.29
       inversify:
         specifier: 7.11.0
         version: 7.11.0(reflect-metadata@0.2.2)
@@ -593,7 +593,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
 
   packages/react-hooks:
     dependencies:
@@ -606,10 +606,10 @@ importers:
         version: 0.18.2
       '@testing-library/react':
         specifier: 'catalog:'
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
-        specifier: 18.3.28
-        version: 18.3.28
+        specifier: 18.3.29
+        version: 18.3.29
       jsdom:
         specifier: 'catalog:'
         version: 25.0.1
@@ -627,7 +627,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
 
   packages/solid-clean:
     devDependencies:
@@ -647,8 +647,8 @@ importers:
         specifier: 'catalog:'
         version: 25.0.1
       solid-js:
-        specifier: 1.9.12
-        version: 1.9.12
+        specifier: 1.9.13
+        version: 1.9.13
       tsdown:
         specifier: 0.15.12
         version: 0.15.12(@arethetypeswrong/core@0.18.2)(oxc-resolver@11.6.1)(typescript@5.9.3)
@@ -657,10 +657,10 @@ importers:
         version: 5.9.3
       vite-plugin-solid:
         specifier: 2.11.12
-        version: 2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+        version: 2.11.12(solid-js@1.9.13)(vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
 
   packages/ts-configs:
     devDependencies:
@@ -679,7 +679,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
 
   packages/wealth-tracker-core:
     dependencies:
@@ -707,7 +707,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
 
 packages:
 
@@ -3329,6 +3329,11 @@ packages:
       '@stryker-mutator/core': 9.3.0
       vitest: '>=2.0.0'
 
+  '@sveltejs/acorn-typescript@1.0.10':
+    resolution: {integrity: sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==}
+    peerDependencies:
+      acorn: ^8.9.0
+
   '@sveltejs/acorn-typescript@1.0.9':
     resolution: {integrity: sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==}
     peerDependencies:
@@ -3386,86 +3391,86 @@ packages:
   '@swc-node/sourcemap-support@0.6.1':
     resolution: {integrity: sha512-ovltDVH5QpdHXZkW138vG4+dgcNsxfwxHVoV6BtmTbz2KKl1A8ZSlbdtxzzfNjCjbpayda8Us9eMtcHobm38dA==}
 
-  '@swc/core-darwin-arm64@1.15.32':
-    resolution: {integrity: sha512-/YWMvJDPu+AAwuUsM2G+DNQ/7zhodURGzdQyewEqcvgklAdDHs3LwQmLLnyn6SJl8DT8UOxkbzK+D1PmPeelRg==}
+  '@swc/core-darwin-arm64@1.15.40':
+    resolution: {integrity: sha512-PaYyclfmQ++77D8ityYvmmVzHv9aG8ROwt2GfG6/ccloy4Hgf80qtOnzb9VYvPsUT7Ty1uhuDRhv3XYpf62qhQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@swc/core-darwin-x64@1.15.32':
-    resolution: {integrity: sha512-KOTXJXdAhWL+hZ77MYP3z+4pcMFaQhQ74yqyN1uz093q0YnbxpqMtYpPISbYvMHzVRNNx5kN+9RZAXEaadhWVA==}
+  '@swc/core-darwin-x64@1.15.40':
+    resolution: {integrity: sha512-HbbPzvfLBUXjIB1Ezks+//lNUjmLjfyd63XSwprJgrZaXYdm70kohXPJUWdqKZozolFxbPaO+xtBaiUp6BoueA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
 
-  '@swc/core-linux-arm-gnueabihf@1.15.32':
-    resolution: {integrity: sha512-oOoxLweljlc0A4X8ybsgxV7cVaYTwBOg2iMDJcFR3Sr48C+lsv9VzSmqdK/IVIXF4W4GjLc3VqTAdSMXlfVLuQ==}
+  '@swc/core-linux-arm-gnueabihf@1.15.40':
+    resolution: {integrity: sha512-SlRZsCjOCPR2LvFs0Ri/Xrx/5o5TCt8vl4gW6mX1hEZOG0a625RxzRHpHdAQNGykmAN/7IeaFAJG+QnNmxlHcA==}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux]
 
-  '@swc/core-linux-arm64-gnu@1.15.32':
-    resolution: {integrity: sha512-oDzEkdl6D6BAWdMtU5KGO7y3HR5fJcvByNLyEk9+ugj8nP5Ovb7P4kBcStBXc4MPExFGQryehiINMlmY8HlclA==}
+  '@swc/core-linux-arm64-gnu@1.15.40':
+    resolution: {integrity: sha512-Q8byxJt2fh8CR3EUX6snBpy47AoBVm+In/+Z3rjDHMjC38ZvR9/gtUUNCT0tfrn4EdVsO8/QPi59nxrxvqxvBQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@swc/core-linux-arm64-musl@1.15.32':
-    resolution: {integrity: sha512-omcqjoZP/b8D8PuczVoRwJieC6ibj7qIxTftNYokz4/aSmKFHvsd7nIFfPk5ZvtzncbH4AY7+Dkr/Lp2gWxYeA==}
+  '@swc/core-linux-arm64-musl@1.15.40':
+    resolution: {integrity: sha512-4z0MgHU+7M0pZDqBN1El7mFXDI1SBwinfcUkAyA4v8QrhOIUOZltySt2aStQLZGrdXVXM4Y4ylfiTC04ED+MoQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@swc/core-linux-ppc64-gnu@1.15.32':
-    resolution: {integrity: sha512-KGkTMyz/Tbn3PBNu0AVZ4GTDFKnICrYcTiNPZq8DrvK42pnFsf3GNDrIG9E5AtQlTmC0YigkWKmu0eMcfTrmgA==}
+  '@swc/core-linux-ppc64-gnu@1.15.40':
+    resolution: {integrity: sha512-fLI4iUgeSZu0eRWUXwe6YzPFx9gHbFiPkl8Rp3mJfP8OpNR3nTQCGPvHdDh9xniW7mVvgMY4ni7A4VzqI1KrpA==}
     engines: {node: '>=10'}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@swc/core-linux-s390x-gnu@1.15.32':
-    resolution: {integrity: sha512-G3Aa4tVS/3OGZBkoNIwUF9F6RAy+Osb4GOlo62SinLmDiErz/ykmM7KH0wkz6l9kM8jJq1HyAM6atJTUEbBk7g==}
+  '@swc/core-linux-s390x-gnu@1.15.40':
+    resolution: {integrity: sha512-YqeKMAb7d4nQSGMJQ454IlaCENpzcDqhvBE9+CPfdnYpnUXxd+BSrB6Xk0YjW8UyoEhUj4p6quATCxbsp6J3jg==}
     engines: {node: '>=10'}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@swc/core-linux-x64-gnu@1.15.32':
-    resolution: {integrity: sha512-ERsjfGcj6CBmj3vJnGDO8m8rTvw6RqMcWo1dogOtNx3/+/0+NNpJiXDobJrr1GwInI/BHAEkvSFIH6d2LqPcUQ==}
+  '@swc/core-linux-x64-gnu@1.15.40':
+    resolution: {integrity: sha512-7HOuS1iGcme/j/TuL1TfmmLGiMQrjv/GmjyZeydl00FKPtpGXEldwqfI56xgd1YzrzoB2svWjxbGGyQ0TEASxg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@swc/core-linux-x64-musl@1.15.32':
-    resolution: {integrity: sha512-N4Ggahe/8SUbTX50P6EdhbW9YWcgbZVb52R4cq6MK+zsoMjRq7rGvV5ztA05QnbaCYqMYx8rTY7KAIA3Crdo4Q==}
+  '@swc/core-linux-x64-musl@1.15.40':
+    resolution: {integrity: sha512-h4kZYHc7dpc9P9u4brRJaS8Pl7tPVHAeiLSzw7T5RfIJgAoSdaCMKzI/2Uay9gFhaw8uyCDl0L5q37r0EpAfIA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@swc/core-win32-arm64-msvc@1.15.32':
-    resolution: {integrity: sha512-01yN0o9jvo8xBTP12aPK2wW8b41jmOlGbDDlAnoynotc4pO6xA0zby9f1z6j++qXDpGBttLySq1omgVrlQKYcw==}
+  '@swc/core-win32-arm64-msvc@1.15.40':
+    resolution: {integrity: sha512-+mQgKZXSj6mV38Zh05QaxSjUDmGP/R2JWlXZTDLSPkDzHU6p3GxN9eeSf5dfyDVU86946fmCvSzyl/ucImx8+A==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
 
-  '@swc/core-win32-ia32-msvc@1.15.32':
-    resolution: {integrity: sha512-fLagI9XZYNpTcmlqAcp3KBtmj7E19WCmYD80Jxj1Kn5tGNa7yxNLd3NNdWxuZGUPl5iC0/KqZru7g08gF6Fsrw==}
+  '@swc/core-win32-ia32-msvc@1.15.40':
+    resolution: {integrity: sha512-yvwdPLGd25mcj/mNatjNQ0lZujtQD6psH3v9PNmMb+fSzjbNG8KIDxjFWrcV+fsFVLOkyOmdJsFmX7NAFjVyPw==}
     engines: {node: '>=10'}
     cpu: [ia32]
     os: [win32]
 
-  '@swc/core-win32-x64-msvc@1.15.32':
-    resolution: {integrity: sha512-gbc2bQ/T2CiR+w0OvcVKwLOFAcPZBvmWmolbwpg1E8UrpeC03DGtyMUApOHNXNYWA3SHFrYXCQtosrcMza1YFg==}
+  '@swc/core-win32-x64-msvc@1.15.40':
+    resolution: {integrity: sha512-OXtKsLU1bVtInzzDEAY2sYiF/rl4tvAnLLLpuMp3HzAOQZ5A+i69AKDhA1YLQTaMAqO3vzyYNVAYVRMPtSYD4w==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
 
-  '@swc/core@1.15.32':
-    resolution: {integrity: sha512-/eWL0n43D64QWEUHLtTE+jDqjkJhyidjkDhv6f0uJohOUAhywxQ9wXYp845DNNds0JpCdI4Uo0a9bl+vbXf+ew==}
+  '@swc/core@1.15.40':
+    resolution: {integrity: sha512-2kwzJikRvgtNAG7MwVZY2vEzZjTxKIq5jXOihuSV/8U+Hej8Va22t65aKnJZs3P+NwojZvR8Mf8kyM7O+V8sQg==}
     engines: {node: '>=10'}
     peerDependencies:
       '@swc/helpers': '>=0.5.17'
@@ -3595,8 +3600,8 @@ packages:
     peerDependencies:
       '@types/react': ^19.2.0
 
-  '@types/react@18.3.28':
-    resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
+  '@types/react@18.3.29':
+    resolution: {integrity: sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==}
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
@@ -4682,6 +4687,9 @@ packages:
   devalue@5.6.4:
     resolution: {integrity: sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==}
 
+  devalue@5.8.1:
+    resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
+
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
@@ -5010,8 +5018,13 @@ packages:
     resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
     engines: {node: '>=0.10'}
 
-  esrap@2.2.4:
-    resolution: {integrity: sha512-suICpxAmZ9A8bzJjEl/+rLJiDKC0X4gYWUxT6URAWBLvlXmtbZd5ySMu/N2ZGEtMCAmflUDPSehrP9BQcsGcSg==}
+  esrap@2.2.9:
+    resolution: {integrity: sha512-4KijP+NxCWthMCUC3qHbE6n4vCjqgJS1uAYKhuT/GWfFTf1Qyive2TgOjep+gzbSzRfnNyaN/UU9YmdOt8Eg0A==}
+    peerDependencies:
+      '@typescript-eslint/types': ^8.2.0
+    peerDependenciesMeta:
+      '@typescript-eslint/types':
+        optional: true
 
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
@@ -5380,8 +5393,8 @@ packages:
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
-  hono@4.12.15:
-    resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
+  hono@4.12.22:
+    resolution: {integrity: sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw==}
     engines: {node: '>=16.9.0'}
 
   hookable@5.5.3:
@@ -6237,6 +6250,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   napi-postinstall@0.3.2:
     resolution: {integrity: sha512-tWVJxJHmBWLy69PvO96TZMZDrzmw5KeiZBz3RHmiM2XZ9grBJ2WgMAFVVg25nqp3ZjTFUs2Ftw1JhscL3Teliw==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -6761,6 +6779,10 @@ packages:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
   postgres-array@2.0.0:
     resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
     engines: {node: '>=4'}
@@ -6867,10 +6889,10 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
-  react-dom@19.2.5:
-    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+  react-dom@19.2.6:
+    resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
     peerDependencies:
-      react: ^19.2.5
+      react: ^19.2.6
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
@@ -6896,8 +6918,8 @@ packages:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
 
-  react@19.2.5:
-    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
+  react@19.2.6:
+    resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
     engines: {node: '>=0.10.0'}
 
   read-cache@1.0.0:
@@ -7232,8 +7254,8 @@ packages:
     resolution: {integrity: sha512-CxdwHXyYTONGHThDbq5XdwbFsuY4wlClRGejfE2NtwUtiHYsP1QtNsHb/hnj31jKYSchztJsaA8pSQoVzkfCFg==}
     engines: {node: '>= 18'}
 
-  solid-js@1.9.12:
-    resolution: {integrity: sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw==}
+  solid-js@1.9.13:
+    resolution: {integrity: sha512-6hJeJMOcEX8ktqjpDoJZEmld3ijvcvWBDtiXBm7f4332SiFN66QeAQI1REQshvyUoISsSeJ4PHDauKYbwao9JQ==}
 
   solid-presence@0.1.8:
     resolution: {integrity: sha512-pWGtXUFWYYUZNbg5YpG5vkQJyOtzn2KXhxYaMx/4I+lylTLYkITOLevaCwMRN+liCVk0pqB6EayLWojNqBFECA==}
@@ -7404,16 +7426,16 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  svelte-check@4.4.6:
-    resolution: {integrity: sha512-kP1zG81EWaFe9ZyTv4ZXv44Csi6Pkdpb7S3oj6m+K2ec/IcDg/a8LsFsnVLqm2nxtkSwsd5xPj/qFkTBgXHXjg==}
+  svelte-check@4.4.8:
+    resolution: {integrity: sha512-67adfgBox5eNSNIvIIwgFizKGdcRrGpiMoNO2obHcYuLz7iTa8Xgm/NGU3ntMFnNm8K1grFOIG6HhMLX/vcN8w==}
     engines: {node: '>= 18.0.0'}
     hasBin: true
     peerDependencies:
       svelte: ^4.0.0 || ^5.0.0-next.0
       typescript: '>=5.0.0'
 
-  svelte@5.55.5:
-    resolution: {integrity: sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==}
+  svelte@5.55.9:
+    resolution: {integrity: sha512-fTjjT8cHLDwigcu2j3pv7Jq04LklXevPB8uBgyHNiTXv+RMNvVnrjS4UEYrLMkhuq1vpCodHjiW+z/95SDs/fg==}
     engines: {node: '>=18'}
 
   svg-tags@1.0.0:
@@ -7609,8 +7631,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tsx@4.21.0:
-    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+  tsx@4.21.1:
+    resolution: {integrity: sha512-5QE2Q04cN1u0993w0LT5rPw3faZqZU1fFn1mGE0pV53N1Dn7c+QFFxQu1mBeSgeOXwFyTicZw02wVgp3Tb5cAQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -7968,6 +7990,46 @@ packages:
 
   vite@7.3.2:
     resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vite@7.3.3:
+    resolution: {integrity: sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -9343,21 +9405,21 @@ snapshots:
       rollup: 4.59.0
       unplugin: 1.16.1
 
-  '@codecov/sveltekit-plugin@2.0.1(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.55.5)(typescript@5.9.3)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.55.5)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))':
+  '@codecov/sveltekit-plugin@2.0.1(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)))(svelte@5.55.9(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)))(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))':
     dependencies:
       '@codecov/bundler-plugin-core': 2.0.1
-      '@codecov/vite-plugin': 2.0.1(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
-      '@sveltejs/kit': 2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.55.5)(typescript@5.9.3)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
-      svelte: 5.55.5
+      '@codecov/vite-plugin': 2.0.1(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
+      '@sveltejs/kit': 2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)))(svelte@5.55.9(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
+      svelte: 5.55.9(@typescript-eslint/types@8.56.1)
       unplugin: 1.16.1
     transitivePeerDependencies:
       - vite
 
-  '@codecov/vite-plugin@2.0.1(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))':
+  '@codecov/vite-plugin@2.0.1(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))':
     dependencies:
       '@codecov/bundler-plugin-core': 2.0.1
       unplugin: 1.16.1
-      vite: 7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      vite: 7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
 
   '@colors/colors@1.5.0':
     optional: true
@@ -9472,10 +9534,10 @@ snapshots:
       '@types/conventional-commits-parser': 5.0.1
       chalk: 5.5.0
 
-  '@corvu/utils@0.4.2(solid-js@1.9.12)':
+  '@corvu/utils@0.4.2(solid-js@1.9.13)':
     dependencies:
       '@floating-ui/dom': 1.7.6
-      solid-js: 1.9.12
+      solid-js: 1.9.13
 
   '@csstools/color-helpers@5.1.0': {}
 
@@ -9824,9 +9886,9 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@hono/node-server@1.14.4(hono@4.12.15)':
+  '@hono/node-server@1.14.4(hono@4.12.22)':
     dependencies:
-      hono: 4.12.15
+      hono: 4.12.22
 
   '@humanfs/core@0.19.1': {}
 
@@ -10183,28 +10245,28 @@ snapshots:
 
   '@keyv/serialize@1.1.1': {}
 
-  '@kobalte/core@0.13.11(solid-js@1.9.12)':
+  '@kobalte/core@0.13.11(solid-js@1.9.13)':
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@internationalized/date': 3.12.0
       '@internationalized/number': 3.6.5
-      '@kobalte/utils': 0.9.1(solid-js@1.9.12)
-      '@solid-primitives/props': 3.2.3(solid-js@1.9.12)
-      '@solid-primitives/resize-observer': 2.1.5(solid-js@1.9.12)
-      solid-js: 1.9.12
-      solid-presence: 0.1.8(solid-js@1.9.12)
-      solid-prevent-scroll: 0.1.10(solid-js@1.9.12)
+      '@kobalte/utils': 0.9.1(solid-js@1.9.13)
+      '@solid-primitives/props': 3.2.3(solid-js@1.9.13)
+      '@solid-primitives/resize-observer': 2.1.5(solid-js@1.9.13)
+      solid-js: 1.9.13
+      solid-presence: 0.1.8(solid-js@1.9.13)
+      solid-prevent-scroll: 0.1.10(solid-js@1.9.13)
 
-  '@kobalte/utils@0.9.1(solid-js@1.9.12)':
+  '@kobalte/utils@0.9.1(solid-js@1.9.13)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.5(solid-js@1.9.12)
-      '@solid-primitives/keyed': 1.5.3(solid-js@1.9.12)
-      '@solid-primitives/map': 0.4.13(solid-js@1.9.12)
-      '@solid-primitives/media': 2.3.5(solid-js@1.9.12)
-      '@solid-primitives/props': 3.2.3(solid-js@1.9.12)
-      '@solid-primitives/refs': 1.1.3(solid-js@1.9.12)
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@solid-primitives/event-listener': 2.4.5(solid-js@1.9.13)
+      '@solid-primitives/keyed': 1.5.3(solid-js@1.9.13)
+      '@solid-primitives/map': 0.4.13(solid-js@1.9.13)
+      '@solid-primitives/media': 2.3.5(solid-js@1.9.13)
+      '@solid-primitives/props': 3.2.3(solid-js@1.9.13)
+      '@solid-primitives/refs': 1.1.3(solid-js@1.9.13)
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.13)
+      solid-js: 1.9.13
 
   '@loaderkit/resolve@1.0.4':
     dependencies:
@@ -10260,18 +10322,18 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@nx/devkit@22.5.4(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.32(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.32(@swc/helpers@0.5.21)))':
+  '@nx/devkit@22.5.4(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.21)))':
     dependencies:
       '@zkochan/js-yaml': 0.0.7
       ejs: 3.1.10
       enquirer: 2.3.6
       minimatch: 10.2.4
-      nx: 22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.32(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.32(@swc/helpers@0.5.21))
+      nx: 22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.21))
       semver: 7.7.3
       tslib: 2.8.1
       yargs-parser: 21.1.1
 
-  '@nx/js@22.5.4(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.32(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.32(@swc/helpers@0.5.21))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.32(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.32(@swc/helpers@0.5.21)))':
+  '@nx/js@22.5.4(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.21))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.21)))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.29.0)
@@ -10280,8 +10342,8 @@ snapshots:
       '@babel/preset-env': 7.28.0(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@babel/runtime': 7.28.2
-      '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.32(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.32(@swc/helpers@0.5.21)))
-      '@nx/workspace': 22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.32(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.32(@swc/helpers@0.5.21))
+      '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.21)))
+      '@nx/workspace': 22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.21))
       '@zkochan/js-yaml': 0.0.7
       babel-plugin-const-enum: 1.2.0(@babel/core@7.29.0)
       babel-plugin-macros: 3.1.0
@@ -10337,13 +10399,13 @@ snapshots:
   '@nx/nx-win32-x64-msvc@22.5.4':
     optional: true
 
-  '@nx/workspace@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.32(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.32(@swc/helpers@0.5.21))':
+  '@nx/workspace@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.21))':
     dependencies:
-      '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.32(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.32(@swc/helpers@0.5.21)))
+      '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.21)))
       '@zkochan/js-yaml': 0.0.7
       chalk: 4.1.2
       enquirer: 2.3.6
-      nx: 22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.32(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.32(@swc/helpers@0.5.21))
+      nx: 22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.21))
       picomatch: 4.0.2
       semver: 7.7.3
       tslib: 2.8.1
@@ -10627,7 +10689,7 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
-  '@react-router/dev@7.13.2(@react-router/serve@7.13.2(react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3))(@types/node@24.2.0)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(yaml@2.8.1)':
+  '@react-router/dev@7.13.2(@react-router/serve@7.13.2(react-router@7.13.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3))(@types/node@24.2.0)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(react-router@7.13.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(terser@5.46.0)(tsx@4.21.1)(typescript@5.9.3)(vite@6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(yaml@2.8.1)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -10636,7 +10698,7 @@ snapshots:
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
-      '@react-router/node': 7.13.2(react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
+      '@react-router/node': 7.13.2(react-router@7.13.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
       '@remix-run/node-fetch-server': 0.13.0
       arg: 5.0.2
       babel-dead-code-elimination: 1.0.12
@@ -10653,14 +10715,14 @@ snapshots:
       pkg-types: 2.3.0
       prettier: 3.8.1
       react-refresh: 0.14.2
-      react-router: 7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react-router: 7.13.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       semver: 7.7.3
       tinyglobby: 0.2.15
       valibot: 1.3.1(typescript@5.9.3)
-      vite: 6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
-      vite-node: 3.2.4(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      vite: 6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
     optionalDependencies:
-      '@react-router/serve': 7.13.2(react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
+      '@react-router/serve': 7.13.2(react-router@7.13.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/node'
@@ -10677,31 +10739,31 @@ snapshots:
       - tsx
       - yaml
 
-  '@react-router/express@7.13.2(express@4.22.1)(react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)':
+  '@react-router/express@7.13.2(express@4.22.1)(react-router@7.13.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)':
     dependencies:
-      '@react-router/node': 7.13.2(react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
+      '@react-router/node': 7.13.2(react-router@7.13.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
       express: 4.22.1
-      react-router: 7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react-router: 7.13.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@react-router/node@7.13.2(react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)':
+  '@react-router/node@7.13.2(react-router@7.13.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)':
     dependencies:
       '@mjackson/node-fetch-server': 0.2.0
-      react-router: 7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react-router: 7.13.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@react-router/serve@7.13.2(react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)':
+  '@react-router/serve@7.13.2(react-router@7.13.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)':
     dependencies:
       '@mjackson/node-fetch-server': 0.2.0
-      '@react-router/express': 7.13.2(express@4.22.1)(react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
-      '@react-router/node': 7.13.2(react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
+      '@react-router/express': 7.13.2(express@4.22.1)(react-router@7.13.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
+      '@react-router/node': 7.13.2(react-router@7.13.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
       compression: 1.8.1
       express: 4.22.1
       get-port: 5.1.1
       morgan: 1.10.1
-      react-router: 7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react-router: 7.13.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       source-map-support: 0.5.21
     transitivePeerDependencies:
       - supports-color
@@ -10940,74 +11002,74 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@solid-primitives/event-listener@2.4.5(solid-js@1.9.12)':
+  '@solid-primitives/event-listener@2.4.5(solid-js@1.9.13)':
     dependencies:
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.13)
+      solid-js: 1.9.13
 
-  '@solid-primitives/keyed@1.5.3(solid-js@1.9.12)':
+  '@solid-primitives/keyed@1.5.3(solid-js@1.9.13)':
     dependencies:
-      solid-js: 1.9.12
+      solid-js: 1.9.13
 
-  '@solid-primitives/map@0.4.13(solid-js@1.9.12)':
+  '@solid-primitives/map@0.4.13(solid-js@1.9.13)':
     dependencies:
-      '@solid-primitives/trigger': 1.2.3(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@solid-primitives/trigger': 1.2.3(solid-js@1.9.13)
+      solid-js: 1.9.13
 
-  '@solid-primitives/media@2.3.5(solid-js@1.9.12)':
+  '@solid-primitives/media@2.3.5(solid-js@1.9.13)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.5(solid-js@1.9.12)
-      '@solid-primitives/rootless': 1.5.3(solid-js@1.9.12)
-      '@solid-primitives/static-store': 0.1.3(solid-js@1.9.12)
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@solid-primitives/event-listener': 2.4.5(solid-js@1.9.13)
+      '@solid-primitives/rootless': 1.5.3(solid-js@1.9.13)
+      '@solid-primitives/static-store': 0.1.3(solid-js@1.9.13)
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.13)
+      solid-js: 1.9.13
 
-  '@solid-primitives/props@3.2.3(solid-js@1.9.12)':
+  '@solid-primitives/props@3.2.3(solid-js@1.9.13)':
     dependencies:
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.13)
+      solid-js: 1.9.13
 
-  '@solid-primitives/refs@1.1.3(solid-js@1.9.12)':
+  '@solid-primitives/refs@1.1.3(solid-js@1.9.13)':
     dependencies:
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.13)
+      solid-js: 1.9.13
 
-  '@solid-primitives/resize-observer@2.1.5(solid-js@1.9.12)':
+  '@solid-primitives/resize-observer@2.1.5(solid-js@1.9.13)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.5(solid-js@1.9.12)
-      '@solid-primitives/rootless': 1.5.3(solid-js@1.9.12)
-      '@solid-primitives/static-store': 0.1.3(solid-js@1.9.12)
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@solid-primitives/event-listener': 2.4.5(solid-js@1.9.13)
+      '@solid-primitives/rootless': 1.5.3(solid-js@1.9.13)
+      '@solid-primitives/static-store': 0.1.3(solid-js@1.9.13)
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.13)
+      solid-js: 1.9.13
 
-  '@solid-primitives/rootless@1.5.3(solid-js@1.9.12)':
+  '@solid-primitives/rootless@1.5.3(solid-js@1.9.13)':
     dependencies:
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.13)
+      solid-js: 1.9.13
 
-  '@solid-primitives/static-store@0.1.3(solid-js@1.9.12)':
+  '@solid-primitives/static-store@0.1.3(solid-js@1.9.13)':
     dependencies:
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.13)
+      solid-js: 1.9.13
 
-  '@solid-primitives/trigger@1.2.3(solid-js@1.9.12)':
+  '@solid-primitives/trigger@1.2.3(solid-js@1.9.13)':
     dependencies:
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.13)
+      solid-js: 1.9.13
 
-  '@solid-primitives/utils@6.4.0(solid-js@1.9.12)':
+  '@solid-primitives/utils@6.4.0(solid-js@1.9.13)':
     dependencies:
-      solid-js: 1.9.12
+      solid-js: 1.9.13
 
-  '@solidjs/router@0.15.4(solid-js@1.9.12)':
+  '@solidjs/router@0.15.4(solid-js@1.9.13)':
     dependencies:
-      solid-js: 1.9.12
+      solid-js: 1.9.13
 
-  '@solidjs/start@1.3.2(solid-js@1.9.12)(vinxi@0.5.11(@types/node@22.18.13)(db0@0.3.4(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3)))(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3))(ioredis@5.10.0)(jiti@1.21.7)(rolldown@1.0.0-beta.45)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vite@7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))':
+  '@solidjs/start@1.3.2(solid-js@1.9.13)(vinxi@0.5.11(@types/node@22.18.13)(db0@0.3.4(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3)))(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3))(ioredis@5.10.0)(jiti@1.21.7)(rolldown@1.0.0-beta.45)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vite@7.3.3(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))':
     dependencies:
-      '@tanstack/server-functions-plugin': 1.121.21(vite@7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
-      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@types/node@22.18.13)(db0@0.3.4(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3)))(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3))(ioredis@5.10.0)(jiti@1.21.7)(rolldown@1.0.0-beta.45)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
-      '@vinxi/server-components': 0.5.1(vinxi@0.5.11(@types/node@22.18.13)(db0@0.3.4(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3)))(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3))(ioredis@5.10.0)(jiti@1.21.7)(rolldown@1.0.0-beta.45)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      '@tanstack/server-functions-plugin': 1.121.21(vite@7.3.3(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
+      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@types/node@22.18.13)(db0@0.3.4(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3)))(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3))(ioredis@5.10.0)(jiti@1.21.7)(rolldown@1.0.0-beta.45)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
+      '@vinxi/server-components': 0.5.1(vinxi@0.5.11(@types/node@22.18.13)(db0@0.3.4(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3)))(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3))(ioredis@5.10.0)(jiti@1.21.7)(rolldown@1.0.0-beta.45)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
       cookie-es: 2.0.0
       defu: 6.1.4
       error-stack-parser: 2.1.4
@@ -11017,10 +11079,10 @@ snapshots:
       seroval-plugins: 1.5.0(seroval@1.5.0)
       shiki: 1.29.2
       source-map-js: 1.2.1
-      terracotta: 1.1.0(solid-js@1.9.12)
+      terracotta: 1.1.0(solid-js@1.9.13)
       tinyglobby: 0.2.15
-      vinxi: 0.5.11(@types/node@22.18.13)(db0@0.3.4(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3)))(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3))(ioredis@5.10.0)(jiti@1.21.7)(rolldown@1.0.0-beta.45)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
-      vite-plugin-solid: 2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      vinxi: 0.5.11(@types/node@22.18.13)(db0@0.3.4(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3)))(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3))(ioredis@5.10.0)(jiti@1.21.7)(rolldown@1.0.0-beta.45)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
+      vite-plugin-solid: 2.11.12(solid-js@1.9.13)(vite@7.3.3(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
     transitivePeerDependencies:
       - '@testing-library/jest-dom'
       - solid-js
@@ -11142,7 +11204,7 @@ snapshots:
       '@stryker-mutator/core': 9.3.0(@types/node@22.18.13)
       '@stryker-mutator/util': 9.3.0
       tslib: 2.8.1
-      vitest: 4.0.18(@types/node@22.18.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.18(@types/node@22.18.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
 
   '@stryker-mutator/vitest-runner@9.3.0(@stryker-mutator/core@9.3.0(@types/node@24.2.0))(vitest@4.0.18)':
     dependencies:
@@ -11150,21 +11212,25 @@ snapshots:
       '@stryker-mutator/core': 9.3.0(@types/node@24.2.0)
       '@stryker-mutator/util': 9.3.0
       tslib: 2.8.1
-      vitest: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
+
+  '@sveltejs/acorn-typescript@1.0.10(acorn@8.16.0)':
+    dependencies:
+      acorn: 8.16.0
 
   '@sveltejs/acorn-typescript@1.0.9(acorn@8.16.0)':
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/adapter-auto@7.0.1(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.55.5)(typescript@5.9.3)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)))':
+  '@sveltejs/adapter-auto@7.0.1(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)))(svelte@5.55.9(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)))':
     dependencies:
-      '@sveltejs/kit': 2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.55.5)(typescript@5.9.3)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      '@sveltejs/kit': 2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)))(svelte@5.55.9(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
 
-  '@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.55.5)(typescript@5.9.3)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))':
+  '@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)))(svelte@5.55.9(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))':
     dependencies:
       '@standard-schema/spec': 1.0.0
       '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
       '@types/cookie': 0.6.0
       acorn: 8.16.0
       cookie: 0.6.0
@@ -11175,16 +11241,16 @@ snapshots:
       mrmime: 2.0.1
       set-cookie-parser: 3.1.0
       sirv: 3.0.2
-      svelte: 5.55.5
-      vite: 7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      svelte: 5.55.9(@typescript-eslint/types@8.56.1)
+      vite: 7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.55.5)(typescript@5.9.3)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))':
+  '@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)))(svelte@5.55.9(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))':
     dependencies:
       '@standard-schema/spec': 1.0.0
       '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
       '@types/cookie': 0.6.0
       acorn: 8.16.0
       cookie: 0.6.0
@@ -11195,55 +11261,55 @@ snapshots:
       mrmime: 2.0.1
       set-cookie-parser: 3.1.0
       sirv: 3.0.2
-      svelte: 5.55.5
-      vite: 7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      svelte: 5.55.9(@typescript-eslint/types@8.56.1)
+      vite: 7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.55.5)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))':
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)))(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
       obug: 2.1.1
-      svelte: 5.55.5
-      vite: 7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      svelte: 5.55.9(@typescript-eslint/types@8.56.1)
+      vite: 7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
 
-  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.55.5)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))':
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)))(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
       obug: 2.1.1
-      svelte: 5.55.5
-      vite: 7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      svelte: 5.55.9(@typescript-eslint/types@8.56.1)
+      vite: 7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
 
-  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))':
+  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.55.5)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)))(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.1
-      svelte: 5.55.5
-      vite: 7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
-      vitefu: 1.1.1(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      svelte: 5.55.9(@typescript-eslint/types@8.56.1)
+      vite: 7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
+      vitefu: 1.1.1(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
 
-  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))':
+  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.5)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.55.5)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)))(svelte@5.55.9(@typescript-eslint/types@8.56.1))(vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.1
-      svelte: 5.55.5
-      vite: 7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
-      vitefu: 1.1.1(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      svelte: 5.55.9(@typescript-eslint/types@8.56.1)
+      vite: 7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
+      vitefu: 1.1.1(vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
 
-  '@swc-node/core@1.14.1(@swc/core@1.15.32(@swc/helpers@0.5.21))(@swc/types@0.1.26)':
+  '@swc-node/core@1.14.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@swc/types@0.1.26)':
     dependencies:
-      '@swc/core': 1.15.32(@swc/helpers@0.5.21)
+      '@swc/core': 1.15.40(@swc/helpers@0.5.21)
       '@swc/types': 0.1.26
 
-  '@swc-node/register@1.11.1(@swc/core@1.15.32(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3)':
+  '@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3)':
     dependencies:
-      '@swc-node/core': 1.14.1(@swc/core@1.15.32(@swc/helpers@0.5.21))(@swc/types@0.1.26)
+      '@swc-node/core': 1.14.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@swc/types@0.1.26)
       '@swc-node/sourcemap-support': 0.6.1
-      '@swc/core': 1.15.32(@swc/helpers@0.5.21)
+      '@swc/core': 1.15.40(@swc/helpers@0.5.21)
       colorette: 2.0.20
       debug: 4.4.3
       oxc-resolver: 11.6.1
@@ -11259,59 +11325,59 @@ snapshots:
       source-map-support: 0.5.21
       tslib: 2.8.1
 
-  '@swc/core-darwin-arm64@1.15.32':
+  '@swc/core-darwin-arm64@1.15.40':
     optional: true
 
-  '@swc/core-darwin-x64@1.15.32':
+  '@swc/core-darwin-x64@1.15.40':
     optional: true
 
-  '@swc/core-linux-arm-gnueabihf@1.15.32':
+  '@swc/core-linux-arm-gnueabihf@1.15.40':
     optional: true
 
-  '@swc/core-linux-arm64-gnu@1.15.32':
+  '@swc/core-linux-arm64-gnu@1.15.40':
     optional: true
 
-  '@swc/core-linux-arm64-musl@1.15.32':
+  '@swc/core-linux-arm64-musl@1.15.40':
     optional: true
 
-  '@swc/core-linux-ppc64-gnu@1.15.32':
+  '@swc/core-linux-ppc64-gnu@1.15.40':
     optional: true
 
-  '@swc/core-linux-s390x-gnu@1.15.32':
+  '@swc/core-linux-s390x-gnu@1.15.40':
     optional: true
 
-  '@swc/core-linux-x64-gnu@1.15.32':
+  '@swc/core-linux-x64-gnu@1.15.40':
     optional: true
 
-  '@swc/core-linux-x64-musl@1.15.32':
+  '@swc/core-linux-x64-musl@1.15.40':
     optional: true
 
-  '@swc/core-win32-arm64-msvc@1.15.32':
+  '@swc/core-win32-arm64-msvc@1.15.40':
     optional: true
 
-  '@swc/core-win32-ia32-msvc@1.15.32':
+  '@swc/core-win32-ia32-msvc@1.15.40':
     optional: true
 
-  '@swc/core-win32-x64-msvc@1.15.32':
+  '@swc/core-win32-x64-msvc@1.15.40':
     optional: true
 
-  '@swc/core@1.15.32(@swc/helpers@0.5.21)':
+  '@swc/core@1.15.40(@swc/helpers@0.5.21)':
     dependencies:
       '@swc/counter': 0.1.3
       '@swc/types': 0.1.26
     optionalDependencies:
-      '@swc/core-darwin-arm64': 1.15.32
-      '@swc/core-darwin-x64': 1.15.32
-      '@swc/core-linux-arm-gnueabihf': 1.15.32
-      '@swc/core-linux-arm64-gnu': 1.15.32
-      '@swc/core-linux-arm64-musl': 1.15.32
-      '@swc/core-linux-ppc64-gnu': 1.15.32
-      '@swc/core-linux-s390x-gnu': 1.15.32
-      '@swc/core-linux-x64-gnu': 1.15.32
-      '@swc/core-linux-x64-musl': 1.15.32
-      '@swc/core-win32-arm64-msvc': 1.15.32
-      '@swc/core-win32-ia32-msvc': 1.15.32
-      '@swc/core-win32-x64-msvc': 1.15.32
+      '@swc/core-darwin-arm64': 1.15.40
+      '@swc/core-darwin-x64': 1.15.40
+      '@swc/core-linux-arm-gnueabihf': 1.15.40
+      '@swc/core-linux-arm64-gnu': 1.15.40
+      '@swc/core-linux-arm64-musl': 1.15.40
+      '@swc/core-linux-ppc64-gnu': 1.15.40
+      '@swc/core-linux-s390x-gnu': 1.15.40
+      '@swc/core-linux-x64-gnu': 1.15.40
+      '@swc/core-linux-x64-musl': 1.15.40
+      '@swc/core-win32-arm64-msvc': 1.15.40
+      '@swc/core-win32-ia32-msvc': 1.15.40
+      '@swc/core-win32-x64-msvc': 1.15.40
       '@swc/helpers': 0.5.21
 
   '@swc/counter@0.1.3': {}
@@ -11324,7 +11390,7 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@tanstack/directive-functions-plugin@1.121.21(vite@7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))':
+  '@tanstack/directive-functions-plugin@1.121.21(vite@7.3.3(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))':
     dependencies:
       '@babel/code-frame': 7.26.2
       '@babel/core': 7.29.0
@@ -11333,7 +11399,7 @@ snapshots:
       '@tanstack/router-utils': 1.161.4
       babel-dead-code-elimination: 1.0.12
       tiny-invariant: 1.3.3
-      vite: 7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      vite: 7.3.3(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11351,7 +11417,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/server-functions-plugin@1.121.21(vite@7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))':
+  '@tanstack/server-functions-plugin@1.121.21(vite@7.3.3(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))':
     dependencies:
       '@babel/code-frame': 7.26.2
       '@babel/core': 7.28.0
@@ -11360,7 +11426,7 @@ snapshots:
       '@babel/template': 7.27.2
       '@babel/traverse': 7.28.5
       '@babel/types': 7.29.0
-      '@tanstack/directive-functions-plugin': 1.121.21(vite@7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      '@tanstack/directive-functions-plugin': 1.121.21(vite@7.3.3(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
       babel-dead-code-elimination: 1.0.12
       tiny-invariant: 1.3.3
     transitivePeerDependencies:
@@ -11378,15 +11444,15 @@ snapshots:
       picocolors: 1.1.1
       pretty-format: 27.5.1
 
-  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.2
       '@testing-library/dom': 10.4.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 18.3.28
-      '@types/react-dom': 19.2.3(@types/react@18.3.28)
+      '@types/react': 18.3.29
+      '@types/react-dom': 19.2.3(@types/react@18.3.29)
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -11478,16 +11544,16 @@ snapshots:
 
   '@types/prop-types@15.7.15': {}
 
-  '@types/react-dom@19.2.3(@types/react@18.3.28)':
+  '@types/react-dom@19.2.3(@types/react@18.3.29)':
     dependencies:
-      '@types/react': 18.3.28
+      '@types/react': 18.3.29
     optional: true
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
 
-  '@types/react@18.3.28':
+  '@types/react@18.3.29':
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
@@ -11639,7 +11705,7 @@ snapshots:
       untun: 0.1.3
       uqr: 0.1.2
 
-  '@vinxi/plugin-directives@0.5.1(vinxi@0.5.11(@types/node@22.18.13)(db0@0.3.4(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3)))(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3))(ioredis@5.10.0)(jiti@1.21.7)(rolldown@1.0.0-beta.45)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))':
+  '@vinxi/plugin-directives@0.5.1(vinxi@0.5.11(@types/node@22.18.13)(db0@0.3.4(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3)))(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3))(ioredis@5.10.0)(jiti@1.21.7)(rolldown@1.0.0-beta.45)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))':
     dependencies:
       '@babel/parser': 7.29.0
       acorn: 8.15.0
@@ -11650,34 +11716,34 @@ snapshots:
       magicast: 0.2.11
       recast: 0.23.11
       tslib: 2.8.1
-      vinxi: 0.5.11(@types/node@22.18.13)(db0@0.3.4(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3)))(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3))(ioredis@5.10.0)(jiti@1.21.7)(rolldown@1.0.0-beta.45)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      vinxi: 0.5.11(@types/node@22.18.13)(db0@0.3.4(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3)))(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3))(ioredis@5.10.0)(jiti@1.21.7)(rolldown@1.0.0-beta.45)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
 
-  '@vinxi/server-components@0.5.1(vinxi@0.5.11(@types/node@22.18.13)(db0@0.3.4(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3)))(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3))(ioredis@5.10.0)(jiti@1.21.7)(rolldown@1.0.0-beta.45)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))':
+  '@vinxi/server-components@0.5.1(vinxi@0.5.11(@types/node@22.18.13)(db0@0.3.4(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3)))(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3))(ioredis@5.10.0)(jiti@1.21.7)(rolldown@1.0.0-beta.45)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))':
     dependencies:
-      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@types/node@22.18.13)(db0@0.3.4(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3)))(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3))(ioredis@5.10.0)(jiti@1.21.7)(rolldown@1.0.0-beta.45)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@types/node@22.18.13)(db0@0.3.4(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3)))(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3))(ioredis@5.10.0)(jiti@1.21.7)(rolldown@1.0.0-beta.45)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
       acorn: 8.15.0
       acorn-loose: 8.5.2
       acorn-typescript: 1.4.13(acorn@8.15.0)
       astring: 1.9.0
       magicast: 0.2.11
       recast: 0.23.11
-      vinxi: 0.5.11(@types/node@22.18.13)(db0@0.3.4(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3)))(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3))(ioredis@5.10.0)(jiti@1.21.7)(rolldown@1.0.0-beta.45)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      vinxi: 0.5.11(@types/node@22.18.13)(db0@0.3.4(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3)))(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3))(ioredis@5.10.0)(jiti@1.21.7)(rolldown@1.0.0-beta.45)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
 
-  '@vitejs/plugin-react-swc@4.2.3(@swc/helpers@0.5.21)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))':
+  '@vitejs/plugin-react-swc@4.2.3(@swc/helpers@0.5.21)(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.2
-      '@swc/core': 1.15.32(@swc/helpers@0.5.21)
-      vite: 7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      '@swc/core': 1.15.40(@swc/helpers@0.5.21)
+      vite: 7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitest/browser-playwright@4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(playwright@1.56.1)(vite@7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)':
+  '@vitest/browser-playwright@4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(playwright@1.56.1)(vite@7.3.3(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vitest@4.0.18)':
     dependencies:
-      '@vitest/browser': 4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
-      '@vitest/mocker': 4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/browser': 4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.3(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vitest@4.0.18)
+      '@vitest/mocker': 4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.3(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
       playwright: 1.56.1
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@22.18.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@1.21.7)(jsdom@25.0.1)(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.18(@types/node@22.18.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@1.21.7)(jsdom@25.0.1)(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -11685,26 +11751,26 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser-playwright@4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(playwright@1.56.1)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)':
+  '@vitest/browser-playwright@4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(playwright@1.56.1)(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vitest@4.0.18)':
     dependencies:
-      '@vitest/browser': 4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
-      '@vitest/mocker': 4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/browser': 4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vitest@4.0.18)
+      '@vitest/mocker': 4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
       playwright: 1.56.1
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@22.18.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.18(@types/node@22.18.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser-playwright@4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(playwright@1.56.1)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)':
+  '@vitest/browser-playwright@4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(playwright@1.56.1)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vitest@4.0.18)':
     dependencies:
-      '@vitest/browser': 4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
-      '@vitest/mocker': 4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/browser': 4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vitest@4.0.18)
+      '@vitest/mocker': 4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
       playwright: 1.56.1
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -11712,16 +11778,16 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser@4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)':
+  '@vitest/browser@4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.3(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vitest@4.0.18)':
     dependencies:
-      '@vitest/mocker': 4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/mocker': 4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.3(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
       '@vitest/utils': 4.0.18
       magic-string: 0.30.21
       pixelmatch: 7.1.0
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@22.18.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@1.21.7)(jsdom@25.0.1)(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.18(@types/node@22.18.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@1.21.7)(jsdom@25.0.1)(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
@@ -11730,16 +11796,16 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser@4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)':
+  '@vitest/browser@4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vitest@4.0.18)':
     dependencies:
-      '@vitest/mocker': 4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/mocker': 4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
       '@vitest/utils': 4.0.18
       magic-string: 0.30.21
       pixelmatch: 7.1.0
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@22.18.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.18(@types/node@22.18.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
@@ -11747,34 +11813,16 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)':
+  '@vitest/browser@4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vitest@4.0.18)':
     dependencies:
-      '@vitest/mocker': 4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/mocker': 4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
       '@vitest/utils': 4.0.18
       magic-string: 0.30.21
       pixelmatch: 7.1.0
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
-      ws: 8.18.3
-    transitivePeerDependencies:
-      - bufferutil
-      - msw
-      - utf-8-validate
-      - vite
-    optional: true
-
-  '@vitest/browser@4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)':
-    dependencies:
-      '@vitest/mocker': 4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
-      '@vitest/utils': 4.0.18
-      magic-string: 0.30.21
-      pixelmatch: 7.1.0
-      pngjs: 7.0.0
-      sirv: 3.0.2
-      tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
@@ -11783,7 +11831,43 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18))(vitest@4.0.18)':
+  '@vitest/browser@4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vitest@4.0.18)':
+    dependencies:
+      '@vitest/mocker': 4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
+      '@vitest/utils': 4.0.18
+      magic-string: 0.30.21
+      pixelmatch: 7.1.0
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.0.3
+      vitest: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/browser@4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vitest@4.0.18)':
+    dependencies:
+      '@vitest/mocker': 4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
+      '@vitest/utils': 4.0.18
+      magic-string: 0.30.21
+      pixelmatch: 7.1.0
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.0.3
+      vitest: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.3(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vitest@4.0.18))(vitest@4.0.18)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -11795,11 +11879,11 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@22.18.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@1.21.7)(jsdom@25.0.1)(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.18(@types/node@22.18.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@1.21.7)(jsdom@25.0.1)(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
     optionalDependencies:
-      '@vitest/browser': 4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
+      '@vitest/browser': 4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.3(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vitest@4.0.18)
 
-  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18))(vitest@4.0.18)':
+  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vitest@4.0.18))(vitest@4.0.18)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -11811,11 +11895,11 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@22.18.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.18(@types/node@22.18.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
     optionalDependencies:
-      '@vitest/browser': 4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
+      '@vitest/browser': 4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vitest@4.0.18)
 
-  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18))(vitest@4.0.18)':
+  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vitest@4.0.18))(vitest@4.0.18)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -11827,11 +11911,11 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
     optionalDependencies:
-      '@vitest/browser': 4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
+      '@vitest/browser': 4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vitest@4.0.18)
 
-  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18))(vitest@4.0.18)':
+  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vitest@4.0.18))(vitest@4.0.18)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -11843,9 +11927,9 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
     optionalDependencies:
-      '@vitest/browser': 4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
+      '@vitest/browser': 4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vitest@4.0.18)
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -11856,42 +11940,71 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))':
+  '@vitest/mocker@4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.7(@types/node@22.18.13)(typescript@5.9.3)
-      vite: 7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      vite: 7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
 
-  '@vitest/mocker@4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))':
+  '@vitest/mocker@4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.7(@types/node@22.18.13)(typescript@5.9.3)
-      vite: 7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      vite: 7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
 
-  '@vitest/mocker@4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))':
+  '@vitest/mocker@4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.3(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.12.7(@types/node@24.2.0)(typescript@5.9.3)
-      vite: 6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      msw: 2.12.7(@types/node@22.18.13)(typescript@5.9.3)
+      vite: 7.3.3(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
     optional: true
 
-  '@vitest/mocker@4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))':
+  '@vitest/mocker@4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.7(@types/node@22.18.13)(typescript@5.9.3)
+      vite: 7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
+
+  '@vitest/mocker@4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.7(@types/node@24.2.0)(typescript@5.9.3)
-      vite: 7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      vite: 6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
+    optional: true
+
+  '@vitest/mocker@4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.7(@types/node@24.2.0)(typescript@5.9.3)
+      vite: 7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
+
+  '@vitest/mocker@4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.7(@types/node@24.2.0)(typescript@5.9.3)
+      vite: 7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
+    optional: true
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -11919,7 +12032,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@22.18.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
 
   '@vitest/utils@4.0.18':
     dependencies:
@@ -12099,13 +12212,13 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  autoprefixer@10.4.27(postcss@8.5.12):
+  autoprefixer@10.4.27(postcss@8.5.15):
     dependencies:
       browserslist: 4.28.1
       caniuse-lite: 1.0.30001777
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.12
+      postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
   axios@1.13.1:
@@ -12755,6 +12868,8 @@ snapshots:
 
   devalue@5.6.4: {}
 
+  devalue@5.8.1: {}
+
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
@@ -12794,7 +12909,7 @@ snapshots:
       '@drizzle-team/brocli': 0.10.2
       '@esbuild-kit/esm-loader': 2.6.5
       esbuild: 0.25.8
-      tsx: 4.21.0
+      tsx: 4.21.1
 
   drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3):
     optionalDependencies:
@@ -13046,9 +13161,10 @@ snapshots:
     dependencies:
       estraverse: 5.3.0
 
-  esrap@2.2.4:
+  esrap@2.2.9(@typescript-eslint/types@8.56.1):
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+    optionalDependencies:
       '@typescript-eslint/types': 8.56.1
 
   esrecurse@4.3.0:
@@ -13489,7 +13605,7 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
-  hono@4.12.15: {}
+  hono@4.12.22: {}
 
   hookable@5.5.3: {}
 
@@ -14458,6 +14574,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@3.3.12: {}
+
   napi-postinstall@0.3.2: {}
 
   natural-compare@1.4.0: {}
@@ -14623,7 +14741,7 @@ snapshots:
 
   nwsapi@2.2.22: {}
 
-  nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.32(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.32(@swc/helpers@0.5.21)):
+  nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.21)):
     dependencies:
       '@napi-rs/wasm-runtime': 0.2.4
       '@yarnpkg/lockfile': 1.1.0
@@ -14672,8 +14790,8 @@ snapshots:
       '@nx/nx-linux-x64-musl': 22.5.4
       '@nx/nx-win32-arm64-msvc': 22.5.4
       '@nx/nx-win32-x64-msvc': 22.5.4
-      '@swc-node/register': 1.11.1(@swc/core@1.15.32(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3)
-      '@swc/core': 1.15.32(@swc/helpers@0.5.21)
+      '@swc-node/register': 1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3)
+      '@swc/core': 1.15.40(@swc/helpers@0.5.21)
     transitivePeerDependencies:
       - debug
 
@@ -14977,37 +15095,37 @@ snapshots:
 
   pngjs@7.0.0: {}
 
-  postcss-import@15.1.0(postcss@8.5.12):
+  postcss-import@15.1.0(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.12
+      postcss: 8.5.15
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.10
 
-  postcss-js@4.1.0(postcss@8.5.12):
+  postcss-js@4.1.0(postcss@8.5.15):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.12
+      postcss: 8.5.15
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.12)(tsx@4.21.0)(yaml@2.8.1):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.15)(tsx@4.21.1)(yaml@2.8.1):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
-      postcss: 8.5.12
-      tsx: 4.21.0
+      postcss: 8.5.15
+      tsx: 4.21.1
       yaml: 2.8.1
 
-  postcss-nested@6.2.0(postcss@8.5.12):
+  postcss-nested@6.2.0(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.12
+      postcss: 8.5.15
       postcss-selector-parser: 6.1.2
 
   postcss-resolve-nested-selector@0.1.6: {}
 
-  postcss-safe-parser@7.0.1(postcss@8.5.12):
+  postcss-safe-parser@7.0.1(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.12
+      postcss: 8.5.15
 
   postcss-selector-parser@6.1.2:
     dependencies:
@@ -15024,6 +15142,12 @@ snapshots:
   postcss@8.5.12:
     dependencies:
       nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -15116,9 +15240,9 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
-  react-dom@19.2.5(react@19.2.5):
+  react-dom@19.2.6(react@19.2.6):
     dependencies:
-      react: 19.2.5
+      react: 19.2.6
       scheduler: 0.27.0
 
   react-is@17.0.2: {}
@@ -15127,19 +15251,19 @@ snapshots:
 
   react-refresh@0.14.2: {}
 
-  react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  react-router@7.13.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       cookie: 1.1.1
-      react: 19.2.5
+      react: 19.2.6
       set-cookie-parser: 2.7.2
     optionalDependencies:
-      react-dom: 19.2.5(react@19.2.5)
+      react-dom: 19.2.6(react@19.2.6)
 
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
 
-  react@19.2.5: {}
+  react@19.2.6: {}
 
   read-cache@1.0.0:
     dependencies:
@@ -15545,34 +15669,34 @@ snapshots:
 
   smol-toml@1.4.1: {}
 
-  solid-js@1.9.12:
+  solid-js@1.9.13:
     dependencies:
       csstype: 3.2.3
       seroval: 1.5.0
       seroval-plugins: 1.5.0(seroval@1.5.0)
 
-  solid-presence@0.1.8(solid-js@1.9.12):
+  solid-presence@0.1.8(solid-js@1.9.13):
     dependencies:
-      '@corvu/utils': 0.4.2(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@corvu/utils': 0.4.2(solid-js@1.9.13)
+      solid-js: 1.9.13
 
-  solid-prevent-scroll@0.1.10(solid-js@1.9.12):
+  solid-prevent-scroll@0.1.10(solid-js@1.9.13):
     dependencies:
-      '@corvu/utils': 0.4.2(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@corvu/utils': 0.4.2(solid-js@1.9.13)
+      solid-js: 1.9.13
 
-  solid-refresh@0.6.3(solid-js@1.9.12):
+  solid-refresh@0.6.3(solid-js@1.9.13):
     dependencies:
       '@babel/generator': 7.29.1
       '@babel/helper-module-imports': 7.28.6
       '@babel/types': 7.29.0
-      solid-js: 1.9.12
+      solid-js: 1.9.13
     transitivePeerDependencies:
       - supports-color
 
-  solid-use@0.9.1(solid-js@1.9.12):
+  solid-use@0.9.1(solid-js@1.9.13):
     dependencies:
-      solid-js: 1.9.12
+      solid-js: 1.9.13
 
   source-map-js@1.2.1: {}
 
@@ -15716,9 +15840,9 @@ snapshots:
       micromatch: 4.0.8
       normalize-path: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.12
+      postcss: 8.5.15
       postcss-resolve-nested-selector: 0.1.6
-      postcss-safe-parser: 7.0.1(postcss@8.5.12)
+      postcss-safe-parser: 7.0.1(postcss@8.5.15)
       postcss-selector-parser: 7.1.0
       postcss-value-parser: 4.2.0
       resolve-from: 5.0.0
@@ -15754,36 +15878,38 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@4.4.6(picomatch@4.0.3)(svelte@5.55.5)(typescript@5.9.3):
+  svelte-check@4.4.8(picomatch@4.0.3)(svelte@5.55.9(@typescript-eslint/types@8.56.1))(typescript@5.9.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       chokidar: 4.0.3
       fdir: 6.5.0(picomatch@4.0.3)
       picocolors: 1.1.1
       sade: 1.8.1
-      svelte: 5.55.5
+      svelte: 5.55.9(@typescript-eslint/types@8.56.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - picomatch
 
-  svelte@5.55.5:
+  svelte@5.55.9(@typescript-eslint/types@8.56.1):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
+      '@sveltejs/acorn-typescript': 1.0.10(acorn@8.16.0)
       '@types/estree': 1.0.8
       '@types/trusted-types': 2.0.7
       acorn: 8.16.0
       aria-query: 5.3.1
       axobject-query: 4.1.0
       clsx: 2.1.1
-      devalue: 5.6.4
+      devalue: 5.8.1
       esm-env: 1.2.2
-      esrap: 2.2.4
+      esrap: 2.2.9(@typescript-eslint/types@8.56.1)
       is-reference: 3.0.3
       locate-character: 3.0.0
       magic-string: 0.30.21
       zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - '@typescript-eslint/types'
 
   svg-tags@1.0.0: {}
 
@@ -15801,7 +15927,7 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
-  tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.1):
+  tailwindcss@3.4.19(tsx@4.21.1)(yaml@2.8.1):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -15817,11 +15943,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.12
-      postcss-import: 15.1.0(postcss@8.5.12)
-      postcss-js: 4.1.0(postcss@8.5.12)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.12)(tsx@4.21.0)(yaml@2.8.1)
-      postcss-nested: 6.2.0(postcss@8.5.12)
+      postcss: 8.5.15
+      postcss-import: 15.1.0(postcss@8.5.15)
+      postcss-js: 4.1.0(postcss@8.5.15)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.15)(tsx@4.21.1)(yaml@2.8.1)
+      postcss-nested: 6.2.0(postcss@8.5.15)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.10
       sucrase: 3.35.1
@@ -15863,10 +15989,10 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  terracotta@1.1.0(solid-js@1.9.12):
+  terracotta@1.1.0(solid-js@1.9.13):
     dependencies:
-      solid-js: 1.9.12
-      solid-use: 0.9.1(solid-js@1.9.12)
+      solid-js: 1.9.13
+      solid-use: 0.9.1(solid-js@1.9.13)
 
   terser@5.46.0:
     dependencies:
@@ -15997,10 +16123,9 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsx@4.21.0:
+  tsx@4.21.1:
     dependencies:
       esbuild: 0.27.3
-      get-tsconfig: 4.13.0
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -16261,7 +16386,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vinxi@0.5.11(@types/node@22.18.13)(db0@0.3.4(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3)))(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3))(ioredis@5.10.0)(jiti@1.21.7)(rolldown@1.0.0-beta.45)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1):
+  vinxi@0.5.11(@types/node@22.18.13)(db0@0.3.4(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3)))(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3))(ioredis@5.10.0)(jiti@1.21.7)(rolldown@1.0.0-beta.45)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1):
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.0)
@@ -16295,7 +16420,7 @@ snapshots:
       unctx: 2.5.0
       unenv: 1.10.0
       unstorage: 1.17.4(db0@0.3.4(drizzle-orm@0.44.7(@types/pg@8.15.6)(pg@8.16.3)))(ioredis@5.10.0)
-      vite: 6.4.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      vite: 6.4.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
       zod: 4.3.6
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -16343,13 +16468,13 @@ snapshots:
       - xml2js
       - yaml
 
-  vite-node@3.2.4(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1):
+  vite-node@3.2.4(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      vite: 7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -16364,57 +16489,57 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)):
+  vite-plugin-solid@2.11.12(solid-js@1.9.13)(vite@6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)):
     dependencies:
       '@babel/core': 7.29.0
       '@types/babel__core': 7.20.5
       babel-preset-solid: 1.9.6(@babel/core@7.29.0)
       merge-anything: 5.1.7
-      solid-js: 1.9.12
-      solid-refresh: 0.6.3(solid-js@1.9.12)
-      vite: 6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
-      vitefu: 1.1.1(vite@6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      solid-js: 1.9.13
+      solid-refresh: 0.6.3(solid-js@1.9.13)
+      vite: 6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
+      vitefu: 1.1.1(vite@6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)):
+  vite-plugin-solid@2.11.12(solid-js@1.9.13)(vite@7.3.3(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)):
     dependencies:
       '@babel/core': 7.29.0
       '@types/babel__core': 7.20.5
       babel-preset-solid: 1.9.6(@babel/core@7.29.0)
       merge-anything: 5.1.7
-      solid-js: 1.9.12
-      solid-refresh: 0.6.3(solid-js@1.9.12)
-      vite: 7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
-      vitefu: 1.1.1(vite@7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      solid-js: 1.9.13
+      solid-refresh: 0.6.3(solid-js@1.9.13)
+      vite: 7.3.3(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
+      vitefu: 1.1.1(vite@7.3.3(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)):
+  vite-plugin-solid@2.11.12(solid-js@1.9.13)(vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)):
     dependencies:
       '@babel/core': 7.29.0
       '@types/babel__core': 7.20.5
       babel-preset-solid: 1.9.6(@babel/core@7.29.0)
       merge-anything: 5.1.7
-      solid-js: 1.9.12
-      solid-refresh: 0.6.3(solid-js@1.9.12)
-      vite: 7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
-      vitefu: 1.1.1(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      solid-js: 1.9.13
+      solid-refresh: 0.6.3(solid-js@1.9.13)
+      vite: 7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
+      vitefu: 1.1.1(vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
     transitivePeerDependencies:
       - supports-color
 
-  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)):
+  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
     optionalDependencies:
-      vite: 7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      vite: 7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@6.4.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1):
+  vite@6.4.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.8
       fdir: 6.5.0(picomatch@4.0.3)
@@ -16427,10 +16552,10 @@ snapshots:
       fsevents: 2.3.3
       jiti: 1.21.7
       terser: 5.46.0
-      tsx: 4.21.0
+      tsx: 4.21.1
       yaml: 2.8.1
 
-  vite@6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1):
+  vite@6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.8
       fdir: 6.5.0(picomatch@4.0.3)
@@ -16443,15 +16568,15 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       terser: 5.46.0
-      tsx: 4.21.0
+      tsx: 4.21.1
       yaml: 2.8.1
 
-  vite@7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1):
+  vite@7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
-      postcss: 8.5.12
+      postcss: 8.5.15
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -16459,15 +16584,15 @@ snapshots:
       fsevents: 2.3.3
       jiti: 1.21.7
       terser: 5.46.0
-      tsx: 4.21.0
+      tsx: 4.21.1
       yaml: 2.8.1
 
-  vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1):
+  vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
-      postcss: 8.5.12
+      postcss: 8.5.15
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -16475,15 +16600,15 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       terser: 5.46.0
-      tsx: 4.21.0
+      tsx: 4.21.1
       yaml: 2.8.1
 
-  vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1):
+  vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
-      postcss: 8.5.12
+      postcss: 8.5.15
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -16491,38 +16616,86 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       terser: 5.46.0
-      tsx: 4.21.0
+      tsx: 4.21.1
       yaml: 2.8.1
 
-  vitefu@1.1.1(vite@6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)):
-    optionalDependencies:
-      vite: 6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
-
-  vitefu@1.1.1(vite@7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)):
-    optionalDependencies:
-      vite: 7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
-
-  vitefu@1.1.1(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)):
-    optionalDependencies:
-      vite: 7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
-
-  vitefu@1.1.1(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)):
-    optionalDependencies:
-      vite: 7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
-
-  vitest-browser-react@2.0.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.18):
+  vite@7.3.3(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1):
     dependencies:
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-      vitest: 4.0.18(@types/node@22.18.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.15
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.18.13
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      terser: 5.46.0
+      tsx: 4.21.1
+      yaml: 2.8.1
+
+  vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1):
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.15
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.18.13
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      terser: 5.46.0
+      tsx: 4.21.1
+      yaml: 2.8.1
+
+  vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1):
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.15
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 24.2.0
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      terser: 5.46.0
+      tsx: 4.21.1
+      yaml: 2.8.1
+
+  vitefu@1.1.1(vite@6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)):
+    optionalDependencies:
+      vite: 6.4.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
+
+  vitefu@1.1.1(vite@7.3.3(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)):
+    optionalDependencies:
+      vite: 7.3.3(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
+
+  vitefu@1.1.1(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)):
+    optionalDependencies:
+      vite: 7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
+
+  vitefu@1.1.1(vite@7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)):
+    optionalDependencies:
+      vite: 7.3.3(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
+
+  vitest-browser-react@2.0.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.0.18):
+    dependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      vitest: 4.0.18(@types/node@22.18.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  vitest@4.0.18(@types/node@22.18.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@1.21.7)(jsdom@25.0.1)(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1):
+  vitest@4.0.18(@types/node@22.18.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@1.21.7)(jsdom@25.0.1)(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/mocker': 4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -16539,11 +16712,11 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      vite: 7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.18.13
-      '@vitest/browser-playwright': 4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(playwright@1.56.1)(vite@7.3.2(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
+      '@vitest/browser-playwright': 4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(playwright@1.56.1)(vite@7.3.3(@types/node@22.18.13)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vitest@4.0.18)
       '@vitest/ui': 4.0.18(vitest@4.0.18)
       jsdom: 25.0.1
     transitivePeerDependencies:
@@ -16559,10 +16732,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.18(@types/node@22.18.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1):
+  vitest@4.0.18(@types/node@22.18.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/mocker': 4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -16579,11 +16752,11 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      vite: 7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.18.13
-      '@vitest/browser-playwright': 4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(playwright@1.56.1)(vite@7.3.2(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
+      '@vitest/browser-playwright': 4.0.18(msw@2.12.7(@types/node@22.18.13)(typescript@5.9.3))(playwright@1.56.1)(vite@7.3.3(@types/node@22.18.13)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vitest@4.0.18)
       '@vitest/ui': 4.0.18(vitest@4.0.18)
       jsdom: 25.0.1
     transitivePeerDependencies:
@@ -16599,10 +16772,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1):
+  vitest@4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/mocker': 4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -16619,11 +16792,11 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      vite: 7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.2.0
-      '@vitest/browser-playwright': 4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(playwright@1.56.1)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
+      '@vitest/browser-playwright': 4.0.18(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(playwright@1.56.1)(vite@7.3.2(@types/node@24.2.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1))(vitest@4.0.18)
       '@vitest/ui': 4.0.18(vitest@4.0.18)
       jsdom: 25.0.1
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,19 +4,11 @@ packages:
     - claude-plugins/*
 
 allowBuilds:
-    # postinstall: loads the native NAPI binding (Rust compiler)
     "@swc/core": true
-    # postinstall: places the platform binary and sets the execute bit
     esbuild: true
-    # postinstall: copies mockServiceWorker.js for browser-based mocking
     msw: true
-    # postinstall: initializes the Nx daemon and native cache
     nx: true
-    # postinstall: napi-postinstall verifies the native binding
     oxc-resolver: true
-    # NOTE: @parcel/watcher (via solid-start → vinxi) is intentionally omitted.
-    # Its install script is a no-op unless npm_config_build_from_source=true;
-    # the binding ships through the @parcel/watcher-<plat> optionalDependency.
 
 blockExoticSubdeps: true
 
@@ -30,3 +22,6 @@ catalog:
     vitest: 4.0.18
 
 minimumReleaseAge: 1440
+
+patchedDependencies:
+    "@codecov/sveltekit-plugin@2.0.1": patches/@codecov__sveltekit-plugin@2.0.1.patch


### PR DESCRIPTION
## Summary

Patch-level dependency bumps across monolab workspaces, generated by `/experiments:commander-update-deep-patch`.

- hono 4.12.15 → 4.12.22 (`apps/qup-api`)
- postcss 8.5.12 → 8.5.15 (`apps/qup-web`)
- react 19.2.5 → 19.2.6, react-dom 19.2.5 → 19.2.6 (`apps/wealth-react`)
- solid-js 1.9.12 → 1.9.13 (`apps/demo`, `apps/qup-web`, `packages/solid-clean`)
- svelte 5.55.5 → 5.55.9 (`apps/green-beard`)
- svelte-check 4.4.6 → 4.4.8 (`apps/green-beard`)
- tsx 4.21.0 → 4.21.1 (`apps/qup-api`)
- vite 7.3.2 → 7.3.3 (`apps/green-beard`)
- @types/react 18.3.28 → 18.3.29 (`packages/react-clean`, `packages/react-hooks`)

Deep-patch research surfaced 29 universal improvement bullets across the bumped versions (security fixes in hono/postcss/svelte, solid-js prototype pollution, swc minifier correctness, vite Safari fix, etc.) — every bullet was classified as **inapplicable to monolab** by the plan-mode reconnaissance pass: the codebase doesn't use the relevant APIs (no Hono JWT/cache/mount, no Solid \`createStore\` / \`createResource\` / \`StoreReturn\`, no Svelte 5 reactive primitives in scope, no RSC, no \`.swcrc\`). The improvements still ship transparently with the bumped versions.

Full plan and per-package research: \`~/.claude/experiments/plans/commander-deep-patch-patch-1779623502/plan.md\`.

> Branch base note: wt branched this worktree from \`main\`. Adjust PR base if integration target is \`develop\`.

## Test plan

- [ ] \`pnpm install\` clean (already done locally)
- [ ] \`pnpm -w build\` / per-affected-workspace build succeeds
- [ ] \`pnpm -w test\` / per-affected-workspace tests pass
- [ ] \`pnpm -w lint\` (eslint / oxfmt / stylelint / markdownlint) clean
- [ ] Smoke-check the apps that bumped runtime deps (qup-api with hono, qup-web with solid-js+postcss, wealth-react with react/react-dom, green-beard with svelte+vite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated React, Solid.js, Svelte, and related tooling dependencies to their latest versions across the monorepo.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pabloimrik17/monolab/pull/220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->