### PR TITLE
fix(release-please): auto-format release PR with oxfmt

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,6 +24,8 @@ jobs:
         outputs:
             releases_created: ${{ steps.release.outputs.releases_created }}
             paths_released: ${{ steps.release.outputs.paths_released }}
+            prs_created: ${{ steps.release.outputs.prs_created }}
+            head_branch: ${{ fromJson(steps.release.outputs.pr || '{}').headBranchName }}
         steps:
             - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
               id: release
@@ -33,6 +35,52 @@ jobs:
                   manifest-file: .release-please-manifest.json
                   # Explicitly target main branch for release PRs
                   target-branch: main
+
+    # release-please round-trips JSON files through JSON.parse/JSON.stringify when
+    # updating versions, which expands compact arrays to multi-line (e.g.
+    # `["ES2023", "DOM"]` → multi-line). Upstream WONTFIX (release-please#2319).
+    # We re-format the release PR with oxfmt so the lint:oxfmt CI check passes.
+    prettify-pr:
+        needs: release-please
+        if: ${{ github.event_name == 'push' && needs.release-please.outputs.prs_created == 'true' && needs.release-please.outputs.head_branch != '' }}
+        runs-on: ubuntu-latest
+        continue-on-error: true
+        permissions:
+            contents: write
+        steps:
+            - name: Checkout release PR branch
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+              with:
+                  ref: ${{ needs.release-please.outputs.head_branch }}
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+              with:
+                  version: 10.27.0
+
+            - name: Setup Node.js
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+              with:
+                  node-version: "24.12.0"
+                  cache: "pnpm"
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Apply oxfmt
+              run: pnpm exec oxfmt
+
+            - name: Commit and push if changed
+              run: |
+                  if git diff --quiet; then
+                    echo "No formatting changes to commit"
+                    exit 0
+                  fi
+                  git config user.name "github-actions[bot]"
+                  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+                  git add -A
+                  git commit -m "chore: apply oxfmt to release PR"
+                  git push
 
     publish:
         needs: release-please


### PR DESCRIPTION
## Summary

Adds a `prettify-pr` job to `release-please.yml` that runs `oxfmt` against the release-please PR after creation/update and pushes the diff back as `github-actions[bot]`.

## Why

`release-please`'s JSON updater round-trips files through `JSON.parse` + `JSON.stringify(parsed, null, indent)`. With an indent argument, V8's `JSON.stringify` **always** expands arrays to multi-line — there's no API to preserve `["A","B"]` compact. Source: [`release-please/src/util/json-stringify.ts`](https://github.com/googleapis/release-please/blob/main/src/util/json-stringify.ts).

Every release bumps any deno.json/package.json containing a compact array (e.g. `"lib": ["ES2023", "DOM"]` in `packages/{react-clean,react-hooks}/deno.json`), expanding it to multi-line. oxfmt 0.36.0 then fails `lint:oxfmt --check` and CI blocks the PR.

Upstream stance: [release-please#2319](https://github.com/googleapis/release-please/issues/2319) — closed WONTFIX. Maintainer's recommendation is exactly this pattern: run a post-processing step against the release PR. Same as [Grafana faro-web-sdk](https://github.com/grafana/faro-web-sdk/blob/main/.github/workflows/release-please.yml) and [Yeoman generator](https://github.com/yeoman/generator/blob/main/.github/workflows/release-please.yml).

## Why not alternatives

- **Upgrade release-please-action v4→v5** — verified: same `jsonStringify` impl in v17.6.0; the bug is in `JSON.stringify` stdlib behavior, not version-specific
- **`type: "generic"` + `// x-release-please-version` marker** — works (verified locally) but requires JSONC source pollution in 5 deno.json files, and any future .json file added to `extra-files` needs the same marker. Post-format job covers anything automatically (CHANGELOG.md formatting issues, future package.json arrays, etc.)
- **Add deno.json to `.oxfmtrc.json` ignorePatterns** — loses lint coverage on the file entirely

## What this does

1. Adds `prs_created` + `head_branch` outputs to the `release-please` job (parsed from `steps.release.outputs.pr` which is a JSON blob)
2. New `prettify-pr` job runs when `prs_created == 'true'`:
   - Checks out the release-please PR head branch
   - `pnpm install --frozen-lockfile`
   - `pnpm exec oxfmt`
   - Commits + pushes as `github-actions[bot]` if there's any diff
3. `continue-on-error: true` so a hiccup in formatting doesn't break the release flow

## Test plan

- [ ] Merge to main
- [ ] Wait for / trigger the next release-please PR (currently PR #226 is already open with the bug reproduced — release-please will update it on next push to main)
- [ ] Verify `prettify-pr` job runs and pushes a follow-up `chore: apply oxfmt to release PR` commit to the PR branch
- [ ] Verify `lint:oxfmt` CI check on the release PR passes
- [ ] Verify subsequent release-please runs don't loop (it should accept the formatted state on diff comparison)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release automation workflow to improve code quality and reliability during the release process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pabloimrik17/monolab/pull/227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->