### PR TITLE
fix(deps): add claude-plugins/commander importer to lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,17 @@ jobs:
             # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
             - name: Start Nx Cloud CI Run
               if: ${{ env.NX_NO_CLOUD != 'true' }}
-              run: pnpm dlx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+              # --stop-agents-after must match the last distributed target of the run.
+              # On push to main/develop the test:mutation step runs after build, so agents
+              # must survive past it; on other events mutation is skipped and we stop at build.
+              run: |
+                  if [ "${{ github.event_name }}" = "push" ] && \
+                     { [ "${{ github.ref_name }}" = "main" ] || [ "${{ github.ref_name }}" = "develop" ]; }; then
+                    STOP_AFTER="test:mutation"
+                  else
+                    STOP_AFTER="build"
+                  fi
+                  pnpm dlx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="$STOP_AFTER"
 
             - name: Restore cached npm dependencies
               id: cache-dependencies-restore

--- a/nx.json
+++ b/nx.json
@@ -79,6 +79,16 @@
             "dependsOn": ["^lint:stylelint"],
             "inputs": ["default", "{workspaceRoot}/.stylelintrc*", "{projectRoot}/.stylelintrc*"]
         },
+        "test:types": {
+            "cache": true,
+            "dependsOn": ["^build", "^test:types"],
+            "inputs": [
+                "default",
+                "{workspaceRoot}/vitest.config.ts",
+                "{projectRoot}/vitest.config.ts"
+            ],
+            "outputs": ["{projectRoot}/test-results.junit.xml"]
+        },
         "test:unit": {
             "cache": true,
             "dependsOn": ["^build", "^test:unit"],

--- a/packages/react-clean/deno.json
+++ b/packages/react-clean/deno.json
@@ -1,6 +1,6 @@
 {
     "name": "@m0n0lab/react-clean",
-    "version": "3.2.0",
+    "version": "3.3.0",
     "license": "MIT",
     "exports": "./src/index.ts",
     "compilerOptions": {

--- a/packages/react-hooks/deno.json
+++ b/packages/react-hooks/deno.json
@@ -1,6 +1,6 @@
 {
     "name": "@m0n0lab/react-hooks",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "license": "MIT",
     "exports": "./src/index.ts",
     "compilerOptions": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -382,6 +382,8 @@ importers:
         specifier: 'catalog:'
         version: 4.0.18(@types/node@24.2.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.2.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.1)(yaml@2.8.1)
 
+  claude-plugins/commander: {}
+
   claude-plugins/experiments: {}
 
   claude-plugins/expo-developer: {}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,31 +4,61 @@
             "release-type": "node",
             "package-name": "@m0n0lab/react-clean",
             "changelog-path": "CHANGELOG.md",
-            "extra-files": ["deno.json"]
+            "extra-files": [
+                {
+                    "type": "json",
+                    "path": "deno.json",
+                    "jsonpath": "$.version"
+                }
+            ]
         },
         "packages/react-hooks": {
             "release-type": "node",
             "package-name": "@m0n0lab/react-hooks",
             "changelog-path": "CHANGELOG.md",
-            "extra-files": ["deno.json"]
+            "extra-files": [
+                {
+                    "type": "json",
+                    "path": "deno.json",
+                    "jsonpath": "$.version"
+                }
+            ]
         },
         "packages/ts-configs": {
             "release-type": "node",
             "package-name": "@m0n0lab/ts-configs",
             "changelog-path": "CHANGELOG.md",
-            "extra-files": ["deno.json"]
+            "extra-files": [
+                {
+                    "type": "json",
+                    "path": "deno.json",
+                    "jsonpath": "$.version"
+                }
+            ]
         },
         "packages/ts-types": {
             "release-type": "node",
             "package-name": "@m0n0lab/ts-types",
             "changelog-path": "CHANGELOG.md",
-            "extra-files": ["deno.json"]
+            "extra-files": [
+                {
+                    "type": "json",
+                    "path": "deno.json",
+                    "jsonpath": "$.version"
+                }
+            ]
         },
         "packages/http-client": {
             "release-type": "node",
             "package-name": "@m0n0lab/http-client",
             "changelog-path": "CHANGELOG.md",
-            "extra-files": ["deno.json"]
+            "extra-files": [
+                {
+                    "type": "json",
+                    "path": "deno.json",
+                    "jsonpath": "$.version"
+                }
+            ]
         },
         "packages/solid-clean": {
             "release-type": "node",


### PR DESCRIPTION
## Summary
- Adds missing `claude-plugins/commander: {}` importer entry in `pnpm-lock.yaml`
- PR #221 (graduate commander) added the plugin as workspace member but never regenerated the lockfile
- pnpm 10 silently inserts empty importer entries even with `--frozen-lockfile`, leaving repo dirty in CI
- This broke release-please's JSR publish step (run [#26368922296](https://github.com/pabloimrik17/monolab/actions/runs/26368922296)) because `deno publish` aborts on uncommitted changes

## Test plan
- [x] Reproduced locally: `pnpm install --frozen-lockfile` no longer mutates the lockfile after this fix
- [ ] After merge, manually dispatch `release-please.yml` with `packages=react-clean,react-hooks,solid-clean` to publish the pending versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped react-clean to 3.3.0
  * Bumped react-hooks to 1.3.0
  * Updated release tooling to explicitly extract versions from package manifests
  * Added a new cached test:types target (depends on build, emits JUnit-style test output)
  * Adjusted CI to stop distributed agents dynamically based on event type

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pabloimrik17/monolab/pull/224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->