### PR TITLE
fix(release): restore compact array format in deno.json

### DIFF
--- a/packages/react-clean/deno.json
+++ b/packages/react-clean/deno.json
@@ -4,9 +4,6 @@
     "license": "MIT",
     "exports": "./src/index.ts",
     "compilerOptions": {
-        "lib": [
-            "ES2023",
-            "DOM"
-        ]
+        "lib": ["ES2023", "DOM"]
     }
 }

--- a/packages/react-hooks/deno.json
+++ b/packages/react-hooks/deno.json
@@ -4,9 +4,6 @@
     "license": "MIT",
     "exports": "./src/index.ts",
     "compilerOptions": {
-        "lib": [
-            "ES2023",
-            "DOM"
-        ]
+        "lib": ["ES2023", "DOM"]
     }
 }


### PR DESCRIPTION
## Summary
- Release commit [20273e3](https://github.com/pabloimrik17/monolab/commit/20273e3) expanded `"lib": ["ES2023", "DOM"]` to multi-line in `packages/react-clean/deno.json` and `packages/react-hooks/deno.json`
- oxfmt requires the compact form → any push/PR against `main` fails `lint:oxfmt`
- Root cause: `release-please-config.json` used string-form `extra-files: ["deno.json"]` which forces a full JSON re-serialization (PR #224 fixes that for future releases)

## Test plan
- [x] `pnpm exec oxfmt --check packages/{react-clean,react-hooks}/deno.json` passes locally
- [ ] CI on this PR passes
- [ ] After merge, PR #224 (develop→main) becomes mergeable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted compiler configuration arrays in package configuration files for improved consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pabloimrik17/monolab/pull/225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->