### PR TITLE
feat(experiments): minor update cascade + shared apply-npm-updates skill

### DIFF
--- a/claude-plugins/experiments/README.md
+++ b/claude-plugins/experiments/README.md
@@ -16,12 +16,28 @@ Apply patch-level npm updates across every project registered in the Commander r
 
 The summary partitions the resolved set into applied / failed / pending so a partial-failure run can be resumed by re-invoking the command after fixing the failed project.
 
+### `/experiments:commander-update-minor`
+
+Minor sibling of `/experiments:commander-update-patch` — identical cross-project flow (registry-driven project picker, parallel Haiku scans, dedup, max-wins alignment with the conflict-policy prompt, override consultation once per matched entry, sequential apply with stop-on-fail), only the level/target are `minor`. Thin wrapper over `commander-update-orchestrator` (`level: "minor"`, `target: "minor"`, shallow). Inherits every `npm-update-minor` hard rule: no tests, no lint, no build, no commits, never mutates the registry.
+
+```bash
+/experiments:commander-update-minor
+```
+
 ### `/experiments:commander-update-deep-patch`
 
 Deep sibling of `/experiments:commander-update-patch`. Same scope (patch-level, cross-project plan, sequential apply with stop-on-fail) plus **research deduplicated by package**: every patch changelog is fetched once across the run (no per-project duplication), subagents produce universal findings only (no codebase cross-reference — that happens at apply time), and after the bumps loop the main agent enters plan mode ONCE with a unified document of (improvement, project) pairs spanning every applied project. Gate options expand to four: `apply-all` / `apply-bumps-only` / `pick-subset` / `cancel`. Plan dirs live under `~/.claude/experiments/plans/commander-deep-patch-<unix-ts>/` and inherit the workflow's 10-day stale-cleanup. Inherits every hard rule from the shallow command plus `npm-update-deep-patch` — no tests, no lint, no build, no commits, never mutates the registry, never auto-executes an override.
 
 ```bash
 /experiments:commander-update-deep-patch
+```
+
+### `/experiments:commander-update-deep-minor`
+
+Minor sibling of `/experiments:commander-update-deep-patch` — identical deep cross-project flow (research deduplicated by package, universal-only findings, four-option gate `apply-all` / `apply-bumps-only` / `pick-subset` / `cancel`, one unified cross-project plan-mode round for improvements after the bumps loop), only the level/target are `minor`. Thin wrapper over `commander-update-orchestrator` (`level: "minor"`, `target: "minor"`, `mode: "deep"`). The surfaced `plan.md` ends with the `## Changelogs` chronology section. Plan dirs live under `~/.claude/experiments/plans/commander-deep-minor-<unix-ts>/` with the 10-day stale-cleanup. Inherits every hard rule from the shallow command plus `npm-update-deep-minor` — no tests, no lint, no build, no commits, never mutates the registry, never auto-executes an override.
+
+```bash
+/experiments:commander-update-deep-minor
 ```
 
 ### `/experiments:ralph`
@@ -54,6 +70,14 @@ Same scope as `npm-update-patch` (patch-level, semver-safe, manifest bump + one 
 /experiments:npm-update-deep-patch
 ```
 
+### `/experiments:npm-update-deep-minor`
+
+Minor sibling of `/experiments:npm-update-deep-patch` — same deep single-project flow (parallel changelog research, plan-mode synthesis, `apply-all` / `apply-bumps-only` / `pick-subset` / `cancel` gate), only the level differs. Scans at `level=minor`, runs `parallel-research-workflow` at `level: "minor"`, and applies bumps via the shared `apply-npm-updates` skill (generic-only — the deep path consults no override registry). The synthesized `plan.md` carries a `## Minor bump set` table and a final `## Changelogs` chronology section. Never runs tests, lint, build, or commits.
+
+```bash
+/experiments:npm-update-deep-minor
+```
+
 ### `/experiments:npm-update-patch`
 
 Scan the current project for patch-level npm updates and interactively apply the subset you accept. Works on pnpm/npm/yarn/bun/deno, single-repo or workspace; treats pnpm `catalog:` entries as first-class. Bumps `package.json` manifests via a single `ncu --upgrade` per file (prefix- and format-preserving), edits `pnpm-workspace.yaml#catalog` in-memory, and runs one final install unless all accepted updates were handled via `run-override`. Never runs tests, lint, or commits.
@@ -67,6 +91,14 @@ When the accepted set contains packages that ship their own upgrade command (e.g
 **Extending the override registry.** Entries live in [`skills/scan-npm-updates/data/pkg-upgrade-overrides.yaml`](./skills/scan-npm-updates/data/pkg-upgrade-overrides.yaml). Append an entry (fields: `id`, `matches`, `command`, `versionSource`, optional `fallbackVersionSource` / `reference` / `notes`) and the command picks it up on the next invocation — no logic change required. The file comment block documents each field.
 
 Tip: pair with `/experiments:npm-changelog <pkg> <from>..<to>` before accepting if you want to skim the changelog for any listed patch.
+
+### `/experiments:npm-update-minor`
+
+Minor sibling of `/experiments:npm-update-patch` — same shallow single-project flow (scan → table → `apply-all` / `pick-subset` / `cancel`, override-registry consultation per matched family), only the level differs. Scans at `level=minor` and applies the accepted set via the shared `apply-npm-updates` skill (`target: minor`): one `ncu --upgrade` per `package.json`, in-memory `pnpm-workspace.yaml#catalog` edits, one final install. Never runs tests, lint, build, or commits.
+
+```bash
+/experiments:npm-update-minor
+```
 
 ### `/experiments:npm-changelog`
 
@@ -90,7 +122,11 @@ Checks for updates to globally-installed skills.sh skills once per session. Dete
 
 ### `scan-npm-updates`
 
-Shared scan backend used by `/experiments:npm-update-patch` (and by future `npm-update-minor`/`major`/`engines` siblings). Invokes `npm-check-updates@21.0.2` via the detected package manager's dlx runner, post-processes pnpm `catalog:` entries, and returns a structured `ScanResult` JSON object. Read-only — never edits files.
+Shared scan backend used by `/experiments:npm-update-{patch,minor}` (and by future `npm-update-major`/`engines` siblings). Invokes `npm-check-updates@21.0.2` via the detected package manager's dlx runner, post-processes pnpm `catalog:` entries, and returns a structured `ScanResult` JSON object. Read-only — never edits files.
+
+### `apply-npm-updates`
+
+Shared single-project apply backend — the single source of truth for the apply mechanism. Given a fully-resolved apply spec (`packageManager`, `cwd`, `target`, `manifestBumps[]`, `catalogEdits[]`, `overrideCommands[]`, `skipInstall`), it runs one `npm-check-updates@21.0.2 --upgrade` per `package.json`, edits `pnpm-workspace.yaml#catalog` in place, runs override commands in declaration order, and runs one install — streaming `ncu`/install/override output verbatim and returning a structured result fragment (it never prints a consumer summary or abort message). Level-agnostic (parameterized solely by `target`). Also documents the caller-invoked override-resolution procedure (registry load → first-win glob match → `{version}` resolution → GENERIC/OVERRIDE_RUN/OVERRIDE_SKIP partition) consumed by the shallow single-project commands and the orchestrator. Consumed by `/experiments:npm-update-{patch,minor}`, `/experiments:npm-update-deep-{patch,minor}`, and `commander-update-orchestrator` (once per project). Never runs tests/lint/build/commits.
 
 ### `group-packages-for-research`
 

--- a/claude-plugins/experiments/commands/commander-update-deep-minor.md
+++ b/claude-plugins/experiments/commands/commander-update-deep-minor.md
@@ -96,7 +96,7 @@ If the user **approves** the plan-mode round, edits land via `Edit` / `Write` ac
 
 - `--projects a,b,c` flag — the orchestrator's interactive picker is the v1 surface. Add when a scripted caller appears.
 - `--all` flag to skip the picker — the picker has an `all` option already; CLI sugar deferred.
-- Per-project parallel apply — sequential by design (see orchestrator Decision 6 in `add-commander-update-deep-patch/design.md`).
+- Per-project parallel apply — sequential by design (see the `commander-update-orchestrator` skill).
 - Auto-rollback on failure — not a goal; the summary partition (applied / failed / pending) is the recovery surface.
 - Auto-rollback of applied bumps when the plan-mode round is rejected — bumps are preserved, user reviews `git diff` per project (same posture as single-project `/experiments:npm-update-deep-minor`).
 - Tests — manual verification only, mirroring the rest of the experiments plugin. See the change's `tasks.md` for the matrix.

--- a/claude-plugins/experiments/commands/commander-update-deep-minor.md
+++ b/claude-plugins/experiments/commands/commander-update-deep-minor.md
@@ -1,0 +1,103 @@
+---
+description: Apply minor-level npm updates across every Commander-registered project with deep research — cross-project plan, deduplicated changelog research, unified plan-mode round for improvements. No tests, no commits.
+---
+
+# commander-update-deep-minor
+
+Apply **minor-level** npm dependency updates across every project registered in the user-scoped Commander registry, in a single invocation, with deep research. Cross-project plan, **research deduplicated by package** (not per project), one cross-project synthesis, sequential apply with stop-on-fail, and one unified plan-mode round for improvements at apply time. The minor sibling of `/experiments:commander-update-deep-patch`.
+
+The command is a thin wrapper around the `commander-update-orchestrator` skill — every prompt, table, summary, plan-mode entry, and error message is produced by the skill (which composes `parallel-research-workflow` in cross-project mode for Step 6.5). The command's sole responsibility is to invoke the skill with the deep-minor input set and surface its output verbatim.
+
+> Tip: pair with `/experiments:commander-list` (read-only registry render) before running this command if you want to inspect the current project set first.
+
+## Invocation
+
+```text
+/experiments:commander-update-deep-minor
+```
+
+The command takes **no positional arguments and no flags**. The level and target are fixed at `minor`, `mode` is fixed at `deep`, and the override registry path defaults to the override file shipped with `scan-npm-updates`.
+
+## Step 1 — Argument handling
+
+1. Trim leading/trailing whitespace from `ARGUMENTS`.
+2. If the trimmed string is empty: proceed silently to Step 2.
+3. If non-empty: print exactly one line — `commander-update-deep-minor takes no arguments; ignoring: <verbatim trimmed argument string>` — then continue with Step 2 normally. Do NOT exit early.
+
+CLI flags such as `--projects`, `--all`, `--level` are not recognized in v1 and SHALL be treated as stray arguments by the rule above (the orchestrator's interactive picker is the only project-selection surface in v1).
+
+## Step 2 — Invoke the orchestrator
+
+Invoke the `commander-update-orchestrator` skill via the `Skill` tool exactly **once** with these inputs:
+
+- `level: "minor"`
+- `target: "minor"`
+- `mode: "deep"`
+- `overrideRegistryPath`: omitted (the skill defaults to `claude-plugins/experiments/skills/scan-npm-updates/data/pkg-upgrade-overrides.yaml` — same as `/experiments:commander-update-minor`).
+- `projectsFilter`: omitted (the skill raises the multi-select project picker).
+
+The command MUST NOT:
+
+- Override `level` or `target` to anything other than `minor`.
+- Override `mode` to anything other than `"deep"`.
+- Override `overrideRegistryPath`.
+- Pass a `projectsFilter` (the skill's interactive picker is the only project-selection surface in v1).
+- Wrap, intercept, or post-process the skill's output (prompts, plan table, summary, plan-mode entry, error messages).
+- Call `experiments:scan-npm-updates`, `experiments:group-packages-for-research`, `experiments:parallel-research-workflow`, `npm-check-updates`, or any package-manager command directly. Every action goes through the skill.
+
+## Step 3 — Surface the skill's output verbatim
+
+Every line the skill emits — including:
+
+- the empty-registry message (`No projects registered. Use /experiments:commander-add to register one.`),
+- the project picker (`AskUserQuestion` multi-select),
+- the workflow's phase 0 stale-cleanup prompt (`delete-stale` / `keep-stale` / `cancel`),
+- the per-batch progress messages from phase 1 changelog fetch,
+- the workflow's phase 1 hard-wall fallback prompt (if triggered),
+- the workflow's phase 3 integrity prompt (if triggered),
+- the rendered cross-project `plan.md` content (improvements + workarounds + skipped + cross-project bump set + `## Changelogs`),
+- the conflict-policy prompt (when applicable),
+- the override prompts (one per matched entry),
+- the four-option deep gate (`apply-all` / `apply-bumps-only` / `pick-subset` / `cancel`),
+- the per-project `ncu` and `<pm> install` stdout/stderr during Step 10a,
+- the `EnterPlanMode` document for Step 10b (when applicable),
+- the workflow's end-of-flow cleanup prompt (`delete-plan` / `keep-plan`) raised by Step 10c,
+- the cross-project deep summary,
+- every error or abort message,
+
+— SHALL be surfaced verbatim. The command exits with the skill's exit code.
+
+## Hard rules
+
+Inherited from `commander-update-orchestrator` (deep mode) and `/experiments:npm-update-deep-minor`. The command preserves every one of them:
+
+- Never run tests, lint, or build at any point.
+- Never create git commits, branches, or pull requests.
+- Never modify any file when the user selects `cancel` at the orchestrator's confirmation gate or rejects the plan-mode round at Step 10b.3.
+- Never mutate `<HOME>/.claude/commander/projects.json` — the registry is read-only on this path. The on-disk file SHALL be byte-identical before and after every run (verifiable via `shasum`).
+- Never mutate a consumer `package.json` entry that is a `catalog:` reference — only `pnpm-workspace.yaml` for those.
+- Never auto-execute an override command without the user selecting `run-override` explicitly for that entry.
+- Never run `ncu --upgrade` as a fallback after an override command fails.
+- Never expand the plan-mode round's scope beyond bullets present in `plan.md` (adjacent opportunities discovered during reconnaissance go to the summary's `Suggested next steps`, never silently into the plan).
+
+## Plan-mode round semantics (deep-specific)
+
+When the gate option is `apply-all` and Step 10a (bumps loop) completes successfully for at least one project AND `plan.md` has at least one improvement bullet, Step 10b enters plan-mode ONCE with a unified document covering every (improvement bullet, applied project) pair:
+
+- **Applicable** pairs are presented with concrete edits — absolute file path, short description, before/after snippet for non-trivial edits.
+- **Inapplicable** pairs are presented with a one-sentence reason captured during reconnaissance (`Project uses Solid, not React; useTransition has no equivalent here.`).
+- The plan-mode footer counts `applicable: <N>` / `inapplicable: <M>` so the user knows the breakdown before approving.
+
+If the user **approves** the plan-mode round, edits land via `Edit` / `Write` across every applicable project; if they **reject**, bumps already applied in Step 10a are PRESERVED (no rollback) — only the improvement edits are skipped, and the summary surfaces `Improvements rejected at plan-mode review. No improvement edits applied; bumps are preserved.`
+
+`apply-bumps-only` SKIPS Step 10b entirely (the summary's `Applied improvements` section is omitted). `pick-subset` accepts both improvement-bullet titles (case-insensitive substring match) AND package names (exact match) for fine-grained exclusion.
+
+## Non-goals (deferred)
+
+- `--projects a,b,c` flag — the orchestrator's interactive picker is the v1 surface. Add when a scripted caller appears.
+- `--all` flag to skip the picker — the picker has an `all` option already; CLI sugar deferred.
+- Per-project parallel apply — sequential by design (see orchestrator Decision 6 in `add-commander-update-deep-patch/design.md`).
+- Auto-rollback on failure — not a goal; the summary partition (applied / failed / pending) is the recovery surface.
+- Auto-rollback of applied bumps when the plan-mode round is rejected — bumps are preserved, user reviews `git diff` per project (same posture as single-project `/experiments:npm-update-deep-minor`).
+- Tests — manual verification only, mirroring the rest of the experiments plugin. See the change's `tasks.md` for the matrix.
+- `/experiments:commander-update-deep-{major,engines}` — separate sub-issues (MON-201, MON-202). They reuse the orchestrator's deep mode and the workflow's cross-project mode with a different `level`/`target` pair; this command is minor-only by contract.

--- a/claude-plugins/experiments/commands/commander-update-minor.md
+++ b/claude-plugins/experiments/commands/commander-update-minor.md
@@ -1,0 +1,80 @@
+---
+description: Apply minor-level npm updates across every project registered in the user-scoped Commander registry. Cross-project plan, deduplicated bumps, sequential apply with stop-on-fail. Reads ~/.claude/commander/projects.json; never mutates the registry. No tests, no commits.
+---
+
+# commander-update-minor
+
+Apply **minor-level** npm dependency updates across every project registered in the user-scoped Commander registry, in a single invocation. Cross-project plan, deduplicated bumps, sequential apply with stop-on-fail. The minor sibling of `/experiments:commander-update-patch`.
+
+The command is a thin wrapper around the `commander-update-orchestrator` skill — every prompt, table, summary, and error message is produced by the skill. The command's sole responsibility is to invoke the skill with the minor-specific inputs and surface its output verbatim.
+
+> Tip: pair with `/experiments:commander-list` (read-only registry render) before running this command if you want to inspect the current project set first.
+
+## Invocation
+
+```text
+/experiments:commander-update-minor
+```
+
+The command takes **no positional arguments and no flags**. The level and target are fixed at `minor`; the override registry path defaults to the override file shipped with `scan-npm-updates`.
+
+## Step 1 — Argument handling
+
+1. Trim leading/trailing whitespace from `ARGUMENTS`.
+2. If the trimmed string is empty: proceed silently to Step 2.
+3. If non-empty: print exactly one line — `commander-update-minor takes no arguments; ignoring: <verbatim trimmed argument string>` — then continue with Step 2 normally. Do NOT exit early.
+
+## Step 2 — Invoke the orchestrator
+
+Invoke the `commander-update-orchestrator` skill via the `Skill` tool exactly **once** with these inputs:
+
+- `level: "minor"`
+- `target: "minor"`
+- `mode`: omitted (defaults to `shallow`)
+- `overrideRegistryPath`: omitted (the skill defaults to `claude-plugins/experiments/skills/scan-npm-updates/data/pkg-upgrade-overrides.yaml`)
+- `projectsFilter`: omitted (the skill raises the multi-select project picker)
+
+The command MUST NOT:
+
+- Override `level` or `target` to anything other than `minor`.
+- Set `mode` to `deep`.
+- Override `overrideRegistryPath`.
+- Pass a `projectsFilter` (the skill's interactive picker is the only project-selection surface in v1).
+- Wrap, intercept, or post-process the skill's output (prompts, plan table, summary, error messages).
+- Call `experiments:scan-npm-updates`, `npm-check-updates`, or any package-manager command directly. Every action goes through the skill.
+
+## Step 3 — Surface the skill's output verbatim
+
+Every line the skill emits — including:
+
+- the empty-registry message (`No projects registered. Use /experiments:commander-add to register one.`),
+- the project picker (`AskUserQuestion` multi-select),
+- the plan table,
+- the conflict-policy prompt (when applicable),
+- the override prompts (one per matched entry),
+- the apply-all / pick-subset / cancel prompt,
+- the per-project `ncu` and `<pm> install` stdout/stderr,
+- the cross-project summary,
+- every error or abort message,
+
+— SHALL be surfaced verbatim. The command exits with the skill's exit code.
+
+## Hard rules
+
+Inherited from `/experiments:npm-update-minor` and the orchestrator. The command preserves every one of them:
+
+- Never run tests, lint, or build.
+- Never create commits, branches, or pull requests.
+- Never modify any file when the user selects `cancel` at the orchestrator's confirmation gate.
+- Never mutate `<HOME>/.claude/commander/projects.json` — the registry is read-only on this path. The on-disk file SHALL be byte-identical before and after every run (verifiable via `shasum`).
+- Never mutate a consumer `package.json` entry that is a `catalog:` reference — only `pnpm-workspace.yaml` for those.
+- Never auto-execute an override command without the user selecting `run-override` explicitly for that entry.
+- Never run `ncu --upgrade` as a fallback after an override command fails.
+
+## Non-goals (deferred)
+
+- `--projects a,b,c` flag — the orchestrator's interactive picker is the v1 surface. Add when a scripted caller appears.
+- `--all` flag to skip the picker — the picker has an `all` option already; CLI sugar deferred.
+- Per-project parallel apply — sequential by design (see orchestrator Decision 2).
+- Auto-rollback on failure — not a goal; the summary partition (applied / failed / pending) is the recovery surface.
+- Tests — manual verification only, mirroring the rest of the experiments plugin. See the change's `tasks.md` for the matrix.

--- a/claude-plugins/experiments/commands/npm-update-deep-minor.md
+++ b/claude-plugins/experiments/commands/npm-update-deep-minor.md
@@ -1,18 +1,18 @@
 ---
-description: Scan, fetch every patch changelog in parallel, research applicable improvements/workarounds against this codebase, then drive a user-gated apply step. Patch level only. No tests/lint/build/commits.
+description: Scan, fetch every minor changelog in parallel, research applicable improvements/workarounds against this codebase, then drive a user-gated apply step. Minor level only. No tests/lint/build/commits.
 ---
 
-# npm-update-deep-patch
+# npm-update-deep-minor
 
-The "deep" sibling of `/experiments:npm-update-patch`. Same scope (patch-level, semver-safe, manifest bumps + one install), but with research: every changelog is fetched in parallel by subagents who cross-reference it against this codebase, then the main agent enters plan mode and synthesizes a single integrated plan of applicable improvements + workarounds-resolved-by-upgrade, plus the bump set. The user picks what to apply.
+The "deep" sibling of `/experiments:npm-update-minor`. Same scope (minor-level, manifest bumps + one install), but with research: every changelog is fetched in parallel by subagents who cross-reference it against this codebase, then the main agent enters plan mode and synthesizes a single integrated plan of applicable improvements + workarounds-resolved-by-upgrade, plus the bump set. The user picks what to apply. The deep single-project sibling of `/experiments:npm-update-deep-patch` — identical in flow, only the level differs.
 
-This command operates exclusively at **patch level**. It always passes `level=patch` to the scan skill and ignores any user-supplied level argument.
+This command operates exclusively at **minor level**. It always passes `level=minor` to the scan skill and to `parallel-research-workflow`, and ignores any user-supplied level argument.
 
 > Tip: this command **never runs tests, lint, build, or commits**. It bumps manifests and runs a single install at most. The summary recommends those as next steps; the caller decides.
 
 ## Step 1 — Scan
 
-Invoke the `experiments:scan-npm-updates` skill with `level=patch`. Parse the JSON result into a `ScanResult` value with shape:
+Invoke the `experiments:scan-npm-updates` skill with `level=minor`. Parse the JSON result into a `ScanResult` value with shape:
 
 ```ts
 {
@@ -33,7 +33,7 @@ If `updates.length === 0`:
 2. Print exactly:
 
     ```text
-    No patch updates available.
+    No minor updates available.
     ```
 
 3. Exit. Do NOT invoke grouping. Do NOT invoke the research workflow. Do NOT create a plan directory.
@@ -53,18 +53,18 @@ Append the grouping skill's `warnings` to a running list for surfacing at summar
 
 ## Step 4 — Dispatch the parallel research workflow
 
-Invoke the `parallel-research-workflow` skill with input `{ groups, level: "patch", scanResult }` (the `scanResult` here is the original `ScanResult` from Step 1, unchanged).
+Invoke the `parallel-research-workflow` skill with input `{ groups, level: "minor", scanResult }` (the `scanResult` here is the original `ScanResult` from Step 1, unchanged), single-project mode.
 
 The workflow handles, in order, all of:
 
 - Phase 0 — stale-plan cleanup prompt (`delete-stale` / `keep-stale` / `cancel`).
-- Plan-dir creation under `~/.claude/experiments/plans/<slug>-patch-<unix-ts>/`, with `scan.json` + global `_meta.json` written.
+- Plan-dir creation under `~/.claude/experiments/plans/<slug>-minor-<unix-ts>/`, with `scan.json` + global `_meta.json` written.
 - Phase 1 — parallel changelog fetch (one subagent per group, each invoking `experiments:npm-changelog` per package).
 - Phase 2 — parallel codebase research (the same subagents continue, writing `research.md` per group).
 - Phase 3 — integrity verification (`retry-failed` / `continue-without` / `abort` only fires if any group is non-healthy).
-- Phase 4 — plan-mode synthesis: the main agent enters plan mode and writes `plan.md` at the plan-dir root.
+- Phase 4 — plan-mode synthesis: the main agent enters plan mode and writes `plan.md` at the plan-dir root (with a `## Minor bump set` table and the `## Changelogs` chronology section).
 
-Surface progress messages emitted by the workflow as they are produced. The command SHALL NOT advance the workflow's phases on its behalf, and SHALL NOT dispatch subagents itself — the workflow is fully responsible for the orchestration above. The command's only responsibility during Steps 4 is to wait for the workflow to finish.
+Surface progress messages emitted by the workflow as they are produced. The command SHALL NOT advance the workflow's phases on its behalf, and SHALL NOT dispatch subagents itself — the workflow is fully responsible for the orchestration above. The command's only responsibility during Step 4 is to wait for the workflow to finish.
 
 Early-exit handling:
 
@@ -78,8 +78,8 @@ When the workflow returns successfully (i.e. `plan.md` exists at the plan-dir ro
 - **Question**: `Plan synthesized. <plan-dir>/plan.md is ready for review. How do you want to proceed?`
 - **Multi-select**: `false`
 - **Options** (in this exact order):
-  - `apply-all` — execute every item in the plan: bump every package in the `Patch bump set` table AND apply every bullet in the `Improvements (applicable to this codebase)` section.
-  - `apply-bumps-only` — bump every package in the `Patch bump set` table; skip improvements entirely. Equivalent in net effect to running the shallow `/experiments:npm-update-patch` against the same set, with no override-registry logic (see hard rules).
+  - `apply-all` — execute every item in the plan: bump every package in the `Minor bump set` table AND apply every bullet in the `Improvements (applicable to this codebase)` section.
+  - `apply-bumps-only` — bump every package in the `Minor bump set` table; skip improvements entirely. Equivalent in net effect to running the shallow `/experiments:npm-update-minor` against the same set, with no override-registry logic (see hard rules).
   - `pick-subset` — accept a free-form list of plan items (specific improvements + specific bumps) to apply.
   - `cancel` — exit without modifying any file. Plan dir is preserved on disk pending the cleanup prompt.
 
@@ -91,14 +91,14 @@ Branch on the selected option.
 
 ### Step 6a — `apply-all` and `apply-bumps-only` (bumps mechanism, shared)
 
-Apply patch-level bumps by invoking the **`apply-npm-updates` skill** — the single source of truth for the single-project apply mechanism (generic `ncu` `package.json` bumps, `pnpm-workspace.yaml` catalog edits, single install). The command builds the resolved spec and invokes the skill **once** with `target: "patch"`; it does NOT restate the `ncu` / catalog / install recipe inline.
+Apply minor-level bumps by invoking the **`apply-npm-updates` skill** — the single source of truth for the single-project apply mechanism (generic `ncu` `package.json` bumps, `pnpm-workspace.yaml` catalog edits, single install). The command builds the resolved spec and invokes the skill **once** with `target: "minor"`; it does NOT restate the `ncu` / catalog / install recipe inline.
 
 Build the resolved apply spec from the accepted set (all updates for `apply-all`/`apply-bumps-only`; `ACCEPTED_BUMPS` for `pick-subset`):
 
-- `packageManager` = the scan's `packageManager`. `cwd` = the project root. `target` = `"patch"`. `cooldown` = the value the scan resolved (omit for `pnpm`).
+- `packageManager` = the scan's `packageManager`. `cwd` = the project root. `target` = `"minor"`. `cooldown` = the value the scan resolved (omit for `pnpm`).
 - `manifestBumps` — one element per distinct `package.json` `sourceFile`: `{ sourceFile, names, includeFilter }`. Set `includeFilter: true` only when this invocation's bumps for the file are a strict subset of ncu's own detected set (i.e. `pick-subset` partial inclusion); otherwise `false`.
 - `catalogEdits` — one element per accepted update with `sourceFile === "pnpm-workspace.yaml"`: `{ name, targetVersion }`.
-- `overrideCommands` — **empty** (`[]`). The deep path consults NO override registry: the override flow stays the shallow `/experiments:npm-update-patch` path's responsibility (see hard rules).
+- `overrideCommands` — **empty** (`[]`). The deep path consults NO override registry: the override flow stays the shallow `/experiments:npm-update-minor` path's responsibility (see hard rules).
 - `skipInstall` — `false` (the deep path always runs the single install after writing manifests).
 
 The skill runs `npm-check-updates@21.0.2` per manifest, performs the in-memory catalog edits, runs **exactly one** install at the end, streams `ncu`/install stdout/stderr verbatim, and returns `{ appliedGeneric, appliedOverrides, installRan, failure }`.
@@ -110,7 +110,7 @@ On a structured `failure`, print the command-owned abort copy for the failing `s
     ```text
     ncu --upgrade failed on {sourceFile} (exit {code}).
     Applied before this failure: {manifest paths already rewritten}.
-    Re-run /experiments:npm-update-deep-patch to retry the rest.
+    Re-run /experiments:npm-update-deep-minor to retry the rest.
     ```
 
 - `step: "catalog"` →
@@ -118,7 +118,7 @@ On a structured `failure`, print the command-owned abort copy for the failing `s
     ```text
     Failed to bump {name} in pnpm-workspace.yaml: {reason}.
     Applied so far: {names already written on disk}.
-    Re-run /experiments:npm-update-deep-patch to retry the rest.
+    Re-run /experiments:npm-update-deep-minor to retry the rest.
     ```
 
 - `step: "install"` →
@@ -133,7 +133,7 @@ For `apply-bumps-only`: stop here, jump to Step 7. Improvements are skipped enti
 
 After the bumps install completes successfully, the command SHALL apply the `Improvements (applicable to this codebase)` bullets from `plan.md` **via Claude Code plan mode** (not via blind edits). Concrete sequence:
 
-1. **Reconnaissance pass.** For each improvement bullet, the main agent reads the area hints (file globs, directory hints) and the relevant files to determine the concrete edits the bullet would translate into in this specific codebase. Bullets whose opportunity does not actually land here (e.g. require a Hono RPC client when the repo only uses Hono server-side) are flagged as `inapplicable` with a one-sentence reason.
+1. **Reconnaissance pass.** For each improvement bullet, the main agent reads the area hints (file globs, directory hints) and the relevant files to determine the concrete edits the bullet would translate into in this specific codebase. Bullets whose opportunity does not actually land here are flagged as `inapplicable` with a one-sentence reason.
 2. **Plan-mode entry (mandatory).** The main agent invokes the `EnterPlanMode` tool with a markdown plan that lists, in order:
     - The applicable improvements with the concrete edits they translate to: file path, brief description of the change, and (for non-trivial edits) the before/after snippet so the user can preview the effect.
     - The inapplicable improvements with their reason — explicitly listed so the user knows what was researched and why nothing was applied for those bullets.
@@ -146,14 +146,12 @@ The improvements step SHALL NOT expand scope beyond bullets present in `plan.md`
 
 The improvements step SHALL NOT execute tests, lint, or build. SHALL NOT create commits or PRs.
 
-**Why plan mode is mandatory here**: this is the only point in the workflow where the command modifies workspace files based on synthesized research that the user has not yet seen rendered as concrete edits. The earlier apply-choice prompt (Step 5) commits the user to a path; plan mode lets them veto specifically the improvements before any source file is touched. Without it, the user only learns "0 of 10 improvements were actually applicable to my codebase" via the Step 7 summary, which is too late to course-correct.
-
 ### Step 6c — `pick-subset`
 
 Free-form selection over both the improvement bullets and the bumps:
 
 1. Compute `IMPROVEMENT_TITLES` = the leading text of each `-` bullet under `## Improvements (applicable to this codebase)` in `plan.md` (one identifier per bullet; keep enough context to disambiguate).
-2. Compute `BUMP_NAMES` = unique package names from the `## Patch bump set` table.
+2. Compute `BUMP_NAMES` = unique package names from the `## Minor bump set` table.
 3. Ask the user (free-form message, no AskUserQuestion):
 
     ```text
@@ -178,7 +176,7 @@ Free-form selection over both the improvement bullets and the bumps:
     - `ACCEPTED_BUMPS = updates from scanResult whose name is in the bump-classified selections`.
     - `ACCEPTED_IMPROVEMENTS = improvement bullets whose title text matches one of the improvement-classified selections`.
     - `SKIPPED_IMPROVEMENTS = (all improvement bullets) − ACCEPTED_IMPROVEMENTS`.
-8. If `ACCEPTED_BUMPS` is non-empty → reuse Step 6a's bumps mechanism with `ACCEPTED_BUMPS` instead of all updates (passing `--filter` to ncu when `ACCEPTED_BUMPS` for a `package.json` is a strict subset of that file's full bump set).
+8. If `ACCEPTED_BUMPS` is non-empty → reuse Step 6a's bumps mechanism (the `apply-npm-updates` invocation) with `ACCEPTED_BUMPS` instead of all updates (setting `includeFilter` on a `package.json` element when `ACCEPTED_BUMPS` for that file is a strict subset of its full bump set).
 9. If `ACCEPTED_IMPROVEMENTS` is non-empty → reuse Step 6b's plan-mode mechanism with `ACCEPTED_IMPROVEMENTS` as the in-scope bullets only.
 10. If both empty after parsing → equivalent to `cancel`; print `Cancelled. No files modified.` and skip to Step 7.
 
@@ -199,7 +197,7 @@ Skip to Step 7. The plan dir is preserved.
 Print a markdown summary:
 
 ```markdown
-## npm-update-deep-patch summary
+## npm-update-deep-minor summary
 ```
 
 Then emit, **conditionally**, these sections (omit any whose count is zero, except `Suggested next steps` which is always present):
@@ -219,7 +217,7 @@ Then emit, **conditionally**, these sections (omit any whose count is zero, exce
 For the `cancel` path specifically, the summary contains:
 
 ```markdown
-## npm-update-deep-patch summary
+## npm-update-deep-minor summary
 
 Cancelled. No files modified.
 
@@ -229,6 +227,8 @@ Cancelled. No files modified.
 - Run lint / typecheck.
 - Review changes (`git diff`) and commit.
 ```
+
+The `plan.md` the command surfaces includes the `## Changelogs` chronology section produced by `parallel-research-workflow`.
 
 ## Step 8 — Cleanup
 
@@ -242,5 +242,5 @@ The command invokes the workflow's cleanup exactly once at this step. The workfl
 - The command SHALL NOT create git commits or open pull requests.
 - The command SHALL NOT modify any file when the user selects `cancel`. The plan dir under `~/.claude/experiments/plans/` is preserved (it is not part of the workspace) until the user selects `delete-plan` at cleanup.
 - The command SHALL NOT mutate any consumer `package.json` entry that is a `catalog:` reference — only `pnpm-workspace.yaml` for those.
-- The command SHALL NOT consult the package upgrade override registry. Override flows (Storybook, etc.) belong to `/experiments:npm-update-patch`'s shallow path; the deep path goes straight through ncu + catalog edits. (The plan can mention overridable family upgrades as improvements; the user then picks whether to apply them via the standard mechanism.)
-- The command SHALL ignore any user-supplied `level` argument and always pass `level=patch` to `scan-npm-updates`.
+- The command SHALL NOT consult the package upgrade override registry. Override flows (Storybook, etc.) belong to `/experiments:npm-update-minor`'s shallow path; the deep path goes straight through ncu + catalog edits (`apply-npm-updates` with empty `overrideCommands`). (The plan can mention overridable family upgrades as improvements; the user then picks whether to apply them via the standard mechanism.)
+- The command SHALL ignore any user-supplied `level` argument and always pass `level=minor` to `scan-npm-updates` and `parallel-research-workflow`.

--- a/claude-plugins/experiments/commands/npm-update-minor.md
+++ b/claude-plugins/experiments/commands/npm-update-minor.md
@@ -1,18 +1,20 @@
 ---
-description: Scan and interactively apply npm patch-level updates across a workspace or single repo (bump + install only, no tests/commits).
+description: Scan and interactively apply npm minor-level updates across a workspace or single repo (bump + install only, no tests/commits).
 ---
 
-# npm-update-patch
+# npm-update-minor
 
-Scan the current project for **patch-level** dependency updates, present them to the user, and apply the accepted subset. Project-agnostic: works on pnpm/npm/yarn/bun/deno, single-repo or workspace, and treats pnpm `catalog:` entries as first-class.
+Scan the current project for **minor-level** dependency updates, present them to the user, and apply the accepted subset. The shallow single-project sibling of `/experiments:npm-update-patch` — identical flow, only the level differs. Project-agnostic: works on pnpm/npm/yarn/bun/deno, single-repo or workspace, and treats pnpm `catalog:` entries as first-class.
 
-The command **only bumps manifests and runs a single install**. It does NOT run tests, lint, build, or create commits — that is explicitly out of scope. The final summary suggests those as next steps; the caller decides.
+The command **only bumps manifests and runs a single install** (via the `apply-npm-updates` skill). It does NOT run tests, lint, build, or create commits — that is explicitly out of scope. The final summary suggests those as next steps; the caller decides.
+
+This command operates exclusively at **minor level**. It always passes `level=minor` to the scan skill and ignores any user-supplied level argument.
 
 > Tip: if you want to read a dep's changelog before accepting, use `/experiments:npm-changelog <pkg> <from>..<to>` as a natural pre-step.
 
 ## Step 1 — Scan
 
-Invoke the `experiments:scan-npm-updates` skill with `level=patch`. Parse the JSON result into a `ScanResult` value with shape:
+Invoke the `experiments:scan-npm-updates` skill with `level=minor`. Parse the JSON result into a `ScanResult` value with shape:
 
 ```ts
 {
@@ -33,7 +35,7 @@ If `updates.length === 0`:
 2. Print exactly:
 
     ```text
-    No patch updates available.
+    No minor updates available.
     ```
 
 3. Exit without prompting.
@@ -59,7 +61,7 @@ If `updates.length > 0`, render a markdown table to the user:
 
 Use **AskUserQuestion** with one question:
 
-- **Question**: `Apply patch updates?`
+- **Question**: `Apply minor updates?`
 - **Multi-select**: `false`
 - **Options**:
   - `apply-all` — "Bump every listed update and run a single install."
@@ -70,7 +72,7 @@ Branch on the selected option.
 
 ## Step 5a — `apply-all`
 
-Let `ACCEPTED = updates`. Proceed to Step 6.
+Let `ACCEPTED = updates`. Proceed to Step 5.5.
 
 ## Step 5b — `pick-subset`
 
@@ -83,13 +85,13 @@ Let `ACCEPTED = updates`. Proceed to Step 6.
     ```
 
 3. Parse the response by splitting on commas and newlines, trimming whitespace, and removing empty tokens. Result: `EXCLUDED`.
-4. If `EXCLUDED === []` → treat as `apply-all` (let `ACCEPTED = updates`, proceed to Step 6).
+4. If `EXCLUDED === []` → treat as `apply-all` (let `ACCEPTED = updates`, proceed to Step 5.5).
 5. Validate that every name in `EXCLUDED` is in `VALID_NAMES`. If any are not:
     - Print: `Unknown package name(s): {invalid names}. Valid names: {VALID_NAMES}.`
     - Re-prompt from step 5b.2. Repeat until input validates.
 6. Let `ACCEPTED = updates where name is not in EXCLUDED`. Let `SKIPPED = updates where name is in EXCLUDED`.
 7. If `ACCEPTED.length === 0` → print `All updates excluded; nothing to apply.` and exit without touching files.
-8. Otherwise proceed to Step 6.
+8. Otherwise proceed to Step 5.5.
 
 ## Step 5c — `cancel`
 
@@ -149,31 +151,31 @@ If every update in `ACCEPTED` falls under `OVERRIDE_SKIP` and `OVERRIDE_RUN` is 
 
 ## Step 6 — Build the apply spec and invoke `apply-npm-updates`
 
-The `apply-npm-updates` skill is the single source of truth for the mechanical apply (generic `ncu` bumps, catalog edits, override commands, single install). The command builds the resolved spec and invokes it **once** with `target: patch`; it does NOT restate the `ncu` / catalog / install recipe inline.
+The `apply-npm-updates` skill is the single source of truth for the mechanical apply (generic `ncu` bumps, catalog edits, override commands, single install). The command builds the resolved spec and invokes it **once** with `target: minor`; it does NOT restate the `ncu` / catalog / install recipe inline.
 
 ### Build the resolved apply spec
 
 From the partition computed in Step 5.5:
 
-- `packageManager` = the scan's `packageManager`. `cwd` = the project root. `target` = `"patch"`.
+- `packageManager` = the scan's `packageManager`. `cwd` = the project root. `target` = `"minor"`.
 - `cooldown` = the release-age period the scan resolved (omit for `pnpm`).
-- `manifestBumps` — one element per distinct `GENERIC` `package.json` `sourceFile`: `{ sourceFile, names: <GENERIC names for this file>, includeFilter }`. Set `includeFilter: true` when the GENERIC set for the file is a strict subset of ncu's detectable candidates — i.e. the primary prompt was `pick-subset` with at least one exclusion, OR any update for this file was removed by `OVERRIDE_RUN`/`OVERRIDE_SKIP`. Otherwise `includeFilter: false` (full-set apply; ncu's own set equals the target set).
+- `manifestBumps` — one element per distinct `GENERIC` `package.json` `sourceFile`: `{ sourceFile, names: <GENERIC names for this file>, includeFilter }`. Set `includeFilter: true` when the GENERIC set for the file is a strict subset of ncu's detectable candidates — i.e. the primary prompt was `pick-subset` with at least one exclusion, OR any update for this file was removed by `OVERRIDE_RUN`/`OVERRIDE_SKIP`. Otherwise `includeFilter: false`.
 - `catalogEdits` — one element per `GENERIC` update with `sourceFile === "pnpm-workspace.yaml"`: `{ name, targetVersion }`.
 - `overrideCommands` — the `OVERRIDE_RUN` entries as `{ id, command: <interpolated command> }`, in declaration order.
-- `skipInstall` — `true` when `OVERRIDE_RUN` is non-empty, `OVERRIDE_SKIP`/`GENERIC` produce no write (every accepted update handled by `run-override` and nothing written outside the override commands); otherwise `false`.
+- `skipInstall` — `true` when `OVERRIDE_RUN` is non-empty and every accepted update was handled by `run-override` with nothing written outside the override commands; otherwise `false`.
 
 ### Invoke and handle the result
 
 Invoke `apply-npm-updates` once with the spec. The skill streams `ncu` / install / override stdout/stderr verbatim and returns `{ appliedGeneric, appliedOverrides, installRan, failure }`.
 
-On a structured `failure`, print the canonical abort copy for the failing `step` (this copy is command-owned), then stop without running anything further:
+On a structured `failure`, print the command-owned abort copy for the failing `step`, then stop without running anything further:
 
 - `step: "ncu"` →
 
     ```text
     ncu --upgrade failed on {sourceFile} (exit {code}).
     Applied before this failure: {manifest paths already rewritten}.
-    Re-run /experiments:npm-update-patch to retry the rest.
+    Re-run /experiments:npm-update-minor to retry the rest.
     ```
 
 - `step: "catalog"` →
@@ -181,7 +183,7 @@ On a structured `failure`, print the canonical abort copy for the failing `step`
     ```text
     Failed to bump {name} in pnpm-workspace.yaml: {reason}.
     Applied so far: {names already written on disk}.
-    Re-run /experiments:npm-update-patch to retry the rest.
+    Re-run /experiments:npm-update-minor to retry the rest.
     ```
 
 - `step: "override"` →
@@ -206,7 +208,7 @@ On success, proceed to Step 8 with the returned result fragment.
 Compose the summary from the `apply-npm-updates` result fragment (Step 6) — `{Ng}` = `appliedGeneric.length`, `{No}` = `appliedOverrides.length`, the `Install:` line from `installRan` — plus the command-owned skip sets (`{Ns_o}` = `OVERRIDE_SKIP`, `{Ns_u}` = user-excluded). After a successful apply, print:
 
 ```markdown
-## npm-update-patch summary
+## npm-update-minor summary
 
 **Applied generically via ncu ({Ng}):**
 
@@ -250,3 +252,4 @@ Compose the summary from the `apply-npm-updates` result fragment (Step 6) — `{
 - Never mutate a consumer `package.json` entry that is a `catalog:` reference — only `pnpm-workspace.yaml` for those.
 - Never auto-execute an override command without the user selecting `run-override` explicitly for that entry.
 - Never run `ncu --upgrade` as a fallback after an override command fails.
+- Always pass `level=minor` to `scan-npm-updates`; ignore any user-supplied level argument.

--- a/claude-plugins/experiments/skills/apply-npm-updates/SKILL.md
+++ b/claude-plugins/experiments/skills/apply-npm-updates/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: apply-npm-updates
+description: Use when a single-project npm update command (`/experiments:npm-update-patch`, `/experiments:npm-update-minor`, their deep variants) or the `commander-update-orchestrator` (once per project) needs to perform the mechanical apply of a fully-resolved update set — generic `package.json` bumps via `npm-check-updates`, `pnpm-workspace.yaml` catalog edits, override commands, and one install. Level-agnostic (parameterized by `target`). Also documents the caller-invoked override-resolution procedure (registry load → first-win glob match → `{version}` resolution → GENERIC/OVERRIDE_RUN/OVERRIDE_SKIP partition). Performs writes only; streams ncu/install verbatim; returns a structured result fragment and NEVER prints a consumer summary or abort message. No tests, lint, build, or commits.
+---
+
+# apply-npm-updates
+
+The single source of truth for the **single-project npm apply mechanism**. The caller resolves conflict policy, override decisions, and `--filter` membership; this skill performs the writes and returns a structured fragment. It is parameterized solely by `target` (= the update level) — the same skill serves `patch`, `minor`, `major`, and `engines` callers identically.
+
+Two things live here:
+
+- **(a) A mechanical apply contract** — Steps A1–A6 below. Caller passes a fully-resolved per-project apply spec; the skill writes manifests, runs overrides, runs one install, and streams `ncu`/install/override stdout/stderr verbatim.
+- **(b) A reusable override-resolution procedure** — the "Override-resolution procedure" section below. Callers that opt into overrides invoke it to turn a candidate package set into matched entries + interpolated commands + a GENERIC/OVERRIDE_RUN/OVERRIDE_SKIP partition. The interactive prompt and the resolution *scope* stay caller-owned.
+
+## When to use
+
+- `/experiments:npm-update-patch` / `/experiments:npm-update-minor` (shallow single-project) — caller resolves overrides via procedure (b) + its own prompt, then invokes (a) once.
+- `/experiments:npm-update-deep-patch` / `/experiments:npm-update-deep-minor` (deep single-project) — caller invokes (a) once with an empty `overrideCommands` set (the deep path consults NO override registry).
+- `commander-update-orchestrator` — invokes (a) **once per project** with that project's resolved spec; resolves overrides cross-project via procedure (b) + its own cross-project prompt.
+
+The skill is meant for command-layer / skill-layer composition. It performs writes only — it does NOT scan, group, prompt for an apply path, or compose the user-facing summary.
+
+This skill is implemented entirely with Claude Code built-in tools (`Read`, `Bash`, `Edit`, `Write`). It introduces no new runtime dependency, library, or sidecar package.
+
+---
+
+## Mechanical apply contract (a)
+
+### Input spec
+
+The caller passes a fully-resolved, single-project apply spec with exactly these fields:
+
+| Field              | Type                                                          | Required | Notes                                                                                                                                                                       |
+| ------------------ | ------------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packageManager`   | `"pnpm" \| "npm" \| "yarn" \| "bun" \| "deno"`                | yes      | Selects the runner prefix and the install command. Rejected if unknown.                                                                                                     |
+| `cwd`              | `string` (absolute)                                           | yes      | Project root whose manifests are bumped. Every `Bash` call runs with this working directory (`cd "<cwd>" && …`) or uses absolute `--packageFile` paths. No shell-state leak. |
+| `target`           | `"patch" \| "minor" \| "major" \| "engines"`                  | yes      | Passed verbatim to `ncu --target`. Rejected if unknown.                                                                                                                     |
+| `cooldown`         | `string`                                                      | no       | Release-age period for `ncu --cooldown`. Omitted for `pnpm` (ncu reads `pnpm-workspace.yaml` natively).                                                                      |
+| `manifestBumps`    | `Array<{ sourceFile, names: string[], includeFilter: bool }>` | no       | One `package.json` manifest per element. One `ncu` call per element.                                                                                                         |
+| `catalogEdits`     | `Array<{ name, targetVersion }>`                              | no       | `pnpm-workspace.yaml` `catalog:` key edits, in-place.                                                                                                                        |
+| `overrideCommands` | `Array<{ id, command }>`                                      | no       | Already-interpolated override commands, in declaration order.                                                                                                               |
+| `skipInstall`      | `boolean` (default `false`)                                   | no       | When `true`, skip the final install (every accepted package was handled by an override that runs its own install).                                                          |
+
+The spec is consumed **as-is**: the skill performs no override matching, no conflict resolution, and no `pick-subset` parsing of its own. The caller already partitioned `manifestBumps` / `catalogEdits` / `overrideCommands`.
+
+### Step A0 — Validate before any side effect
+
+- If `packageManager` is not one of `pnpm` / `npm` / `yarn` / `bun` / `deno`: abort with `Error: invalid packageManager "<value>". Expected pnpm|npm|yarn|bun|deno.` and perform NO `ncu`, catalog edit, override command, or install.
+- If `target` is not one of `patch` / `minor` / `major` / `engines`: abort with `Error: invalid target "<value>". Expected patch|minor|major|engines.` and perform NO side effect.
+
+Resolve the runner prefix from `packageManager`:
+
+| `packageManager` | runner prefix                            | install command |
+| ---------------- | ---------------------------------------- | --------------- |
+| `pnpm`           | `pnpm dlx`                               | `pnpm install`  |
+| `npm`            | `npx -y`                                 | `npm install`   |
+| `yarn`           | `yarn dlx`                               | `yarn install`  |
+| `bun`            | `bunx`                                   | `bun install`   |
+| `deno`           | `deno run --allow-read --allow-net npm:` | `deno install`  |
+
+Maintain an `appliedSoFar: string[]` buffer (manifest paths / catalog file already written, plus override ids executed) for failure reporting. Maintain the result accumulators `appliedGeneric: [{ name, location }]`, `appliedOverrides: [{ id, command, matchedNames }]`, `installRan: boolean`.
+
+### Step A1 — Generic `package.json` bumps (one ncu per `manifestBumps` element)
+
+For each `manifestBumps` element (each a distinct `package.json` `sourceFile`), invoke `npm-check-updates@21.0.2` **exactly once**:
+
+```bash
+<runner-prefix> npm-check-updates@21.0.2 \
+  -p <packageManager> \
+  --target <target> \
+  --upgrade \
+  --packageFile <sourceFile> \
+  [--cooldown <cooldown>]      # include only when `cooldown` is set AND packageManager !== "pnpm"
+  [--filter "<names>"]         # include only when the element's `includeFilter` is true
+```
+
+Rules:
+
+- `-p <packageManager>` is **always** passed — mirror scan semantics and prevent ncu auto-detect drift (e.g. ncu otherwise auto-detects `deno` when a sibling `deno.json` exists, collapsing `--dep` to `['imports']` and dropping `dependencies`/`devDependencies` updates).
+- `--cooldown <cooldown>` is included when `cooldown` is set and `packageManager !== "pnpm"`; omitted otherwise.
+- `--filter "<names>"` is included **only** when the element's `includeFilter === true`. `<names>` = the element's `names`, joined by single spaces, double-quoted. It is a literal list — ncu treats it as exact names (see `scan-npm-updates/research/ncu-filter-spike.md`). When `includeFilter === false`, `--filter` is omitted (ncu's own detected set equals the target set for this file).
+- Stream `ncu` stdout/stderr to the user verbatim so diffs are observable.
+
+On success, append each bumped package to `appliedGeneric` (with its `location` from the caller's spec context) and push `<sourceFile>` to `appliedSoFar`.
+
+If `ncu` exits non-zero on a manifest, **stop immediately** and return the structured failure:
+
+```ts
+{ step: "ncu", sourceFile: "<sourceFile>", exitCode: <code>, appliedSoFar: [...] }
+```
+
+Do NOT run any catalog edit, override command, or install after this point. Do NOT print a consumer-specific abort message (`Re-run …` / `Stopping the run …`) — the caller owns that copy.
+
+### Step A2 — `pnpm-workspace.yaml` catalog edits
+
+For each `catalogEdits` element (`name`, `targetVersion`):
+
+- Under the top-level `catalog:` block of `<cwd>/pnpm-workspace.yaml`, locate the key matching `name`.
+- Replace its value with `targetVersion`. Preserve surrounding whitespace, comments, and the order of other keys. (ncu 21.0.2 does not rewrite catalog entries — see `scan-npm-updates/research/ncu-catalog-spike.md`; this is an in-place `Edit`, NOT an `ncu` invocation.)
+- Do NOT touch any consumer `package.json` entry that references `catalog:` — only `pnpm-workspace.yaml`.
+
+On success, append the package to `appliedGeneric` (location `catalog:<key>` / the caller-supplied location) and push `pnpm-workspace.yaml` to `appliedSoFar`.
+
+If a catalog key is unexpectedly missing, **stop immediately** and return:
+
+```ts
+{ step: "catalog", name: "<name>", exitCode: null, appliedSoFar: [...] }
+```
+
+Do NOT run any override command or install. Do NOT print a consumer abort message.
+
+### Step A3 — Override commands (declaration order)
+
+After every generic manifest write (A1) and catalog edit (A2) for the project has succeeded, execute each `overrideCommands` element's `command` **exactly once, in declaration order**, streaming stdout/stderr.
+
+On success, append `{ id, command, matchedNames }` to `appliedOverrides` (the caller supplies `matchedNames` context, or the skill records the command's id) and push the entry id to `appliedSoFar`.
+
+If any override exits non-zero, **stop immediately** and return:
+
+```ts
+{ step: "override", entryId: "<id>", exitCode: <code>, appliedSoFar: [...] }
+```
+
+Do NOT run `ncu --upgrade` as a fallback for the matched packages (leaves the tree consistent and reviewable). Do NOT run the final install on this path. Do NOT print a consumer abort message.
+
+### Step A4 — Single install with skip rule
+
+After all generic bumps, catalog edits, and override commands land successfully:
+
+- If `skipInstall === true`, run **no** install command; set `installRan = false`; record that the install was delegated to the override command(s). (This is set by the caller when every accepted package was handled by an override that runs its own install and nothing was written outside the override.)
+- Otherwise run **exactly one** install command for `packageManager` (per the Step A0 table). Stream the output. On success set `installRan = true`.
+
+If the install exits non-zero, return:
+
+```ts
+{ step: "install", exitCode: <code>, appliedSoFar: [...] }
+```
+
+Do NOT print a consumer abort message.
+
+### Step A5 — Return the structured result
+
+On success return:
+
+```ts
+{
+  appliedGeneric:   [{ name, location }, ...],   // every generically-bumped package (A1 + A2)
+  appliedOverrides: [{ id, command, matchedNames }, ...],   // every override that ran (A3)
+  installRan:       boolean,                      // A4
+  failure:          null
+}
+```
+
+On failure return the same shape with `failure` populated per the failing step (A1/A2/A3/A4) and the partial accumulators reflecting what landed before the failure.
+
+The skill streams `ncu` / install / override stdout/stderr verbatim (observability) but prints **NO** consumer-facing summary block (`## …-<level> summary`) and **NO** consumer-specific abort copy. The caller composes those so single-project and cross-project consumers each preserve their own wording and exit semantics.
+
+---
+
+## Override-resolution procedure (b) — caller-invoked
+
+Callers that opt into overrides invoke this procedure to turn a candidate package set into the inputs for the apply contract. The procedure is the **matching / version-resolution / partition algorithm only** — the interactive `run-override` / `skip-matched` / `force-generic` prompt and the *scope* of resolution (which packages, single-project vs cross-project) remain caller-owned.
+
+### R1 — Load the registry
+
+`Read` the override registry from the caller-supplied path (default `claude-plugins/experiments/skills/scan-npm-updates/data/pkg-upgrade-overrides.yaml`). Parse it as YAML into a list of entries under the top-level `overrides:` key. Required fields per entry: `id`, `matches`, `command`, `versionSource`. Optional: `fallbackVersionSource`, `reference`, `notes`.
+
+If the file is missing, unreadable, fails to parse, or lacks `overrides`: emit a single-line warning `Override registry unavailable: <reason>. Proceeding without overrides.`, treat the registry as **empty**, and do NOT abort. (Graceful degradation — legacy generic-only behavior.)
+
+### R2 — First-win glob match
+
+For each candidate package, find the **first** entry (in declaration order) whose `matches` list includes a pattern matching the package `name`. Glob semantics:
+
+- `*` matches any run of characters within a package name (so `@storybook/*` matches `@storybook/react` and `@storybook/addon-essentials`; `storybook-addon-*` matches `storybook-addon-themes`).
+- No other glob metacharacters. Exact strings (`storybook`) match only that literal name.
+
+Matching is first-win — a package binds to at most one entry. Candidates binding to no entry remain GENERIC. Build `MATCHED_BY_ENTRY = { entry.id → [candidates bound to this entry] }`.
+
+### R3 — Resolve `{version}` and interpolate
+
+For each matched entry resolve `versionSource` against the caller's candidate set (the caller passes the resolution source — the single-project accepted set, or the cross-project `proposedTarget` set):
+
+- `target-of:<name>` → the target version of the candidate whose name equals `<name>`, prefix-stripped (`^`/`~`/`=`). Unresolved if that candidate is absent.
+- `max-target-of:<glob>` → the max semver across target versions (prefix-stripped) of candidates whose names match `<glob>`. Unresolved if no candidate matches.
+- `latest` → the literal string `latest`.
+
+If `versionSource` is unresolved and `fallbackVersionSource` is defined, try it. If both fail, emit the canonical warning `Cannot resolve {version} for override {id}: neither {versionSource} nor {fallbackVersionSource} produced a value. Falling back to generic ncu --upgrade for matched packages.` (substitute the entry's fields), drop the entry from `MATCHED_BY_ENTRY`, and let its matched candidates rejoin GENERIC. Otherwise interpolate the resolved version into `command` by replacing the literal token `{version}`.
+
+### R4 — Partition (after the caller obtains a per-entry action)
+
+The caller raises its own `AskUserQuestion` per matched entry and records an action ∈ `{ run-override, skip-matched, force-generic }`. Given those actions, partition the candidate set into three disjoint subsets:
+
+- `OVERRIDE_RUN` = candidates bound to a `run-override` entry — handled by the interpolated override command; excluded from generic `ncu`.
+- `OVERRIDE_SKIP` = candidates bound to a `skip-matched` entry — excluded from everything.
+- `GENERIC` = candidates bound to no entry, PLUS candidates bound to a `force-generic` entry, PLUS candidates whose entry was dropped in R3.
+
+The caller then builds the apply spec: GENERIC `package.json` candidates → `manifestBumps` (set `includeFilter` when the GENERIC set for a file is a strict subset of ncu's detectable candidates — i.e. `pick-subset` partial inclusion OR any `OVERRIDE_RUN`/`OVERRIDE_SKIP` touching the file); GENERIC `pnpm-workspace.yaml` candidates → `catalogEdits`; `run-override` interpolated commands → `overrideCommands`; `skipInstall` when every accepted package was handled by `run-override` and nothing is written outside the override commands.
+
+### Procedure scenarios
+
+- **First-win glob**: `@storybook/react` with a first matching `storybook` entry (patterns include `@storybook/*`) binds to `storybook` and to no later entry.
+- **Version fallback**: entry `versionSource: target-of:storybook`, `fallbackVersionSource: max-target-of:@storybook/*`; no `storybook` candidate present but `@storybook/react` resolves `8.1.2` → interpolate `8.1.2`.
+- **Missing registry**: file absent → procedure returns empty matches, emits the `Override registry unavailable: …` warning, does NOT abort.
+- **Prompt/scope not included**: the procedure returns matches / interpolated commands / partitions only; it does NOT raise the override `AskUserQuestion` itself.
+
+---
+
+## Level-agnostic operation
+
+The skill contains **no** level-specific logic. Behavior is parameterized solely by `target` (passed to `ncu --target`); a `target: "minor"` invocation differs from `target: "patch"` only in the `--target` value threaded through every `ncu` call — nothing else changes.
+
+## Hard rules
+
+- SHALL NOT run tests, lint, or build (`vitest`, `nx test`, lint, build are never invoked).
+- SHALL NOT create git commits, branches, or pull requests.
+- SHALL NOT mutate any consumer `package.json` entry that is a `catalog:` reference — only `pnpm-workspace.yaml` for those.
+- SHALL NOT run `ncu --upgrade` as a fallback after an override command fails.
+- SHALL NOT read or write the override registry data file except via the read-only resolution procedure (R1).
+- SHALL NOT print a consumer-facing summary heading or a consumer-specific abort message — those are caller-owned.
+
+## See also
+
+- `/experiments:npm-update-patch`, `/experiments:npm-update-minor` — shallow single-project consumers (procedure (b) + contract (a)).
+- `/experiments:npm-update-deep-patch`, `/experiments:npm-update-deep-minor` — deep single-project consumers (contract (a), empty overrides).
+- `commander-update-orchestrator` — cross-project consumer (procedure (b) cross-project + contract (a) once per project).
+- `scan-npm-updates/data/pkg-upgrade-overrides.yaml` — the single, level-independent override registry consumed via procedure (b).

--- a/claude-plugins/experiments/skills/commander-update-orchestrator/SKILL.md
+++ b/claude-plugins/experiments/skills/commander-update-orchestrator/SKILL.md
@@ -250,9 +250,9 @@ If `any package.conflict === true`, raise exactly **one** `AskUserQuestion` (reg
 
 - `multiSelect: false`
 - **Options**:
-    - `use-max-where-possible` — Apply `proposedTarget` only to occurrences whose range admits it; non-admitting occurrences keep their per-project `targetVersion`.
-    - `per-project` — Every occurrence retains its per-project `targetVersion`; no max-alignment for the conflicting packages.
-    - `skip-package` — Drop every conflicting package from the run entirely (their occurrences are removed from the plan).
+  - `use-max-where-possible` — Apply `proposedTarget` only to occurrences whose range admits it; non-admitting occurrences keep their per-project `targetVersion`.
+  - `per-project` — Every occurrence retains its per-project `targetVersion`; no max-alignment for the conflicting packages.
+  - `skip-package` — Drop every conflicting package from the run entirely (their occurrences are removed from the plan).
 
 The chosen policy applies to **every** conflicting package in the run. Do NOT prompt per-package.
 
@@ -387,13 +387,14 @@ Render a single markdown table:
 
 When the workflow returned successfully in Step 6.5 (i.e. `<plan-dir>/plan.md` exists at the plan-dir root):
 
-1. **Read** `<plan-dir>/plan.md` and surface its content verbatim. The workflow's cross-project plan template emits these four H2 sections, in this exact order:
+1. **Read** `<plan-dir>/plan.md` and surface its content verbatim. The workflow's cross-project plan template emits these five H2 sections, in this exact order:
     - `## Improvements (universal — applicability checked per project at apply time)`
     - `## Workarounds resolved`
     - `## Skipped or unavailable`
     - `## Cross-project bump set`
+    - `## Changelogs`
 
-    The `Cross-project bump set` table uses three columns: `package`, `proposed target`, `projects (locations)`. The third column merges per-project + per-location data: e.g., a row for `react` bumped to `^19.0.14` across `proj-A` (root) and `proj-B` (root) renders `proj-A (root); proj-B (root)` (`;` separates projects, `,` separates multiple locations within the same project). The orchestrator SHALL NOT regenerate this table inline — the workflow already produced it from the `<plan-dir>/cross-project-plan.json` artifact persisted in Step 6.5.5.
+    The `Cross-project bump set` table uses three columns: `package`, `proposed target`, `projects (locations)`. The third column merges per-project + per-location data: e.g., a row for `react` bumped to `^19.0.14` across `proj-A` (root) and `proj-B` (root) renders `proj-A (root); proj-B (root)` (`;` separates projects, `,` separates multiple locations within the same project). The orchestrator SHALL NOT regenerate this table inline — the workflow already produced it from the `<plan-dir>/cross-project-plan.json` artifact persisted in Step 6.5.5. The `## Changelogs` section is workflow-produced (per the `parallel-research-workflow` changelog requirement) and is surfaced verbatim along with the rest of `plan.md`; the orchestrator SHALL NOT regenerate or summarize it.
 
 2. **Append** the orchestrator-owned drift sections after the workflow's content, in this exact order. Each section is omitted when its count is zero:
     - `**Warnings:**` heading with each warning as a `-` bullet, when the orchestrator's `warnings[]` list (the running list across Step 5, Step 6.5.2 grouping-skill warnings, Step 6.5.3 mixed-pm warning, and any later source) is non-empty.
@@ -425,32 +426,15 @@ The plan-dir is preserved on disk; the workflow's end-of-flow cleanup runs separ
 
 **Mode-independent.** Step 8 runs identically in both `shallow` and `deep` modes — same registry path default, same first-win matching, same `run-override` / `skip-matched` / `force-generic` prompt, same `OVERRIDE_RUN` / `OVERRIDE_SKIP` / `GENERIC` partitioning. This is Decision 5 in `design.md`: cross-project deep mode IS consulted for overrides (explicit divergence from single-project `npm-update-deep-patch`, which deliberately skips overrides). Rationale: in cross-project context, Storybook-style families spanning multiple projects need the same coordinated handling shallow already provides; degrading to "run shallow first, then deep" would defeat the one-command UX.
 
-Load the override registry from `overrideRegistryPath` (default `claude-plugins/experiments/skills/scan-npm-updates/data/pkg-upgrade-overrides.yaml`). Apply the same first-win matching logic as `npm-update-patch.md` Step 5.5.
+Resolve overrides using the **`apply-npm-updates` override-resolution procedure** (R1–R3) for registry load, first-win matching, and `{version}` resolution — the shared procedure, NOT an inline copy of the algorithm. The cross-project prompt (8.4) and the cross-project resolution **scope** stay owned by this skill.
 
-### 8.1 Load
+### 8.1 Load + match + resolve (procedure R1–R3)
 
-- `Read` the file. If missing or unparseable: print `Override registry unavailable: <reason>. Proceeding without overrides.` and treat the registry as empty. Do NOT abort.
+Invoke the procedure with the registry path from `overrideRegistryPath` (default `claude-plugins/experiments/skills/scan-npm-updates/data/pkg-upgrade-overrides.yaml`) and the resolution source set to the **cross-project aggregated `proposedTarget` set** (NOT per-project):
 
-### 8.2 Compute matches across the cross-project package set
-
-For each package in the post-policy plan, find the first override entry whose `matches` list includes a pattern matching the package `name`. Pattern semantics (mirror `npm-update-patch.md` Step 5.5):
-
-- `*` matches any run of characters within a package name.
-- No other glob metacharacters.
-
-Matching is **first-win**: a package binds to at most one entry. Build `MATCHED_BY_ENTRY = { entry.id → [packages bound to this entry] }`.
-
-### 8.3 Resolve `{version}` against the cross-project aggregated `proposedTarget` set
-
-For each entry in `MATCHED_BY_ENTRY`, resolve `versionSource`:
-
-- `target-of:<name>` → the `proposedTarget` of the package whose `name == <name>` in the cross-project plan (prefix-stripped). If not present, source is unresolved.
-- `max-target-of:<glob>` → the max semver across `proposedTarget` of packages whose `name` matches `<glob>` in the cross-project plan (prefix-stripped). If no match, source is unresolved.
-- `latest` → the literal string `latest`.
-
-If `versionSource` is unresolved and `fallbackVersionSource` is defined, try it. If both fail, emit a warning, drop this entry from `MATCHED_BY_ENTRY`, and let its matched packages rejoin the generic flow.
-
-Interpolate the resolved version into `command` by replacing the literal token `{version}`.
+- **R1 (load)** — on a missing/unparseable registry the procedure prints `Override registry unavailable: <reason>. Proceeding without overrides.` and treats it as empty. Do NOT abort.
+- **R2 (first-win glob match)** — over the post-policy plan's package names. Build `MATCHED_BY_ENTRY = { entry.id → [packages bound to this entry] }`.
+- **R3 (resolve + interpolate)** — resolve `{version}` against the cross-project `proposedTarget` set: `target-of:<name>` → the `proposedTarget` of the package whose `name == <name>` in the cross-project plan (prefix-stripped); `max-target-of:<glob>` → the max semver across `proposedTarget` of packages whose `name` matches `<glob>` (prefix-stripped); `latest` → the literal `latest`; with `fallbackVersionSource` fallback. `{version}` resolution SHALL run against the cross-project aggregate, never per-project. On an unresolvable entry the procedure warns, drops the entry, and its matched packages rejoin the generic flow. Otherwise the resolved version is interpolated into `command`.
 
 ### 8.4 Prompt once per matched entry across the run
 
@@ -469,9 +453,9 @@ For each remaining entry, raise exactly **one** `AskUserQuestion`:
 
 - `multiSelect: false`
 - **Options**:
-    - `run-override` — Execute the command once per affected project; skip generic ncu bump for these packages.
-    - `skip-matched` — Leave these packages untouched in every project; do not run the override and do not bump generically.
-    - `force-generic` — Ignore the override and bump these packages with the generic ncu flow in every affected project.
+  - `run-override` — Execute the command once per affected project; skip generic ncu bump for these packages.
+  - `skip-matched` — Leave these packages untouched in every project; do not run the override and do not bump generically.
+  - `force-generic` — Ignore the override and bump these packages with the generic ncu flow in every affected project.
 
 Record the chosen action per entry into `OVERRIDE_ACTIONS: Map<entry.id, "run-override"|"skip-matched"|"force-generic">` along with the interpolated command.
 
@@ -494,19 +478,19 @@ Raise exactly **one** `AskUserQuestion`. The option set depends on `mode`.
 - **Question copy**: `Apply <level> updates across <N> project(s)?`
 - `multiSelect: false`
 - **Options** (in this exact order):
-    - `apply-all` — Proceed with the entire (post-policy, post-override) plan.
-    - `pick-subset` — Accept a free-form package-name list to exclude before apply.
-    - `cancel` — Exit without modifying any file.
+  - `apply-all` — Proceed with the entire (post-policy, post-override) plan.
+  - `pick-subset` — Accept a free-form package-name list to exclude before apply.
+  - `cancel` — Exit without modifying any file.
 
 ### 9.D — Deep-mode options (four)
 
 - **Question copy**: `Apply <level> updates across <N> project(s)?` (same as shallow)
 - `multiSelect: false`
 - **Options** (in this exact order):
-    - `apply-all` — Proceed with the entire (post-policy, post-override) plan, INCLUDING the post-bumps plan-mode improvements round (Step 10b).
-    - `apply-bumps-only` — Apply bumps + overrides + installs sequentially per project (Step 10a), but SKIP the plan-mode improvements round (Step 10b) entirely. The Step 11 summary's `Applied improvements` section is omitted (zero items). All `run-override` decisions resolved in Step 8 still execute on this path because they were resolved before the gate.
-    - `pick-subset` — Accept a free-form selection combining improvement-bullet titles AND package names. Substring match (case-insensitive) for improvements; exact match for bumps. Excluded improvements skip Step 10b for those bullets; excluded packages skip Step 10a for those names.
-    - `cancel` — Exit without modifying any file. In deep mode the plan-dir IS preserved on disk and the orchestrator invokes Step 10c (end-of-flow cleanup) before exiting; in shallow mode there is no plan-dir.
+  - `apply-all` — Proceed with the entire (post-policy, post-override) plan, INCLUDING the post-bumps plan-mode improvements round (Step 10b).
+  - `apply-bumps-only` — Apply bumps + overrides + installs sequentially per project (Step 10a), but SKIP the plan-mode improvements round (Step 10b) entirely. The Step 11 summary's `Applied improvements` section is omitted (zero items). All `run-override` decisions resolved in Step 8 still execute on this path because they were resolved before the gate.
+  - `pick-subset` — Accept a free-form selection combining improvement-bullet titles AND package names. Substring match (case-insensitive) for improvements; exact match for bumps. Excluded improvements skip Step 10b for those bullets; excluded packages skip Step 10a for those names.
+  - `cancel` — Exit without modifying any file. In deep mode the plan-dir IS preserved on disk and the orchestrator invokes Step 10c (end-of-flow cleanup) before exiting; in shallow mode there is no plan-dir.
 
 ### 9.1 `apply-all`
 
@@ -598,7 +582,7 @@ Iterate the resolved project set in **registry insertion order** (already preser
 Collect occurrences in `ACCEPTED` whose `projectName` matches this project. Apply:
 
 - The chosen conflict policy (Step 6) — drop occurrences for `skip-package`-dropped packages; preserve per-project `effectiveTarget` under `per-project`; honor partition under `use-max-where-possible`.
-- The override partition (Step 8.5) — drop occurrences in `OVERRIDE_SKIP`; route `OVERRIDE_RUN` packages to step 10.4; route everything else to step 10.3.
+- The override partition (Step 8.5) — drop occurrences in `OVERRIDE_SKIP`; route `OVERRIDE_RUN` packages to the apply spec's `overrideCommands`; route everything else (GENERIC) to the apply spec's `manifestBumps` / `catalogEdits` (built in Step 10.3).
 - The user exclusion (Step 9.2) — already excluded from `ACCEPTED`.
 
 If the per-project subset is empty (no generic occurrences AND no override entries touch this project), skip apply AND install for this project. Continue to the next.
@@ -607,104 +591,53 @@ If the per-project subset is empty (no generic occurrences AND no override entri
 
 For every Bash invocation in the apply for this project, prepend `cd "<record.path>" &&` (or use absolute paths for ncu's `--packageFile`). The skill SHALL NOT mutate the user's shell state across iterations.
 
-### 10.3 Generic ncu apply (`GENERIC` subset for this project)
+### 10.3 Build the per-project apply spec and invoke `apply-npm-updates`
 
-Group occurrences by `sourceFile` and distinguish two manifest kinds:
+The `apply-npm-updates` skill is the single source of truth for the per-project mechanical apply (generic `ncu` `package.json` bumps, `pnpm-workspace.yaml` catalog edits, override commands, single install). The orchestrator builds the resolved spec for this project and invokes the skill **once**; it SHALL NOT restate the `ncu` / catalog / install recipe inline.
 
-#### `package.json` files
+Build the spec from this project's subset (Step 10.1):
 
-Invoke `npm-check-updates@21.0.2` once per distinct `sourceFile`:
+- `packageManager` = this project's `ScanResult.packageManager`. `cwd` = `<record.path>`. `target` = the orchestrator's `target` input. `cooldown` = the value `scan-npm-updates` resolved for this project (omit for `pnpm`).
+- `manifestBumps` — one element per distinct `GENERIC` `package.json` `sourceFile`: `{ sourceFile, names: <GENERIC names for this file, space-separated>, includeFilter }`. Set `includeFilter: true` when **any** of: the user picked `pick-subset` and excluded ≥1 package for this project; any update for the file was removed by `OVERRIDE_RUN`/`OVERRIDE_SKIP`; or the conflict policy is `use-max-where-possible` and ncu's full set ≠ this project's effective subset. Otherwise `false` (ncu's own set equals the target set for this file).
+- `catalogEdits` — one element per `GENERIC` occurrence with `sourceFile === "pnpm-workspace.yaml"`: `{ name, targetVersion: <effectiveTarget> }`.
+- `overrideCommands` — the `OVERRIDE_RUN` entries that touch this project, as `{ id, command: <interpolated command> }`, in declaration order (run once per affected project).
+- `skipInstall` — `true` when every accepted package for this project went through `run-override` AND no generic ncu bump ran AND no catalog edit happened for this project (every override handles its own install); otherwise `false`.
 
-```bash
-<runner-prefix> npm-check-updates@21.0.2 \
-  -p <pm> \
-  --target <target> \
-  --upgrade \
-  --packageFile <sourceFile> \
-  [--cooldown <period>]        # mirror the value scan-npm-updates resolved for this project; omit for pnpm
-  [--filter "<names>"]         # see "When to filter" below
-```
+Invoke `apply-npm-updates` once with this spec and `cwd: <record.path>`. The skill streams `ncu` / install / override stdout/stderr verbatim and returns `{ appliedGeneric, appliedOverrides, installRan, failure }`. Fold the returned fragment into this project's entry of the cross-project summary (Step 11).
 
-Where:
+### 10.4 On structured failure — format the cross-project abort copy
 
-- `<runner-prefix>` matches the per-project package manager (`pnpm dlx`, `npx -y`, `yarn dlx`, `bunx`, `deno run --allow-read --allow-net npm:`).
-- `-p <pm>` is the project's package manager from `ScanResult.packageManager`. MUST be passed to mirror scan semantics and prevent ncu auto-detection drift.
-- `--target <target>` — the orchestrator's `target` input (e.g., `patch`).
-- `<names>` is the GENERIC package names for this `sourceFile`, joined by single spaces, double-quoted.
+If `apply-npm-updates` returns a non-null `failure`, **stop the entire run** (Step 10.6) and print the orchestrator-owned cross-project abort copy for the failing `step` (the skill never prints this copy):
 
-##### When to include `--filter`
+- `step: "ncu"` →
 
-- The user picked `pick-subset` and at least one package was excluded for this project, OR
-- Any update for this `sourceFile` was removed by `OVERRIDE_RUN` / `OVERRIDE_SKIP` (so ncu must NOT bump packages routed elsewhere), OR
-- The conflict policy is `use-max-where-possible` and ncu's full set ≠ this project's effective subset.
+    ```text
+    ncu --upgrade failed on {sourceFile} ({projectName}, exit {code}).
+    Stopping the run. Subsequent projects not attempted.
+    ```
 
-Otherwise omit `--filter` (ncu's own set equals the target set for this file).
+- `step: "catalog"` →
 
-##### Failure handling
+    ```text
+    Failed to bump {name} in pnpm-workspace.yaml ({projectName}): {reason}.
+    Stopping the run. Subsequent projects not attempted.
+    ```
 
-Stream stdout/stderr through to the user. If ncu exits non-zero, abort the entire run with:
+- `step: "override"` →
 
-```text
-ncu --upgrade failed on {sourceFile} ({projectName}, exit {code}).
-Stopping the run. Subsequent projects not attempted.
-```
+    ```text
+    Override command failed ({entry.id}, {projectName}, exit {code}): {interpolated command}.
+    Stopping the run. Subsequent projects not attempted.
+    ```
+
+- `step: "install"` →
+
+    ```text
+    Install failed ({pm}, {projectName}, exit {code}). Manifests already bumped; review changes before retrying.
+    Stopping the run. Subsequent projects not attempted.
+    ```
 
 Then jump to Step 11 (summary) with the run partition (applied / failed / pending).
-
-#### `pnpm-workspace.yaml` (catalog updates)
-
-For each occurrence with `sourceFile === "pnpm-workspace.yaml"`:
-
-- Under the top-level `catalog:` block, locate the key matching `name`.
-- Replace the value with `effectiveTarget`. Preserve surrounding whitespace, comments, and other keys' order.
-- Do NOT touch any consumer `package.json` that references `catalog:`.
-
-If a key is unexpectedly missing, abort the entire run with:
-
-```text
-Failed to bump {name} in pnpm-workspace.yaml ({projectName}): {reason}.
-Stopping the run. Subsequent projects not attempted.
-```
-
-### 10.4 Override commands (`OVERRIDE_RUN` entries that touch this project)
-
-After the generic path has written every manifest successfully for this project, execute each `OVERRIDE_RUN` entry's interpolated command **in declaration order**, exactly **once per affected project**. Stream stdout/stderr.
-
-If any override exits non-zero, abort the entire run with:
-
-```text
-Override command failed ({entry.id}, {projectName}, exit {code}): {interpolated command}.
-Stopping the run. Subsequent projects not attempted.
-```
-
-Do NOT run `ncu --upgrade` as a fallback. Do NOT run the final install for this project.
-
-### 10.5 Install
-
-After all generic bumps and overrides land for this project, run exactly **one** install command using this project's package manager:
-
-| `packageManager` | Command        |
-| ---------------- | -------------- |
-| `pnpm`           | `pnpm install` |
-| `npm`            | `npm install`  |
-| `yarn`           | `yarn install` |
-| `bun`            | `bun install`  |
-| `deno`           | `deno install` |
-
-**Skip the install** when:
-
-- Every accepted package for this project went through `run-override` AND
-- No generic ncu bump ran for this project AND
-- No `pnpm-workspace.yaml` catalog edit happened for this project.
-
-In that case, every override command is assumed to have handled its own install. Record this in the summary.
-
-If the install exits non-zero, abort the entire run with:
-
-```text
-Install failed ({pm}, {projectName}, exit {code}). Manifests already bumped; review changes before retrying.
-Stopping the run. Subsequent projects not attempted.
-```
 
 ### 10.6 Stop-on-fail
 
@@ -808,8 +741,8 @@ The workflow prompts the user via `AskUserQuestion`:
 - **Question**: `Plan dir at <plan-dir>. Keep for inspection or delete?`
 - `multiSelect: false`
 - **Options**:
-    - `delete-plan` — recursively `rm -rf <plan-dir>`.
-    - `keep-plan` — leave it on disk; the next deep invocation's phase 0 stale-cleanup catches it after 10 days.
+  - `delete-plan` — recursively `rm -rf <plan-dir>`.
+  - `keep-plan` — leave it on disk; the next deep invocation's phase 0 stale-cleanup catches it after 10 days.
 
 Capture the user's choice into `cleanupOutcome ∈ { "delete-plan", "keep-plan" }`. The Step 11 summary's `Suggested next steps` uses `cleanupOutcome` to decide whether to include the `Review <plan-dir>/plan.md before re-running.` bullet.
 
@@ -931,8 +864,8 @@ Print a markdown summary. The H1 varies by mode. Render sections conditionally; 
 
 - **Applied improvements**: one line per applied (bullet, project) pair. Format `- {bullet title} → {projectName} ({sourceFile or general path hint})`. The `sourceFile or hint` cell is the absolute path of the primary file edited under that pair when a single file is dominant; otherwise a generic hint like `multiple files under apps/<workspace>/src/`.
 - **Skipped improvements**: distinguish the two skip reasons with the parenthetical:
-    - `(excluded via pick-subset)` — when the user excluded the bullet at the gate (9.2.D).
-    - `(rejected at plan-mode review)` — when the user rejected the whole plan-mode round at 10b.3.
+  - `(excluded via pick-subset)` — when the user excluded the bullet at the gate (9.2.D).
+  - `(rejected at plan-mode review)` — when the user rejected the whole plan-mode round at 10b.3.
 - **Inapplicable improvements**: one line per (bullet, project) pair marked inapplicable during 10b.1. Format `- {bullet title} → {projectName} ({one-sentence reason captured during reconnaissance})`.
 - **Skipped or unavailable groups**: copied verbatim from `<plan-dir>/plan.md`'s `## Skipped or unavailable` section (workflow-owned). Heading count `<N>` is the bullet count under that section in `plan.md`.
 
@@ -979,10 +912,10 @@ After the run completes (success, partial, cancel), the user-scoped registry `<H
 - `Unknown selection(s): {invalid items}. Valid improvements: {titles}. Valid bumps: {names}.` — Step 9.2.D invalid pick-subset (deep).
 - `All updates excluded; nothing to apply.` — Step 9.2.S empty post-exclusion (shallow).
 - `Cancelled. No files modified.` — Step 9.3 user cancel (both modes); also Step 9.2.D empty selection treated as cancel.
-- `ncu --upgrade failed on {sourceFile} ({projectName}, exit {code}). Stopping the run. Subsequent projects not attempted.` — Step 10.3 ncu failure.
-- `Failed to bump {name} in pnpm-workspace.yaml ({projectName}): {reason}. Stopping the run. Subsequent projects not attempted.` — Step 10.3 catalog failure.
-- `Override command failed ({entry.id}, {projectName}, exit {code}): {interpolated command}. Stopping the run. Subsequent projects not attempted.` — Step 10.4 override failure.
-- `Install failed ({pm}, {projectName}, exit {code}). Manifests already bumped; review changes before retrying. Stopping the run. Subsequent projects not attempted.` — Step 10.5 install failure.
+- `ncu --upgrade failed on {sourceFile} ({projectName}, exit {code}). Stopping the run. Subsequent projects not attempted.` — Step 10.4 `apply-npm-updates` `ncu` failure.
+- `Failed to bump {name} in pnpm-workspace.yaml ({projectName}): {reason}. Stopping the run. Subsequent projects not attempted.` — Step 10.4 `apply-npm-updates` `catalog` failure.
+- `Override command failed ({entry.id}, {projectName}, exit {code}): {interpolated command}. Stopping the run. Subsequent projects not attempted.` — Step 10.4 `apply-npm-updates` `override` failure.
+- `Install failed ({pm}, {projectName}, exit {code}). Manifests already bumped; review changes before retrying. Stopping the run. Subsequent projects not attempted.` — Step 10.4 `apply-npm-updates` `install` failure.
 - `Improvements rejected at plan-mode review. No improvement edits applied; bumps are preserved.` — Step 10b.3 plan-mode rejection (deep mode).
 
 ## Non-goals (deferred)

--- a/claude-plugins/experiments/skills/parallel-research-workflow/SKILL.md
+++ b/claude-plugins/experiments/skills/parallel-research-workflow/SKILL.md
@@ -46,7 +46,7 @@ The workflow ships two research contracts selected by the `mode` input. Phases 0
 | Phase 4 `plan.md` H1                              | `Deep-<level> plan: <slug>`                                                                                                                   | `Deep-<level> plan (cross-project): <slug>`                                                                                                                                                                                              |
 | Phase 4 `plan.md` Improvements heading            | `## Improvements (applicable to this codebase)`                                                                                               | `## Improvements (universal — applicability checked per project at apply time)`                                                                                                                                                          |
 | Phase 4 `plan.md` improvement / workaround bullet | `... (group: <groupId>)`                                                                                                                      | `... (group: <groupId>; affects projects: <comma-separated names>)`                                                                                                                                                                      |
-| Phase 4 `plan.md` bump-set table H2               | `## Patch bump set` (or matching level)                                                                                                       | `## Cross-project bump set`                                                                                                                                                                                                              |
+| Phase 4 `plan.md` bump-set table H2               | `## <Level> bump set` — title-cased level (`Patch`/`Minor`/`Major`/`Engines`), level-derived (never hardcoded `Patch`)                        | `## Cross-project bump set`                                                                                                                                                                                                              |
 | Phase 4 `plan.md` bump-set table columns          | `package`, `current → target`, `location`                                                                                                     | `package`, `proposed target`, `projects (locations)`                                                                                                                                                                                     |
 | Phases 0, 1, 3, end-of-flow cleanup               | Identical machinery.                                                                                                                          | Identical machinery. No new phases introduced; no phase transition order changed.                                                                                                                                                        |
 
@@ -154,9 +154,9 @@ If at least one entry is stale, prompt the user once via `AskUserQuestion`:
 - **Question**: `Found <N> stale plan dir(s) under ~/.claude/experiments/plans/. What do you want to do?`
 - **Multi-select**: `false`
 - **Options**:
-    - `delete-stale` — recursively remove every stale entry, then continue.
-    - `keep-stale` — leave them alone for this invocation; continue.
-    - `cancel` — abort the deep-\* run; print `Cancelled. No files modified.`; do not create a new plan dir; exit.
+  - `delete-stale` — recursively remove every stale entry, then continue.
+  - `keep-stale` — leave them alone for this invocation; continue.
+  - `cancel` — abort the deep-\* run; print `Cancelled. No files modified.`; do not create a new plan dir; exit.
 
 If no stale entries exist, do not prompt — proceed silently. The skill SHALL NOT delete any directory without explicit `delete-stale` selection. The 10-day threshold is fixed in v1.
 
@@ -242,9 +242,9 @@ If a batch hard-walls (all subagents stalled at `pending/pending`), prompt the u
 - **Question**: `Subagent dispatch was denied or rate-limited for batch <n>/<total> (<groupIds>). How do you want to proceed?`
 - **Multi-select**: `false`
 - **Options**:
-    - `retry-current-batch` — re-dispatch this batch only (no backoff sleep — the user has already paused the flow). Repeats the same batch with the same `maxConcurrent`.
-    - `degrade-to-main-agent` — abandon subagent dispatch for the remaining groups; the main agent synthesizes `plan.md` directly using already-cached changelogs under `~/.claude/changelogs/`. The main agent SHALL prepend a one-line banner to `plan.md`: `> Research consolidated in main agent due to subagent dispatch limits. Per-group research.md files were not produced for: <comma-separated groupIds of un-dispatched batches>.`
-    - `abort` — exit cleanly. Plan dir is preserved on disk.
+  - `retry-current-batch` — re-dispatch this batch only (no backoff sleep — the user has already paused the flow). Repeats the same batch with the same `maxConcurrent`.
+  - `degrade-to-main-agent` — abandon subagent dispatch for the remaining groups; the main agent synthesizes `plan.md` directly using already-cached changelogs under `~/.claude/changelogs/`. The main agent SHALL prepend a one-line banner to `plan.md`: `> Research consolidated in main agent due to subagent dispatch limits. Per-group research.md files were not produced for: <comma-separated groupIds of un-dispatched batches>.`
+  - `abort` — exit cleanly. Plan dir is preserved on disk.
 
 If the user picks `retry-current-batch` and the same batch hard-walls again, the prompt re-fires with the question text prefixed `Retried and still hard-walled.` — same three options, no automatic escalation. If the user picks `degrade-to-main-agent`, the workflow skips directly to a modified phase 3 (see "Degraded phase 3" below) and then phase 4 with the banner.
 
@@ -465,9 +465,9 @@ If at least one group is `failed` or `missing` (excluding `expected-missing` in 
 - **Question**: `Research integrity check: <healthy>/<total> groups healthy. Non-healthy: <comma-separated groupIds>. How do you want to proceed?`
 - **Multi-select**: `false`
 - **Options**:
-    - `retry-failed` — re-dispatch phase 1 + phase 2 from scratch only for the non-healthy groups. Healthy groups are NOT touched and their `research.md` files are preserved.
-    - `continue-without` — proceed to phase 4 using only the healthy groups. Non-healthy groups will be documented in `plan.md`'s `## Skipped or unavailable` section with their `errorReason`.
-    - `abort` — exit cleanly. The plan dir is preserved on disk for manual inspection.
+  - `retry-failed` — re-dispatch phase 1 + phase 2 from scratch only for the non-healthy groups. Healthy groups are NOT touched and their `research.md` files are preserved.
+  - `continue-without` — proceed to phase 4 using only the healthy groups. Non-healthy groups will be documented in `plan.md`'s `## Skipped or unavailable` section with their `errorReason`.
+  - `abort` — exit cleanly. The plan dir is preserved on disk for manual inspection.
 
 The skill SHALL NOT auto-retry. There is no default option — the user must explicitly pick.
 
@@ -498,7 +498,7 @@ When all groups are healthy or the user chose `continue-without`:
 
 1. Update the global `_meta.json.phase` to `"planning"`.
 2. The main agent enters Claude Code plan mode.
-3. The main agent reads every healthy `groups/<id>/research.md` plus the original `scan.json` (single-project mode) or both `scan-by-project.json` and `cross-project-plan.json` (cross-project mode), then writes `<plan-dir>/plan.md`. The template depends on `mode`.
+3. The main agent reads every healthy `groups/<id>/research.md` plus the original `scan.json` (single-project mode) or both `scan-by-project.json` and `cross-project-plan.json` (cross-project mode), and — for the `## Changelogs` section — the on-disk `experiments:npm-changelog` cache under `~/.claude/changelogs/` (no network), then writes `<plan-dir>/plan.md`. The template depends on `mode`.
 
 ### 4.S — Single-project `plan.md` template (`mode: "single-project"`, default)
 
@@ -520,19 +520,25 @@ When all groups are healthy or the user chose `continue-without`:
 - <groupId> — <reason>.
 - ...
 
-## Patch bump set
+## <Level> bump set
 
 | package | current → target | location |
 | ------- | ---------------- | -------- |
 | ...     | ...              | ...      |
+
+## Changelogs
+
+<one block per package — see "4.C — Changelog chronology section">
 ```
 
 Rules:
 
-- The four `H2` sections SHALL appear in this exact order: `Improvements (applicable to this codebase)`, `Workarounds resolved`, `Skipped or unavailable`, `Patch bump set`.
-- Sections with zero items still render with a single sentinel line (e.g. `_no improvements identified_`) — never omit the heading.
+- The five `H2` sections SHALL appear in this exact order: `Improvements (applicable to this codebase)`, `Workarounds resolved`, `Skipped or unavailable`, `<Level> bump set`, `Changelogs`.
+- The bump-set heading is **level-derived**: the title-cased `level` input followed by `bump set` — `Patch bump set`, `Minor bump set`, `Major bump set`, or `Engines bump set`. It SHALL NOT be hardcoded to `Patch`.
+- Sections with zero items still render with a single sentinel line (e.g. `_no improvements identified_`) — never omit the heading. The `Changelogs` section uses the per-package `_no changelog available_` sentinel defined in 4.C.
 - The `<reason>` cell in `Skipped or unavailable` rows: for `failed`/`missing` groups, copy `groups/<id>/_meta.json.errorReason` verbatim; for `expected-missing` groups (degraded path), use the constant string `research consolidated in main agent (subagent dispatch limited)` without reading per-group meta.
-- The `Patch bump set` table SHALL list every update from `scan.json` regardless of group health. Columns are exactly `package`, `current → target`, `location`. Rows sorted by `location` then `name` for stability.
+- The `<Level> bump set` table SHALL list every update from `scan.json` regardless of group health. Columns are exactly `package`, `current → target`, `location`. Rows sorted by `location` then `name` for stability.
+- The `Changelogs` section is the final section and is assembled per "4.C — Changelog chronology section (both modes)". In single-project mode `<from>`/`<to>` per package are the `currentVersion`/`targetVersion` from `scan.json`.
 
 ### 4.D — Cross-project `plan.md` template (`mode: "cross-project"`)
 
@@ -562,17 +568,22 @@ Projects covered: <comma-separated project names from scan-by-project.json keys,
 | ------- | --------------- | ---------------------------- |
 | react   | ^19.0.14        | proj-A (root); proj-B (root) |
 | ...     | ...             | ...                          |
+
+## Changelogs
+
+<one block per package — see "4.C — Changelog chronology section"; cross-project variant uses representative from → to>
 ```
 
 Rules:
 
 - H1 form: `# Deep-<level> plan (cross-project): <slug>`. The H1 SHALL include the `(cross-project)` parenthetical and SHALL use the `slugOverride`-derived `<slug>` (NOT the CWD/`package.json`-derived slug).
 - A single descriptive line `Projects covered: <comma-separated project names from scan-by-project.json keys, alphabetical>` SHALL appear directly under the H1.
-- The four H2 sections SHALL appear in this exact order: `Improvements (universal — applicability checked per project at apply time)`, `Workarounds resolved`, `Skipped or unavailable`, `Cross-project bump set`.
+- The five H2 sections SHALL appear in this exact order: `Improvements (universal — applicability checked per project at apply time)`, `Workarounds resolved`, `Skipped or unavailable`, `Cross-project bump set`, `Changelogs`.
 - Sections with zero items still render with a single sentinel line:
-    - `_no improvements identified_` under the Improvements heading.
-    - `_no workarounds resolved_` under the Workarounds heading.
-    - `_no skipped groups_` under the Skipped or unavailable heading.
+  - `_no improvements identified_` under the Improvements heading.
+  - `_no workarounds resolved_` under the Workarounds heading.
+  - `_no skipped groups_` under the Skipped or unavailable heading.
+  - The `Changelogs` section uses the per-package `_no changelog available_` sentinel defined in 4.C.
 - Each improvement / workaround bullet SHALL end with the parenthetical `(group: <groupId>; affects projects: <comma-separated project names>)`. The `affects projects:` list is derived from the cross-project scan artifacts: for each package in the bullet, list every project whose `ScanResult.updates[]` includes the package (sourced from `<plan-dir>/scan-by-project.json` and `<plan-dir>/cross-project-plan.json`, which the orchestrator caller wrote before / during Step 6.5.5). Names are alphabetical within the parenthetical, comma-separated.
 - The `<reason>` cell in `Skipped or unavailable` rows follows the same rule as single-project: for `failed`/`missing` groups, copy `groups/<id>/_meta.json.errorReason` verbatim; for `expected-missing` groups (degraded path), use the constant string `research consolidated in main agent (subagent dispatch limited)`.
 - The `Cross-project bump set` table columns are exactly `package`, `proposed target`, `projects (locations)`.
@@ -580,6 +591,47 @@ Rules:
 - Table rows sorted by `package` name (alphabetical, stable).
 - The table SHALL list every package in the cross-project bump set regardless of group health (even if its research group is `failed`/`missing`/`expected-missing`, the bump row appears so the orchestrator's apply step still considers it).
 - Hint lines on improvement / workaround bullets carry abstract context only (file globs by convention, framework names, idiomatic patterns) — same restriction as the cross-project subagent prompt template. The main agent SHALL NOT promote a single-project path discovered during phase 4 into a Hint line; if no universal hint exists, write `Hint: none`.
+- The `Changelogs` section is the final section and is assembled per "4.C — Changelog chronology section (both modes)". The cross-project variant uses a **representative** `<from>` (the most-common `currentVersion` across occurrences) → `<to>` (the package's `effectiveTarget` from `cross-project-plan.json`), deduped to **one block per package** — it SHALL NOT enumerate per-project version variations (the `Cross-project bump set` table is the source for those).
+
+### 4.C — Changelog chronology section (both modes)
+
+Phase 4 synthesis SHALL append a final `## Changelogs` section to `plan.md` in **both** modes, assembled entirely from changelog data **already on disk** — the per-group `changelogs/<package-basename>/` outputs written in phase 1 and the `experiments:npm-changelog` cache under `~/.claude/changelogs/<normalized-name>/`. Synthesis SHALL NOT issue any network call (`npm view`, `gh api`, `curl`, …) to build this section.
+
+The section contains **one block per package in the bump set**, ordered **alphabetically** by package name. Each block:
+
+1. **Header** `### <package> (<from> → <to>)`. Single-project: `<from>`/`<to>` = the package's `currentVersion`/`targetVersion` from `scan.json`. Cross-project: the representative `currentVersion` (most-common across occurrences; ties broken by first-occurrence order) → the `effectiveTarget` from `cross-project-plan.json`.
+2. **Links line first**, reused from the npm-changelog cache metadata — no network. Read the repository URL from `~/.claude/changelogs/<normalized-name>/_meta.json.repository` (and `changelogFiles` when useful), plus the per-version source/release URLs from each `<ver>.meta.json.sourceUrl` for the covered versions. Emit these as the first line of the block.
+3. **Bodies** — the full verbatim changelog body for each **stable version in `(from, to]`** (every version newer than the installed `from`, up to and including `to`; the installed `from` is **excluded** — its changelog is not "new"), in **ascending** order (oldest→newest). Each version's body is the cached `~/.claude/changelogs/<normalized-name>/<ver>.md` content verbatim, wrapped in a collapsible `<details><summary>{ver}</summary>` … `</details>` block.
+
+Reading the section top-to-bottom therefore advances through versions chronologically (oldest first) — the reverse of repository changelog ordering.
+
+**Missing / empty:** if no changelog body is available for a package (every covered version failed, `no_changelog_source`, or `from == to` so the half-open span is empty), render the links line (when a repository is known) followed by the sentinel `_no changelog available_`.
+
+**Normalized name:** the `<normalized-name>` is the `npm-changelog` cache key for the package (the same normalization `experiments:npm-changelog` applies). The `<package-basename>` of the per-group `changelogs/` output is the package name's last path segment.
+
+**Degraded path:** when `degrade-to-main-agent` was selected at the phase-1 hard wall (no per-group `research.md`), the cached `<ver>.md` files still exist under `~/.claude/changelogs/`; the main agent SHALL build the `## Changelogs` section from that cache anyway.
+
+**Always render when there is a bump:** the `## Changelogs` section SHALL render whenever the bump set has ≥1 package, independent of whether any improvements or workarounds were found. Because `plan.md` is a file the user opens deliberately (not chat output), embedding verbatim changelog bodies does not violate the `experiments:npm-changelog` "never paste into chat" rule.
+
+Example block:
+
+```markdown
+### axios (1.7.0 → 1.7.9)
+
+Repo: https://github.com/axios/axios — releases: [1.7.1](…), … [1.7.9](…)
+
+<details><summary>1.7.1</summary>
+
+<verbatim cached 1.7.1.md body>
+
+</details>
+
+<details><summary>1.7.9</summary>
+
+<verbatim cached 1.7.9.md body>
+
+</details>
+```
 
 ### 4 — Common rules (both modes)
 
@@ -594,8 +646,8 @@ When the consumer re-invokes the workflow for cleanup, the workflow SHALL prompt
 - **Question**: `Plan dir at <plan-dir>. Keep for inspection or delete?`
 - **Multi-select**: `false`
 - **Options**:
-    - `delete-plan` — recursively `rm -rf <plan-dir>`.
-    - `keep-plan` — leave it on disk; the next invocation's stale-cleanup (phase 0) will catch it after 10 days.
+  - `delete-plan` — recursively `rm -rf <plan-dir>`.
+  - `keep-plan` — leave it on disk; the next invocation's stale-cleanup (phase 0) will catch it after 10 days.
 
 Cleanup re-entry is consumer-driven and optional: when phase 1 or phase 3 returns `abort`, the workflow itself exits cleanly with the plan dir preserved (per lines covering each abort option) and does NOT prompt for cleanup on its own. The consumer decides whether to re-invoke the workflow for cleanup; if it does, the workflow MUST present the `delete-plan` / `keep-plan` prompt above. If the consumer skips re-invocation, the plan dir stays on disk until the next stale-cleanup pass (phase 0).
 

--- a/openspec/changes/add-minor-update-cascade/.openspec.yaml
+++ b/openspec/changes/add-minor-update-cascade/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-01

--- a/openspec/changes/add-minor-update-cascade/design.md
+++ b/openspec/changes/add-minor-update-cascade/design.md
@@ -1,0 +1,102 @@
+## Context
+
+The `npm:update-*` / `commander:update-*` matrix ships only the `patch` row. The cross-project layer is already factored: `commander-update-{patch,deep-patch}` are thin wrappers over `commander-update-orchestrator`, fully parameterized by `level`/`target`/`mode`. The single-project layer is **not**: the apply mechanism (override consult → ncu `package.json` + `pnpm-workspace.yaml` catalog edits → one install → summary) is restated in three sites — `npm-update-patch` (inline), `npm-update-deep-patch` (inline bumps), and `commander-update-orchestrator` (Steps 8/10, "mirror npm-update-patch Step 5.5"). The orchestrator's non-goals defer a shared `apply-npm-updates` skill "until the deep variants land (third consumer)" — reached now.
+
+This change extracts that shared mechanism, threads `<level>` through the few remaining hardcoded patch strings, adds a changelog-chronology section to the deep plan, and lands the four `minor` commands as the first reuse. Plugin-only; no automated tests in `claude-plugins/experiments/` (manual verification, mirroring prior changes). Versions are driven by release-please from conventional commits — manifests are never hand-edited.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One shared `npm-update-apply` capability owning the single-project apply mechanism + the override-resolution procedure, consumed by all single-project commands and (per project) by the orchestrator.
+- Phase A is **behavior-preserving**: today's `patch` commands produce byte-equivalent user-visible output (prompts, tables, summaries, streamed ncu/install, error copy) after the rewire.
+- A `## Changelogs` section in the deep `plan.md` (both workflow modes): packages alphabetical, versions ascending, repo/release links first, full verbatim bodies collapsed — assembled entirely from already-cached `npm-changelog` data (no re-fetch).
+- The four `minor` commands as thin, level-parameterized wrappers (MON-137/146/195/200).
+
+**Non-Goals:**
+- `major` / `engines` rows (MON-201/202) — breaking-change / peer / engines semantics are not `homónima` to patch; separate tickets. (They do become trivial wrappers after this.)
+- Unifying the override **prompt** copy across single-project and cross-project (the two surfaces legitimately differ — see D2).
+- Changing any observable behavior of the shipped patch commands.
+- Tests/lint/build/commits; registry mutation; auto-rollback.
+
+## Decisions
+
+### D1 — `npm-update-apply` = mechanical apply + override-resolution procedure; the prompt + scope stay with callers
+
+The skill exposes two things:
+
+**(a) A mechanical apply contract.** Caller passes a fully-resolved per-project apply spec; the skill performs writes only and streams `ncu`/install stdout/stderr verbatim:
+
+```
+Input  { packageManager, cwd, target,            // target = ncu --target (= level)
+         cooldown?,                                // mirror scan; omit for pnpm
+         manifestBumps: [{ sourceFile, names[], includeFilter }],   // one ncu call per sourceFile
+         catalogEdits:  [{ name, targetVersion }],                  // pnpm-workspace.yaml in-place
+         overrideCommands: [{ id, command }],                       // interpolated, declaration order
+         skipInstall }                                              // overrides handled their own install
+Result { appliedGeneric: [{ name, location }], appliedOverrides: [{ id, command, matchedNames }],
+         installRan, failure?: { step, sourceFile?|entryId?, exitCode, appliedSoFar[], rawMessage } }
+```
+
+On failure the skill returns the structured `failure` (and the streamed stderr the user already saw); it does **not** print the consumer-specific abort copy. The caller formats its own canonical abort message (single-project "Re-run /experiments:npm-update-<level>…" vs orchestrator "Stopping the run. Subsequent projects not attempted."). This preserves byte-equivalence while sharing the mechanism.
+
+**(b) An override-resolution procedure** (registry load → first-win glob match → `target-of:`/`max-target-of:`/`latest` `{version}` resolution + interpolation → GENERIC/OVERRIDE_RUN/OVERRIDE_SKIP partition). Documented once in this capability; **invoked** by callers that opt into overrides, **skipped** by those that don't. The interactive `run-override`/`skip-matched`/`force-generic` prompt and *which* packages are in scope stay caller-owned.
+
+*Why:* the heaviest, line-for-line duplication is the mechanical block (a) and the matching algorithm (b) — both fully extracted. The only things left in callers are the prompt copy and resolution scope, which genuinely diverge.
+
+*Alternative considered:* skill owns the override prompt too, making `npm-update-patch` a pure wrapper. Rejected — `npm-update-deep-patch` skips overrides entirely and the orchestrator prompts **cross-project** (one prompt per entry across all projects, then runs the command once per affected project), so the prompt can't be shared; baking it in would force 3 awkward modes ("resolve", "no-overrides", "pre-resolved") into the skill.
+
+### D2 — Caller responsibilities after extraction
+
+| Consumer | Overrides | Bumps |
+|---|---|---|
+| `npm-update-patch` (shallow) | resolve (single-project) via (b) + own prompt | apply via (a) |
+| `npm-update-deep-patch` (deep) | **skipped** (preserve existing divergence) | apply via (a), generic-only |
+| `commander-update-orchestrator` (both modes) | resolve **cross-project** (own Step 8 prompt) | apply via (a) **per project** |
+
+The orchestrator computes each project's `effectiveTarget` (post conflict-policy) and per-project override partition, then calls (a) once per project. Its Step 10.3/10.4/10.5 collapse into "build the per-project spec → invoke `npm-update-apply` → fold the returned fragment into the cross-project summary; stop-on-fail on `failure`".
+
+### D3 — `<level>` parameterization
+
+All consumer-visible patch literals become `<level>`-interpolated: scan `level`, ncu `--target`, `No <level> updates available.`, `## ...-<level> summary` / `## ...-deep-<level> summary`, retry-hint command names. Title-cased where a section heading needs it. **Latent fix:** `parallel-research-workflow` 4.S hardcodes `## Patch bump set`; interpolate to `## <Level> bump set` (the mode-table already says "or matching level"). Cross-project bump set stays `## Cross-project bump set` (level-independent). No level-specific *logic* exists anywhere — only these strings + the `level`/`target` inputs.
+
+### D4 — Changelog section (parallel-research-workflow phase 4, both modes)
+
+- New `## Changelogs` H2 **at the end** of `plan.md` (after the bump-set table — reference material, not actionable).
+- One block per bumped package, **alphabetical** by name. Header `### <name> (<from> → <to>)`.
+- **Links first:** a line with the repository URL + per-version release/source links, read from the existing `npm-changelog` cache — `~/.claude/changelogs/<normalized-name>/_meta.json` (`repository`, `changelogFiles`) and each `<ver>.meta.json.sourceUrl`. **No network call** in synthesis.
+- **Bodies:** the stable versions in `(from, to]` (every version newer than the installed `from`, up to `to`; `from` excluded — its changelog is not "new"), **ascending**, each full verbatim body from the cached `<ver>.md` wrapped in `<details><summary>{ver}</summary>…</details>`. Top→bottom = chronology advancing (opposite to repos).
+- **Missing:** a package whose changelog failed (`error.txt` / `no_changelog_source`) or has no new version renders the links line (if a repo is known) + `_no changelog available_`.
+- **Degraded path:** if phase-1 hard-walled into `degrade-to-main-agent` (no per-group `research.md`), the cached `<ver>.md` files still exist under `~/.claude/changelogs/`; the main agent builds the section from the cache anyway.
+- **Cross-project:** the package is deduped (one block); display `from`=`mostCommonCurrentVersion`, `to`=`effectiveTarget` (already computed in orchestrator 6.5.1). A note points to the bump-set table for per-project version variations rather than repeating them per project.
+- Not a chat paste — `plan.md` is a file; the `npm-changelog` "never paste into chat" rule does not apply to file synthesis.
+
+### D5 — One change, phased; verification gate between A and B
+
+`tasks.md` sequences: **Phase A** (new `npm-update-apply`; rewire `npm-update-patch` + `npm-update-deep-patch` + orchestrator; changelog section) → **byte-equivalence gate** (D6) → **Phase B** (4 minor wrappers). Specs split accordingly: Phase A = new `npm-update-apply` + modified `parallel-research-workflow` / `commander-update-orchestrator-skill` / `npm-update-deep-patch-command` / `experiments-plugin`; Phase B = `npm-update-minor-command`, `npm-update-deep-minor-command`, `commander-update-minor-command`, `commander-update-deep-minor-command`.
+
+### D6 — Behavior-equivalence verification (manual)
+
+No test runner here. The gate: capture a **reference run** of the four shipped patch commands against a known fixture (a small multi-PM workspace + the registered commander project set) *before* Phase A — record prompts, tables, summaries, streamed ncu/install, error copy. After Phase A, re-run and **diff**; acceptance = identical user-visible output modulo timestamps/absolute paths. Documented as explicit tasks; Phase B does not start until the gate passes.
+
+### D7 — Override registry stays single + shared across levels
+
+One `pkg-upgrade-overrides.yaml` (not per-level). Override families (e.g. Storybook) need coordinated upgrades regardless of level; `minor` reuses the same file via the same default path. No new data file.
+
+## Risks / Trade-offs
+
+- **Refactor regresses shipped patch output** → D6 byte-equivalence gate before Phase B; canonical abort copy stays caller-owned (skill returns structured failure, never prints consumer copy).
+- **`plan.md` bloats** with full changelog bodies on large cross-project minor runs → `<details>` collapse + section placed last + `_no changelog available_` sentinel; reading is opt-in. No hard cap (the user wants all bodies); flagged as a soft note in the spec.
+- **Stale/missing changelog cache** for a version → links-only + sentinel; synthesis never re-fetches (phase 1 already fetched; failures surface inline).
+- **Cross-project `from` ambiguity** when projects sit on different current versions → show the representative `mostCommonCurrentVersion` + a pointer to the bump-set table; do not fabricate a single per-project history.
+- **Scope creep into major/engines** → specs reference `level=minor` only; major/engines explicitly deferred.
+- **Orchestrator↔skill coupling** (per-project spec contract) → the contract in D1 is the single integration surface; the orchestrator owns conflict/override resolution, the skill owns mechanical writes — clean seam.
+
+## Migration Plan
+
+Markdown-only change (skill + command files under `claude-plugins/experiments/`). "Deploy" = land the files; rollback = `git revert`. The phased gate (D6) is the safety net: Phase A is provably output-equivalent before any new command surface (Phase B) is added. release-please bumps the plugin version from the conventional commits — no manual version edits.
+
+## Open Questions
+
+- **Version span** — confirm bodies cover `(from, to]` (exclude the already-installed `from`). Recommended; flagging for sign-off.
+- **Changelog section when zero findings** — include it whenever there is ≥1 bumped package, independent of improvements/workarounds. Recommended yes.
+- **Cross-project per-project version detail** — representative `from→to` + reference to bump-set table (recommended) vs. enumerating each project's span inside the block.

--- a/openspec/changes/add-minor-update-cascade/proposal.md
+++ b/openspec/changes/add-minor-update-cascade/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+The npm/commander dependency-update command matrix ships only the `patch` row. The four `minor` commands are pending — MON-137 (`npm:update-minor`), MON-146 (`npm:update-deep-minor`), MON-195 (`commander:update-minor`), MON-200 (`commander:update-deep-minor`, this branch). The cross-project layer is already factored (thin command wrappers → `commander-update-orchestrator`), but the **single-project apply flow is duplicated in three places**: inline in `npm-update-patch`, inline in `npm-update-deep-patch`, and re-specified ("mirror npm-update-patch Step 5.5") inside the orchestrator. The orchestrator's own non-goals defer a shared `apply-npm-updates` skill *"until the deep variants land (third consumer)"* — that consumer is now. Extract once, then every remaining command (minor now; major/engines later) is a thin, level-parameterized wrapper. This change also adds a changelog-chronology section to the generated deep plan, so a reviewer sees the full version history of every bumped package in one place.
+
+## What Changes
+
+**Phase A — platform (behavior-preserving; output byte-equivalent to today's shipped patch commands):**
+
+- **NEW shared skill `apply-npm-updates`** — the single-project apply mechanism, parameterized by `level`/`target`: override-registry consultation → ncu `package.json` bumps + `pnpm-workspace.yaml` catalog edits → single `<pm> install` → summary fragment.
+- **Rewire** `npm-update-patch` (shallow apply) and `npm-update-deep-patch` (bumps mechanism) to **consume** `apply-npm-updates` instead of inlining it.
+- **Rewire** `commander-update-orchestrator` (Steps 8 + 10) to **invoke** `apply-npm-updates` per project — passing the per-project resolved accepted set (`effectiveTarget` + override actions) — instead of re-specifying ncu inline.
+- **NEW plan.md `## Changelogs` section** in `parallel-research-workflow` phase-4 synthesis (both single-project and cross-project modes → benefits existing deep-patch + new deep-minor + future levels). Packages **alphabetical**; within each, versions **ascending** (oldest→newest) so top→bottom reads as chronology advancing (opposite to repos). Each package block: repo/release **links first** (reused from cached `npm-changelog` metadata — `_meta.json.repository` / `changelogFiles` + per-version `{ver}.meta.json.sourceUrl`, **no re-fetch**), then full verbatim per-version bodies in collapsible `<details>`. `_no changelog available_` sentinel when absent.
+
+**Phase B — minor column (thin wrappers on the now-factored flow):**
+
+- **NEW** `/experiments:npm-update-minor` (MON-137) — shallow single-project; scan(minor) + `apply-npm-updates`(target=minor).
+- **NEW** `/experiments:npm-update-deep-minor` (MON-146) — deep single-project; scan + group + workflow + `apply-npm-updates`.
+- **NEW** `/experiments:commander-update-minor` (MON-195) — shallow cross-project; `orchestrator(level=minor, mode=shallow)`.
+- **NEW** `/experiments:commander-update-deep-minor` (MON-200) — deep cross-project; `orchestrator(level=minor, mode=deep)`.
+
+**Out of scope:** the `major`/`engines` rows (MON-201/MON-202) — non-`homónima` semantics (breaking changes, peer/engines handling), separate tickets — though they become trivial wrappers once this lands. No tests/lint/build, no commits/branches/PRs, no registry mutation. Manual verification only (mirrors the rest of the experiments plugin).
+
+## Capabilities
+
+### New Capabilities
+
+- `npm-update-apply`: shared single-project apply skill (override → ncu/catalog → install → summary fragment). The deduplicated mechanism consumed by `npm-update-{patch,minor}` (shallow), `npm-update-deep-{patch,minor}` (bumps), and `commander-update-orchestrator` (per-project apply). Owns the apply requirements moved out of the three current sites.
+- `npm-update-minor-command`: `/experiments:npm-update-minor` (MON-137).
+- `npm-update-deep-minor-command`: `/experiments:npm-update-deep-minor` (MON-146).
+- `commander-update-minor-command`: `/experiments:commander-update-minor` (MON-195).
+- `commander-update-deep-minor-command`: `/experiments:commander-update-deep-minor` (MON-200).
+
+### Modified Capabilities
+
+- `parallel-research-workflow`: phase-4 plan.md gains the `## Changelogs` chronology section (both modes); the plan.md section enumeration is extended.
+- `commander-update-orchestrator-skill`: per-project apply (Steps 8 + 10) now delegates to `npm-update-apply`; deep-mode plan.md section enumeration (Step 7.D) includes `Changelogs`. Observable output preserved.
+- `npm-update-deep-patch-command`: bumps/apply mechanism delegates to `npm-update-apply`; the surfaced plan.md now includes `Changelogs`. Observable output preserved.
+- `experiments-plugin`: the shallow `npm-update-patch` apply requirements refactor to delegate to `npm-update-apply`. Observable output preserved.
+
+## Impact
+
+- **Code** (`claude-plugins/experiments/`):
+  - NEW `skills/apply-npm-updates/SKILL.md`.
+  - NEW commands: `npm-update-minor.md`, `npm-update-deep-minor.md`, `commander-update-minor.md`, `commander-update-deep-minor.md`.
+  - MODIFIED commands: `npm-update-patch.md`, `npm-update-deep-patch.md`.
+  - MODIFIED skills: `commander-update-orchestrator/SKILL.md`, `parallel-research-workflow/SKILL.md`.
+- **Regression surface**: shipped patch commands are refactored underneath. Mitigated by the byte-equivalence requirement on Phase A + a manual patch re-run before Phase B adds new commands.
+- **Data**: reuses the existing shared `pkg-upgrade-overrides.yaml` (one file, not per-level) and the `npm-changelog` cache; no new data files.
+- **No** dependency / CI / published-package impact (plugin-only; this plugin has no automated tests).
+- **Linear**: closes MON-137, MON-146, MON-195, MON-200; unblocks the major/engines rows of MON-154.

--- a/openspec/changes/add-minor-update-cascade/specs/commander-update-deep-minor-command/spec.md
+++ b/openspec/changes/add-minor-update-cascade/specs/commander-update-deep-minor-command/spec.md
@@ -1,0 +1,82 @@
+## ADDED Requirements
+
+### Requirement: Command location, frontmatter, and invocation contract
+
+The `experiments` plugin SHALL include a slash command at `claude-plugins/experiments/commands/commander-update-deep-minor.md` with YAML frontmatter declaring a non-empty `description` field. The command SHALL be invocable as `/experiments:commander-update-deep-minor`.
+
+The command SHALL accept no positional arguments and no flags. The `ARGUMENTS` token is preserved only for handling stray user input (a one-line warning, not an early exit).
+
+#### Scenario: Command file exists with frontmatter
+
+- **WHEN** examining `claude-plugins/experiments/commands/`
+- **THEN** the file `commander-update-deep-minor.md` SHALL exist
+- **AND** SHALL contain YAML frontmatter with a non-empty `description` field
+
+#### Scenario: Stray arguments are reported and ignored, not fatal
+
+- **WHEN** the user invokes `/experiments:commander-update-deep-minor foo bar`
+- **THEN** the command prints exactly one line `commander-update-deep-minor takes no arguments; ignoring: foo bar` and continues into the orchestrator invocation
+- **AND** the command does NOT exit early on stray input
+
+#### Scenario: Empty argument string proceeds silently
+
+- **WHEN** the user invokes `/experiments:commander-update-deep-minor` with no argument or only whitespace
+- **THEN** the command proceeds directly to the orchestrator invocation with no preamble line
+
+---
+
+### Requirement: Single invocation of the orchestrator with the deep-minor input set
+
+The command SHALL invoke the `commander-update-orchestrator` skill exactly **once** per command execution, via the `Skill` tool, with these inputs:
+
+- `level: "minor"`
+- `target: "minor"`
+- `mode: "deep"`
+- `overrideRegistryPath`: omitted (the skill defaults to the shared `pkg-upgrade-overrides.yaml`)
+- `projectsFilter`: omitted (the skill's interactive multi-select picker is the only project-selection surface in v1)
+
+The command SHALL NOT override `level`/`target` to anything other than `minor`, SHALL NOT override `mode` to anything other than `"deep"`, SHALL NOT override `overrideRegistryPath`, SHALL NOT pass a `projectsFilter`, and SHALL NOT invoke any other skill or package-manager command directly. Every action goes through the orchestrator.
+
+#### Scenario: Orchestrator invoked with deep-minor inputs
+
+- **WHEN** `/experiments:commander-update-deep-minor` runs against a registry with at least one project
+- **THEN** the orchestrator skill is invoked exactly once with `level: "minor"`, `target: "minor"`, `mode: "deep"`
+- **AND** the command issues no other Skill invocations and runs no `ncu` / `<pm>` commands of its own
+
+#### Scenario: Orchestrator output is surfaced verbatim
+
+- **WHEN** the orchestrator emits prompts (project picker, conflict policy, override actions, the four-option deep gate, plan-mode entry), the rendered `plan.md`, summaries, or error messages
+- **THEN** the command surfaces every line verbatim, without wrapping, prefixing, or post-processing
+- **AND** the command exits with the same exit code the orchestrator returned
+
+#### Scenario: Surfaced plan includes the changelog section
+
+- **WHEN** the orchestrator surfaces the workflow-produced `plan.md`
+- **THEN** the surfaced content includes the `## Changelogs` chronology section (per the `parallel-research-workflow` spec)
+
+---
+
+### Requirement: Hard rules inherited from the orchestrator and the deep flow
+
+The command SHALL inherit and preserve every hard rule from `commander-update-orchestrator` (deep mode) and the single-project deep flow. The command SHALL NOT run tests/lint/build; SHALL NOT create commits/branches/PRs; SHALL NOT modify any file when the user selects `cancel` at the gate or rejects the plan-mode round; SHALL NOT mutate `<HOME>/.claude/commander/projects.json` (byte-identical, verifiable via `shasum`); SHALL NOT mutate a `catalog:` consumer `package.json` (only `pnpm-workspace.yaml`); SHALL NOT auto-execute an override without explicit `run-override`; and SHALL NOT run `ncu --upgrade` as a fallback after an override fails.
+
+#### Scenario: Cancel at the gate leaves the workspace untouched
+
+- **WHEN** the user picks `cancel` at the orchestrator's confirmation gate
+- **THEN** no manifest, override command, install, or plan-mode round runs, the command exits zero, and the registry SHA is unchanged
+
+#### Scenario: Plan-mode rejection preserves bumps but skips improvements
+
+- **WHEN** the user rejects the plan-mode round after some bumps already landed
+- **THEN** the already-applied bumps are preserved (no rollback), no improvement edits are applied, and `Improvements rejected at plan-mode review. No improvement edits applied; bumps are preserved.` is surfaced verbatim
+
+---
+
+### Requirement: Non-goals deferred to follow-ups
+
+The command SHALL NOT implement `--projects a,b,c`, `--all`, per-project parallel apply, auto-rollback (of projects or of bumps when plan-mode is rejected), or automated tests in v1 (deferred, matching the deep-patch sibling).
+
+#### Scenario: CLI flags are not recognized
+
+- **WHEN** the user invokes `/experiments:commander-update-deep-minor --projects foo,bar`
+- **THEN** the command treats `--projects foo,bar` as a stray argument, prints the standard ignore line, and continues into the orchestrator with no project filter applied

--- a/openspec/changes/add-minor-update-cascade/specs/commander-update-deep-minor-command/spec.md
+++ b/openspec/changes/add-minor-update-cascade/specs/commander-update-deep-minor-command/spec.md
@@ -58,7 +58,7 @@ The command SHALL NOT override `level`/`target` to anything other than `minor`, 
 
 ### Requirement: Hard rules inherited from the orchestrator and the deep flow
 
-The command SHALL inherit and preserve every hard rule from `commander-update-orchestrator` (deep mode) and the single-project deep flow. The command SHALL NOT run tests/lint/build; SHALL NOT create commits/branches/PRs; SHALL NOT modify any file when the user selects `cancel` at the gate or rejects the plan-mode round; SHALL NOT mutate `<HOME>/.claude/commander/projects.json` (byte-identical, verifiable via `shasum`); SHALL NOT mutate a `catalog:` consumer `package.json` (only `pnpm-workspace.yaml`); SHALL NOT auto-execute an override without explicit `run-override`; and SHALL NOT run `ncu --upgrade` as a fallback after an override fails.
+The command SHALL inherit and preserve every hard rule from `commander-update-orchestrator` (deep mode) and the single-project deep flow. The command SHALL NOT run tests/lint/build; SHALL NOT create commits/branches/PRs; SHALL NOT modify any file when the user selects `cancel` at the gate; on plan-mode rejection it SHALL NOT apply any improvement edits, but already-applied bumps (from the Step 10a bumps loop) are preserved, not reverted; SHALL NOT mutate `<HOME>/.claude/commander/projects.json` (byte-identical, verifiable via `shasum`); SHALL NOT mutate a `catalog:` consumer `package.json` (only `pnpm-workspace.yaml`); SHALL NOT auto-execute an override without explicit `run-override`; and SHALL NOT run `ncu --upgrade` as a fallback after an override fails.
 
 #### Scenario: Cancel at the gate leaves the workspace untouched
 

--- a/openspec/changes/add-minor-update-cascade/specs/commander-update-minor-command/spec.md
+++ b/openspec/changes/add-minor-update-cascade/specs/commander-update-minor-command/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: Command location, frontmatter, and invocation contract
+
+The `experiments` plugin SHALL include a slash command at `claude-plugins/experiments/commands/commander-update-minor.md` with YAML frontmatter declaring a non-empty `description` field. The command SHALL be invocable as `/experiments:commander-update-minor`.
+
+The command SHALL accept no positional arguments and no flags. The `ARGUMENTS` token is preserved only for handling stray user input (a one-line warning, not an early exit).
+
+#### Scenario: Command file exists with frontmatter
+
+- **WHEN** examining `claude-plugins/experiments/commands/`
+- **THEN** the file `commander-update-minor.md` SHALL exist
+- **AND** SHALL contain YAML frontmatter with a non-empty `description` field
+
+#### Scenario: Stray arguments are reported and ignored, not fatal
+
+- **WHEN** the user invokes `/experiments:commander-update-minor foo bar`
+- **THEN** the command prints exactly one line `commander-update-minor takes no arguments; ignoring: foo bar` and continues into the orchestrator invocation
+- **AND** the command does NOT exit early on stray input
+
+#### Scenario: Empty argument string proceeds silently
+
+- **WHEN** the user invokes `/experiments:commander-update-minor` with no argument or only whitespace
+- **THEN** the command proceeds directly to the orchestrator invocation with no preamble line
+
+---
+
+### Requirement: Single invocation of the orchestrator with the minor (shallow) input set
+
+The command SHALL invoke the `commander-update-orchestrator` skill exactly **once** per command execution, via the `Skill` tool, with these inputs:
+
+- `level: "minor"`
+- `target: "minor"`
+- `overrideRegistryPath`: omitted (the skill defaults to the shared `pkg-upgrade-overrides.yaml`)
+- `projectsFilter`: omitted (the skill's interactive multi-select picker is the only project-selection surface in v1)
+
+`mode` SHALL be omitted (defaulting to `shallow`). The command SHALL NOT override `level`/`target` to anything other than `minor`, SHALL NOT set `mode` to `deep`, SHALL NOT override `overrideRegistryPath`, SHALL NOT pass a `projectsFilter`, and SHALL NOT invoke any other skill or package-manager command directly.
+
+#### Scenario: Orchestrator invoked with minor shallow inputs
+
+- **WHEN** `/experiments:commander-update-minor` runs against a registry with at least one project
+- **THEN** the orchestrator skill is invoked exactly once with `level: "minor"`, `target: "minor"`, and `mode` shallow (absent)
+- **AND** the command issues no other Skill invocations and runs no `ncu` / `<pm>` commands of its own
+
+#### Scenario: Orchestrator output is surfaced verbatim
+
+- **WHEN** the orchestrator emits prompts (project picker, conflict policy, override actions, gate), tables, summaries, or error messages
+- **THEN** the command surfaces every line verbatim, without wrapping, prefixing, or post-processing
+- **AND** the command exits with the same exit code the orchestrator returned
+
+---
+
+### Requirement: Hard rules inherited from the orchestrator
+
+The command SHALL inherit and preserve every hard rule from `commander-update-orchestrator` (shallow mode). The command SHALL NOT run tests/lint/build; SHALL NOT create commits/branches/PRs; SHALL NOT modify any file when the user selects `cancel`; SHALL NOT mutate `<HOME>/.claude/commander/projects.json` (byte-identical before/after, verifiable via `shasum`); SHALL NOT mutate a `catalog:` consumer `package.json` (only `pnpm-workspace.yaml`); SHALL NOT auto-execute an override without explicit `run-override`; and SHALL NOT run `ncu --upgrade` as a fallback after an override fails.
+
+#### Scenario: Cancel at the gate leaves the workspace untouched
+
+- **WHEN** the user picks `cancel` at the orchestrator's confirmation gate
+- **THEN** no manifest, install, or override command runs, the command exits zero, and the registry SHA is unchanged
+
+#### Scenario: Registry byte-identity verified post-run
+
+- **WHEN** a full run completes (success, partial, or cancel)
+- **THEN** `<HOME>/.claude/commander/projects.json` SHALL be byte-identical to its pre-run state
+
+---
+
+### Requirement: Non-goals deferred to follow-ups
+
+The command SHALL NOT implement `--projects a,b,c`, `--all`, per-project parallel apply, auto-rollback, or automated tests in v1 (deferred, matching the patch sibling).
+
+#### Scenario: CLI flags are not recognized
+
+- **WHEN** the user invokes `/experiments:commander-update-minor --projects foo,bar`
+- **THEN** the command treats `--projects foo,bar` as a stray argument, prints the standard ignore line, and continues into the orchestrator with no project filter applied

--- a/openspec/changes/add-minor-update-cascade/specs/commander-update-orchestrator-skill/spec.md
+++ b/openspec/changes/add-minor-update-cascade/specs/commander-update-orchestrator-skill/spec.md
@@ -1,0 +1,94 @@
+## MODIFIED Requirements
+
+### Requirement: Override-registry consultation
+
+Before apply, the skill SHALL load the override registry indicated by `overrideRegistryPath` (default `claude-plugins/experiments/skills/scan-npm-updates/data/pkg-upgrade-overrides.yaml`) and resolve matches using the `npm-update-apply` override-resolution procedure (first-win glob matching over package names plus `{version}` resolution via `target-of:<name>` / `max-target-of:<glob>` / `latest` with `fallbackVersionSource`). The procedure supplies the matching and version-resolution algorithm only; the prompt and its cross-project scope are owned by this skill.
+
+Override prompts SHALL be raised exactly once per matched entry across the entire run. When an entry's matches span multiple projects, the chosen action (`run-override`, `skip-matched`, `force-generic`) SHALL apply to every project the matches touch. The skill SHALL NOT raise an override prompt per project.
+
+`{version}` resolution SHALL run against the cross-project aggregated `proposedTarget` set, not per-project sets.
+
+If the override registry is missing or unparseable, the procedure SHALL degrade gracefully and the skill SHALL print a single warning (`Override registry unavailable: <reason>. Proceeding without overrides.`) and continue with no overrides applied.
+
+#### Scenario: Single override prompt across projects
+
+- **WHEN** `@storybook/*` matches updates in three projects
+- **THEN** the user is prompted exactly once with the override question; the chosen action applies to all three projects
+
+#### Scenario: Missing registry degrades gracefully
+
+- **WHEN** the override registry file does not exist
+- **THEN** the skill prints `Override registry unavailable: ENOENT. Proceeding without overrides.` and continues with the generic flow only
+
+#### Scenario: Matching algorithm sourced from the shared procedure
+
+- **WHEN** the skill resolves overrides
+- **THEN** it uses the `npm-update-apply` override-resolution procedure for first-win matching and `{version}` resolution (not an inline copy of the algorithm)
+- **AND** still raises its own cross-project `run-override` / `skip-matched` / `force-generic` prompt once per matched entry
+
+### Requirement: Sequential apply per project with stop-on-fail
+
+After the confirmation gate, the skill SHALL apply updates **sequentially, one project at a time**, in the registry's insertion order (filtered to the resolved project set). For each project, the skill SHALL:
+
+1. Resolve the project's working directory `<record.path>` (passed to `npm-update-apply` as `cwd`).
+2. Compute the per-project subset of accepted updates (the package occurrences for that project under the chosen conflict policy and override actions), including each occurrence's `effectiveTarget`.
+3. If the per-project subset is empty (every package skipped/overridden out for this project), the skill SHALL skip apply and install for this project and continue to the next.
+4. Build the resolved single-project apply spec for this project — generic `package.json` occurrences as `manifestBumps` (with `includeFilter` set whenever the per-project generic subset is a strict subset of the file's ncu candidate set), `pnpm-workspace.yaml` occurrences as `catalogEdits` (using `effectiveTarget`), interpolated `run-override` commands touching this project as `overrideCommands` (declaration order), and `skipInstall` per the install-skip rule — and invoke the `npm-update-apply` skill **once** with `target: <target>` and `cwd: <record.path>`. The skill performs the `ncu` bumps, catalog edits, override commands, and the single install for this project; the orchestrator SHALL NOT restate that recipe inline.
+
+If `npm-update-apply` returns a structured failure for a project (any of `ncu`, `catalog`, `override`, `install`), the skill SHALL **stop the entire run** at that point, format the cross-project abort message (`Stopping the run. Subsequent projects not attempted.`) from the returned `step` and `exitCode`, and SHALL NOT attempt apply on subsequent projects. The skill SHALL fold each project's returned result fragment into the cross-project summary, which SHALL list:
+
+- Projects fully applied (with per-project bumps and overrides).
+- The project where the failure occurred (with the failing step and exit code).
+- Projects pending (not yet attempted).
+
+The user is responsible for reviewing partial state and re-running the command.
+
+#### Scenario: Sequential order matches registry insertion order
+
+- **WHEN** the resolved set is `[proj-B, proj-A]` (in the registry's insertion order, after filtering)
+- **THEN** apply runs `proj-B` to completion first, then `proj-A`; never in parallel and never reordered
+
+#### Scenario: Empty per-project subset skips that project
+
+- **WHEN** every accepted package is bound to a `skip-matched` override for `proj-C`
+- **THEN** apply for `proj-C` is skipped (no `npm-update-apply` invocation) and the skill proceeds to the next project
+
+#### Scenario: Failure halts subsequent projects
+
+- **WHEN** apply succeeds for `proj-A` and `proj-B`, then `npm-update-apply` returns an `ncu` failure for `proj-C`
+- **THEN** the skill stops; `proj-D` is not attempted; the summary lists `proj-A`/`proj-B` as applied, `proj-C` as failed (with the failing step), and `proj-D` as pending
+
+#### Scenario: One install per project
+
+- **WHEN** apply succeeds for two projects with different package managers
+- **THEN** each project's `npm-update-apply` invocation runs that project's install command exactly once (via the skill)
+
+### Requirement: Deep-mode plan rendering reads workflow `plan.md`
+
+When `mode === "deep"` and the workflow has successfully produced `plan.md`, the skill's Step 7 SHALL:
+
+1. Read `<plan-dir>/plan.md` from the workflow's output.
+2. Surface its content as the run plan: `## Improvements (universal — applicability checked per project at apply time)`, `## Workarounds resolved`, `## Skipped or unavailable`, `## Cross-project bump set`, `## Changelogs`.
+3. Append the orchestrator-owned sections in this order after the plan content:
+    - `**Warnings:**` heading with each warning as a `-` bullet, when the orchestrator's `warnings[]` is non-empty.
+    - `**Skipped (scan-failed) (<N>):**` heading with `<name>: <error>` bullets, when `scanFailed[]` is non-empty.
+    - `**Skipped (path missing) (<N>):**` heading with `<name> — <path>` bullets, when `pathMissing[]` is non-empty.
+
+The `Cross-project bump set` table in deep mode uses the columns `package | proposed target | projects (locations)` — the same shape as shallow Step 7, just with the workflow generating it inside `plan.md` instead of the orchestrator generating it inline. The `## Changelogs` section is workflow-produced (per the `parallel-research-workflow` changelog requirement) and is surfaced verbatim along with the rest of `plan.md`.
+
+#### Scenario: Deep-mode plan combines workflow output with orchestrator drift sections
+
+- **WHEN** Step 7 fires in deep mode with one path-missing record and one scan-failed record
+- **THEN** the rendered output contains the workflow's five H2 sections in order (including `## Changelogs`)
+- **AND** appends `**Skipped (scan-failed) (1):**` and `**Skipped (path missing) (1):**` with their respective bullets
+
+#### Scenario: Changelogs section surfaced verbatim
+
+- **WHEN** the workflow's `plan.md` includes the `## Changelogs` section
+- **THEN** the orchestrator surfaces that section verbatim and does NOT regenerate or summarize it
+
+#### Scenario: Empty-plan early exit in deep mode
+
+- **WHEN** the workflow's `plan.md` reports zero bumps AND zero improvements AND zero workarounds
+- **THEN** the skill prints `No <level> updates available across selected projects.` and exits zero
+- **AND** the plan-dir is preserved on disk (the workflow's end-of-flow cleanup runs separately)

--- a/openspec/changes/add-minor-update-cascade/specs/experiments-plugin/spec.md
+++ b/openspec/changes/add-minor-update-cascade/specs/experiments-plugin/spec.md
@@ -1,0 +1,188 @@
+## MODIFIED Requirements
+
+### Requirement: npm-update-patch Command
+
+The `experiments` plugin SHALL provide the `/experiments:npm-update-patch` command at `claude-plugins/experiments/commands/npm-update-patch.md`, invocable as a Claude Code slash command.
+
+The command SHALL:
+
+- Have YAML frontmatter with at least `description`.
+- Invoke the `scan-npm-updates` skill with `level=patch`.
+- If there are no updates, show an informational message and terminate.
+- Render a table with columns: `name`, `currentVersion → targetVersion`, `location`.
+- Present the user with a single `AskUserQuestion` with options `apply-all`, `pick-subset`, `cancel`.
+- If `pick-subset`: ask for names to exclude (comma-separated or one package per line; empty = include all); validate that names exist in the list and re-prompt if not.
+- Resolve overrides via the `npm-update-apply` override-resolution procedure against the accepted set (loading the Package Upgrade Override Registry at `claude-plugins/experiments/skills/scan-npm-updates/data/pkg-upgrade-overrides.yaml`). For each matched entry, present the user with an `AskUserQuestion` with options `run-override`, `skip-matched`, `force-generic`, then partition the accepted set into `GENERIC` / `OVERRIDE_RUN` / `OVERRIDE_SKIP` per the chosen actions (`run-override` → handled by the override command and excluded from generic ncu; `skip-matched` → excluded from everything; `force-generic` → bumped generically as if unmatched).
+- Build the resolved apply spec and invoke the `npm-update-apply` skill once with `target: patch` to perform the mechanical apply: generic `package.json` updates as `manifestBumps` (with `--filter "<names>"` membership — the per-manifest GENERIC partition, space-separated and literal — whenever that set is a strict subset of ncu's detected candidates, i.e. `pick-subset` or any `OVERRIDE_RUN`/`OVERRIDE_SKIP` touching the manifest); `pnpm-workspace.yaml#catalog` updates as `catalogEdits` (in-memory key edit preserving whitespace and comments); interpolated `run-override` commands as `overrideCommands` (executed once each, skipping generic ncu for their matched packages); and `skipInstall` set when every accepted package was handled by `run-override` and nothing was written outside the override command. The skill runs `npm-check-updates@21.0.2` per manifest (mirroring the `--target` and `--cooldown` flags resolved by the scan), performs the catalog edits, runs the override commands, and runs the single `<pm> install`. The command SHALL NOT restate that recipe inline.
+- Display a textual summary composed from the `npm-update-apply` result fragment: what was applied (generic vs. override), what was skipped, what overrides ran (if any), and a message suggesting (not executing) verification steps to the dev/agent (tests, lint, commit).
+- Not execute tests, lint, build, or create commits.
+
+#### Scenario: Command file exists with frontmatter
+
+- **WHEN** examining `claude-plugins/experiments/commands/`
+- **THEN** `npm-update-patch.md` SHALL exist with YAML frontmatter containing a `description` field
+
+#### Scenario: Command invocable as slash command
+
+- **WHEN** user types `/experiments:npm-update-patch`
+- **THEN** Claude SHALL execute the command instructions
+
+#### Scenario: No patch updates available
+
+- **WHEN** the skill returns an empty `updates` array
+- **THEN** the command SHALL print a message like "No patch updates available" and terminate without prompting
+
+#### Scenario: Apply-all delegates to ncu --upgrade
+
+- **WHEN** the skill returns N updates targeting M distinct `package.json` manifests AND the user selects `apply-all` AND no registry entry matches
+- **THEN** the command SHALL run `ncu --target patch --upgrade --packageFile <path>` exactly once per manifest (via `npm-update-apply`)
+- **AND** SHALL NOT perform per-entry `Edit` calls on those manifests
+- **AND** SHALL reuse the `--cooldown` flag value resolved by the scan (omit when the scan relied on pnpm's native read)
+
+#### Scenario: Pick-subset passes accepted names as ncu --filter
+
+- **WHEN** the skill returns updates AND the user selects `pick-subset` AND excludes one package
+- **THEN** the command SHALL invoke `ncu --target patch --upgrade --packageFile <path> --filter "<space-separated accepted names>"` per manifest (via `npm-update-apply`)
+- **AND** only the accepted packages SHALL be rewritten in each manifest
+- **AND** the excluded packages SHALL remain unchanged
+
+#### Scenario: Pick-subset with invalid exclusion name
+
+- **WHEN** the user submits an exclusion name not present in the updates list
+- **THEN** the command SHALL re-prompt with the invalid name(s) highlighted and the list of valid names
+
+#### Scenario: Cancel flow
+
+- **WHEN** the user selects `cancel`
+- **THEN** the command SHALL exit without modifying any file
+
+#### Scenario: Catalog update edits pnpm-workspace.yaml
+
+- **WHEN** an applied update has `sourceFile: "pnpm-workspace.yaml"`
+- **THEN** the command SHALL bump the version under `catalog:` in `pnpm-workspace.yaml` using the in-memory edit path (via `npm-update-apply`)
+- **AND** SHALL NOT invoke `ncu --upgrade` on the catalog file
+- **AND** SHALL NOT touch the consumer `package.json`
+
+#### Scenario: Registry entry matches — user selects run-override
+
+- **WHEN** the accepted set contains `storybook@8.1.2` and `@storybook/react@8.1.2` AND the registry matches them to the `storybook` entry AND the user selects `run-override`
+- **THEN** the command SHALL execute the interpolated override command (e.g. `npx storybook@8.1.2 upgrade`) exactly once
+- **AND** SHALL NOT invoke `ncu --upgrade` for `storybook` or `@storybook/react`
+- **AND** the summary SHALL list these packages under "applied via override"
+
+#### Scenario: Registry entry matches — user selects skip-matched
+
+- **WHEN** the accepted set contains `storybook@8.1.2` AND the user selects `skip-matched` for the `storybook` entry
+- **THEN** the command SHALL NOT execute the override command
+- **AND** SHALL NOT invoke `ncu --upgrade` for packages matched by the entry
+- **AND** the summary SHALL list matched packages under "skipped by override policy"
+
+#### Scenario: Registry entry matches — user selects force-generic
+
+- **WHEN** the accepted set contains `storybook@8.1.2` AND the user selects `force-generic` for the `storybook` entry
+- **THEN** the command SHALL invoke `ncu --upgrade` for the matched packages as if the registry did not match
+- **AND** SHALL NOT execute the override command
+
+#### Scenario: Registry invalid or missing
+
+- **WHEN** the registry file does not exist OR fails to parse as YAML OR lacks an `overrides` top-level key
+- **THEN** the command SHALL emit a warning and proceed as if no entries matched
+- **AND** SHALL NOT abort the invocation
+
+#### Scenario: Override command fails at runtime
+
+- **WHEN** the override command exits non-zero
+- **THEN** the command SHALL report the exit code and the command that failed
+- **AND** SHALL NOT run `ncu --upgrade` as a fallback for the matched packages
+- **AND** SHALL NOT run the final `<pm> install` if nothing was written outside the override
+
+#### Scenario: Install step skipped when only overrides ran
+
+- **WHEN** every accepted package was handled by `run-override` AND no `ncu --upgrade` invocation or catalog edit was made
+- **THEN** the command SHALL NOT run the final `<pm> install`
+- **AND** the summary SHALL note that the install was delegated to the override command(s)
+
+#### Scenario: No post-install verification
+
+- **WHEN** the command completes applying updates
+- **THEN** the command SHALL NOT invoke tests, lint, build, or create a commit
+- **AND** the final message SHALL suggest these as next steps for the dev/agent
+
+### Requirement: Package Upgrade Override Registry
+
+The `experiments` plugin SHALL provide a package upgrade override registry as a YAML data file at `claude-plugins/experiments/skills/scan-npm-updates/data/pkg-upgrade-overrides.yaml`.
+
+The registry SHALL declare an `overrides` top-level key whose value is a list of entries. Each entry SHALL have:
+
+- `id` (string, required): stable identifier for the entry (e.g. `storybook`).
+- `matches` (list of strings, required, non-empty): glob patterns over package names. A package matches an entry when its name matches any pattern in the list.
+- `command` (string, required): command template with the literal token `{version}` to be interpolated.
+- `versionSource` (string, required): resolution strategy for `{version}`. Allowed values:
+    - `target-of:<name>` — use the `targetVersion` of the named package from the accepted set.
+    - `max-target-of:<glob>` — use the max semver across `targetVersion`s of accepted packages whose names match the glob.
+    - `latest` — use the literal string `latest`.
+- `fallbackVersionSource` (string, optional): same syntax as `versionSource`, used when the primary source cannot be resolved.
+- `reference` (string, optional): URL to official documentation for the upgrade command.
+- `notes` (string, optional): human-readable explanation of what the override does, surfaced in the AskUserQuestion prompt.
+
+The registry is a single, level-independent data file. It SHALL be consumed via the `npm-update-apply` override-resolution procedure by the single-project shallow commands (`/experiments:npm-update-patch`, `/experiments:npm-update-minor`) and, cross-project, by the `commander-update-orchestrator` skill; the single-project deep path does not consult it. The `scan-npm-updates` skill SHALL NOT read or emit overrides.
+
+The registry SHALL include a seed entry for Storybook with:
+
+- `id: storybook`
+- `matches` covering `storybook`, `@storybook/*`, `eslint-plugin-storybook`, `storybook-addon-*`.
+- `command: "npx storybook@{version} upgrade"`
+- `versionSource: target-of:storybook`
+- `fallbackVersionSource: max-target-of:@storybook/*`
+- `reference: https://storybook.js.org/docs/releases/upgrading`
+
+Matching SHALL be first-win ordered: a package matches at most one entry, the first in declaration order whose `matches` patterns coincide.
+
+Glob semantics for `matches`: `*` matches any sequence of characters within a package name segment. No other glob metacharacters are supported in this iteration.
+
+#### Scenario: Registry file exists with seed entry
+
+- **WHEN** examining `claude-plugins/experiments/skills/scan-npm-updates/data/pkg-upgrade-overrides.yaml`
+- **THEN** the file SHALL exist and parse as YAML
+- **AND** SHALL contain at least one entry under `overrides:` with `id: storybook`
+
+#### Scenario: Entry matches by exact name
+
+- **WHEN** the accepted set includes a package named `storybook`
+- **THEN** it SHALL match the `storybook` entry via the exact-name pattern `storybook`
+
+#### Scenario: Entry matches by glob
+
+- **WHEN** the accepted set includes a package named `@storybook/react`
+- **THEN** it SHALL match the `storybook` entry via the glob pattern `@storybook/*`
+
+#### Scenario: Entry does not match unrelated package
+
+- **WHEN** the accepted set includes a package named `react`
+- **THEN** it SHALL NOT match the `storybook` entry
+
+#### Scenario: First-win match order
+
+- **WHEN** two entries declare overlapping `matches` patterns AND a package would match both
+- **THEN** the package SHALL be considered matched by the first entry in declaration order
+
+#### Scenario: Version interpolation with target-of
+
+- **WHEN** the `storybook` entry has `versionSource: target-of:storybook` AND the accepted set contains `storybook` with `targetVersion: "8.1.2"`
+- **THEN** the interpolated command SHALL be `npx storybook@8.1.2 upgrade`
+
+#### Scenario: Version interpolation falls back to max-target-of
+
+- **WHEN** the `storybook` entry has `versionSource: target-of:storybook` AND `fallbackVersionSource: max-target-of:@storybook/*` AND the accepted set contains `@storybook/react` `8.1.2` and `@storybook/addon-essentials` `8.1.1` but NO `storybook` package
+- **THEN** the interpolated command SHALL use `8.1.2` (the max across matching packages)
+
+#### Scenario: Version interpolation unresolvable
+
+- **WHEN** neither `versionSource` nor `fallbackVersionSource` can be resolved against the accepted set
+- **THEN** the command SHALL emit a warning identifying the entry and SHALL skip the override prompt for that entry
+- **AND** the matched packages SHALL fall back to generic `ncu --upgrade` treatment
+
+#### Scenario: Adding a new entry requires no command logic change
+
+- **WHEN** a new entry is appended to `overrides:` in the YAML file with valid `id`, `matches`, `command`, and `versionSource`
+- **THEN** the consuming commands SHALL pick it up on next invocation without any change to their command files

--- a/openspec/changes/add-minor-update-cascade/specs/npm-update-apply/spec.md
+++ b/openspec/changes/add-minor-update-cascade/specs/npm-update-apply/spec.md
@@ -1,0 +1,208 @@
+## ADDED Requirements
+
+### Requirement: Skill location and structure
+
+The `experiments` plugin SHALL include a skill at `claude-plugins/experiments/skills/apply-npm-updates/SKILL.md` with YAML frontmatter declaring a non-empty `description` field. The skill SHALL be invocable via the `Skill` tool by the single-project update commands (`/experiments:npm-update-patch`, `/experiments:npm-update-minor`, and their deep variants) and, once per project, by the `commander-update-orchestrator` skill.
+
+The skill SHALL be implemented entirely with Claude Code built-in tools (`Read`, `Bash`, `Edit`, `Write`) and SHALL NOT introduce a new runtime dependency, library, or sidecar package. The skill is the single source of truth for the single-project npm apply mechanism; consumers SHALL NOT restate the `ncu` / catalog-edit / install recipe inline.
+
+#### Scenario: Skill file exists
+
+- **WHEN** examining `claude-plugins/experiments/skills/`
+- **THEN** the directory `apply-npm-updates/` SHALL exist
+- **AND** SHALL contain a `SKILL.md` file with non-empty `description` frontmatter
+
+#### Scenario: Skill is invocable by consumers
+
+- **WHEN** a consumer command or the orchestrator invokes the skill via the `Skill` tool with a resolved apply spec
+- **THEN** the skill performs the mechanical apply for that one project and returns its structured result
+
+---
+
+### Requirement: Mechanical apply input contract
+
+The skill SHALL accept a fully-resolved, single-project apply spec with exactly these inputs (the caller resolves conflict policy, override decisions, and `--filter` membership before invoking):
+
+- `packageManager` (required) — one of `pnpm`, `npm`, `yarn`, `bun`, `deno`.
+- `cwd` (required) — absolute path of the project whose manifests are bumped. Every `Bash` invocation SHALL run with this working directory (or use absolute `--packageFile` paths); the skill SHALL NOT mutate the caller's shell state across invocations.
+- `target` (required) — one of `patch`, `minor`, `major`, `engines`. Passed verbatim to `ncu --target`.
+- `cooldown` (optional) — release-age period to pass as `ncu --cooldown`; omitted for `pnpm` (ncu reads `pnpm-workspace.yaml` natively).
+- `manifestBumps` (optional) — array of `{ sourceFile, names: string[], includeFilter: boolean }`; one `package.json` manifest per element.
+- `catalogEdits` (optional) — array of `{ name, targetVersion }` for `pnpm-workspace.yaml` catalog keys.
+- `overrideCommands` (optional) — array of `{ id, command }`, the already-interpolated override commands in declaration order.
+- `skipInstall` (optional, default `false`) — when `true`, the final install is skipped (every accepted package was handled by an override that runs its own install).
+
+The skill SHALL reject an unknown `packageManager` or `target` before any side effect.
+
+#### Scenario: Unknown target rejected before side effects
+
+- **WHEN** the caller invokes the skill with `target: "junk"`
+- **THEN** the skill aborts with an invalid-target error and performs no `ncu`, catalog edit, override command, or install
+
+#### Scenario: Resolved spec is consumed as-is
+
+- **WHEN** the caller passes `manifestBumps`, `catalogEdits`, and `overrideCommands` already partitioned
+- **THEN** the skill applies exactly those, performing no override matching, no conflict resolution, and no `pick-subset` parsing of its own
+
+---
+
+### Requirement: Generic package.json bumps via npm-check-updates
+
+For each `manifestBumps` element (a `package.json` `sourceFile`), the skill SHALL invoke `npm-check-updates@21.0.2` exactly once via the package-manager runner prefix (`pnpm dlx`, `npx -y`, `yarn dlx`, `bunx`, `deno run --allow-read --allow-net npm:`):
+
+```bash
+<runner-prefix> npm-check-updates@21.0.2 -p <packageManager> --target <target> --upgrade --packageFile <sourceFile> [--cooldown <period>] [--filter "<names>"]
+```
+
+`-p <packageManager>` SHALL always be passed (mirror scan semantics, prevent ncu auto-detect drift). `--cooldown` SHALL be included when `cooldown` is set and omitted for `pnpm`. `--filter "<names>"` (the element's `names`, space-separated, double-quoted) SHALL be included when `includeFilter` is `true` and omitted otherwise. The skill SHALL stream `ncu` stdout/stderr to the user verbatim.
+
+If `ncu` exits non-zero for a manifest, the skill SHALL stop immediately and return a structured failure `{ step: "ncu", sourceFile, exitCode, appliedSoFar }` without printing any consumer-specific abort message.
+
+#### Scenario: One ncu invocation per manifest
+
+- **WHEN** the spec has two distinct `package.json` source files
+- **THEN** the skill invokes `npm-check-updates@21.0.2` exactly once per file, with `-p <pm> --target <target> --upgrade --packageFile <sourceFile>`
+
+#### Scenario: Filter included only when requested
+
+- **WHEN** a `manifestBumps` element has `includeFilter: true` with `names: ["lodash", "zod"]`
+- **THEN** the ncu invocation for that file includes `--filter "lodash zod"`
+- **AND** an element with `includeFilter: false` is invoked without `--filter`
+
+#### Scenario: ncu failure returns structured failure, not consumer copy
+
+- **WHEN** `ncu` exits non-zero on a manifest
+- **THEN** the skill stops, returns `{ step: "ncu", sourceFile, exitCode, appliedSoFar }`, and does NOT run the install or any override command
+- **AND** the skill does NOT print a `Re-run /experiments:...` or `Stopping the run...` line (the caller owns that copy)
+
+---
+
+### Requirement: pnpm-workspace.yaml catalog edits
+
+For each `catalogEdits` element (`sourceFile === "pnpm-workspace.yaml"` semantics), the skill SHALL locate the matching key under the top-level `catalog:` block and replace its value with `targetVersion`, preserving surrounding whitespace, comments, and other keys' order. The skill SHALL NOT touch any consumer `package.json` entry that is a `catalog:` reference.
+
+If a catalog key is unexpectedly missing, the skill SHALL stop and return `{ step: "catalog", name, exitCode: null, appliedSoFar }`.
+
+#### Scenario: Catalog value edited in place
+
+- **WHEN** `catalogEdits` includes `{ name: "zod", targetVersion: "^3.24.1" }`
+- **THEN** the skill rewrites the `zod` key under `catalog:` in `pnpm-workspace.yaml` to `^3.24.1`
+- **AND** does NOT invoke `npm-check-updates` for the catalog file
+
+#### Scenario: Consumer catalog reference untouched
+
+- **WHEN** a consumer `package.json` declares `"zod": "catalog:"`
+- **THEN** the skill does NOT modify that `package.json`
+
+---
+
+### Requirement: Override command execution
+
+After every generic manifest write and catalog edit for the project has succeeded, the skill SHALL execute each `overrideCommands` element's `command` exactly once, in declaration order, streaming stdout/stderr. If any override exits non-zero, the skill SHALL stop and return `{ step: "override", entryId, exitCode, appliedSoFar }`. The skill SHALL NOT run `ncu --upgrade` as a fallback after an override fails, and SHALL NOT run the final install on this path.
+
+#### Scenario: Overrides run after generic writes in declaration order
+
+- **WHEN** the spec has generic manifest bumps and two override commands
+- **THEN** the skill writes all manifests first, then runs the two override commands in declaration order
+
+#### Scenario: Override failure stops with no fallback
+
+- **WHEN** an override command exits non-zero
+- **THEN** the skill returns `{ step: "override", entryId, exitCode, appliedSoFar }`
+- **AND** does NOT run `ncu --upgrade` for the matched packages and does NOT run the install
+
+---
+
+### Requirement: Single install with skip rule
+
+After all generic bumps, catalog edits, and override commands for the project land successfully, the skill SHALL run exactly one install command for the project's package manager (`pnpm install` / `npm install` / `yarn install` / `bun install` / `deno install`), unless `skipInstall` is `true`. The skill SHALL skip the install when `skipInstall` is `true` (every accepted package was handled by an override that ran its own install). If the install exits non-zero, the skill SHALL return `{ step: "install", exitCode, appliedSoFar }`.
+
+#### Scenario: One install per invocation
+
+- **WHEN** the spec applies bumps across three manifests with `skipInstall: false` and `packageManager: "pnpm"`
+- **THEN** the skill runs `pnpm install` exactly once after all manifests are written
+
+#### Scenario: Install skipped when overrides handled everything
+
+- **WHEN** `skipInstall: true` and no generic manifest write or catalog edit occurred
+- **THEN** the skill runs no install command
+- **AND** the result records that the install was delegated to the override command(s)
+
+---
+
+### Requirement: Structured result and caller-owned messaging
+
+On success the skill SHALL return a structured result `{ appliedGeneric: [{ name, location }], appliedOverrides: [{ id, command, matchedNames }], installRan: boolean, failure: null }`. On failure the skill SHALL return the same shape with `failure` populated per the failing-step requirements above. The skill SHALL stream `ncu` / install / override stdout/stderr verbatim (observability), but SHALL NOT print the consumer-facing summary block or the consumer-specific abort copy — the caller composes those so that single-project and cross-project consumers each preserve their own wording and exit semantics.
+
+#### Scenario: Success returns a composable fragment
+
+- **WHEN** the apply completes successfully
+- **THEN** the result lists every generically-bumped package (with `location`) and every override that ran (with command and matched names) and `installRan`
+- **AND** the skill prints no `## ...-<level> summary` heading of its own
+
+#### Scenario: Failure leaves messaging to the caller
+
+- **WHEN** any step fails
+- **THEN** the structured `failure` carries the step, identifiers, exit code, and `appliedSoFar`
+- **AND** the skill does NOT print a consumer-specific abort message; the caller formats and prints it
+
+---
+
+### Requirement: Override-resolution procedure (caller-invoked)
+
+The skill SHALL document a reusable override-resolution procedure that callers invoke when they opt into overrides: load the override registry from the caller-supplied path (default `claude-plugins/experiments/skills/scan-npm-updates/data/pkg-upgrade-overrides.yaml`); match each candidate package against `overrides[].matches` with first-win glob semantics (`*` matches any run of characters within a name; no other metacharacters); resolve `{version}` via `target-of:<name>`, `max-target-of:<glob>`, or `latest`, falling back to `fallbackVersionSource` when the primary is unresolved; interpolate `{version}` into `command`; and partition candidates into `GENERIC` / `OVERRIDE_RUN` / `OVERRIDE_SKIP`. If the registry is missing or unparseable, the procedure SHALL degrade gracefully (treat as empty, emit a one-line warning) and SHALL NOT abort.
+
+The interactive `run-override` / `skip-matched` / `force-generic` prompt and the *scope* of resolution (which packages, single-project vs. cross-project) remain caller-owned — the single-project commands and the orchestrator prompt with their own copy and scope. The procedure is the matching/resolution algorithm only.
+
+#### Scenario: First-win glob match
+
+- **WHEN** a candidate set includes `@storybook/react` and the registry's first matching entry is `storybook` (patterns include `@storybook/*`)
+- **THEN** the package binds to the `storybook` entry and to no later entry
+
+#### Scenario: Version resolution with fallback
+
+- **WHEN** an entry has `versionSource: target-of:storybook` and `fallbackVersionSource: max-target-of:@storybook/*`, and no `storybook` package is present but `@storybook/react` resolves to `8.1.2`
+- **THEN** the procedure interpolates `8.1.2` into the command
+
+#### Scenario: Missing registry degrades gracefully
+
+- **WHEN** the override registry file does not exist
+- **THEN** the procedure treats the registry as empty, emits `Override registry unavailable: <reason>. Proceeding without overrides.`, and does NOT abort
+
+#### Scenario: Prompt and scope are not part of the procedure
+
+- **WHEN** a caller uses the procedure
+- **THEN** the procedure returns matches/partitions only and does NOT raise the override `AskUserQuestion` itself
+
+---
+
+### Requirement: Level-agnostic operation
+
+The skill SHALL contain no level-specific logic. Behavior is parameterized solely by `target` (passed to `ncu --target`); the same skill serves `patch`, `minor`, `major`, and `engines` callers identically.
+
+#### Scenario: Minor target threads through unchanged
+
+- **WHEN** the skill is invoked with `target: "minor"`
+- **THEN** every `ncu` invocation uses `--target minor` and no other behavior differs from a `patch` invocation
+
+---
+
+### Requirement: Hard rules
+
+The skill SHALL preserve the family hard rules:
+
+- SHALL NOT run tests, lint, or build.
+- SHALL NOT create git commits, branches, or pull requests.
+- SHALL NOT mutate any consumer `package.json` entry that is a `catalog:` reference — only `pnpm-workspace.yaml` for those.
+- SHALL NOT run `ncu --upgrade` as a fallback after an override command fails.
+- SHALL NOT read or write the override registry data file except via the read-only resolution procedure.
+
+#### Scenario: No verification steps executed
+
+- **WHEN** an apply completes
+- **THEN** no `vitest`, `nx test`, lint, build, or git commit command has been invoked by the skill
+
+#### Scenario: No ncu fallback after override failure
+
+- **WHEN** an override command fails
+- **THEN** the skill SHALL NOT invoke `ncu --upgrade` for the matched packages

--- a/openspec/changes/add-minor-update-cascade/specs/npm-update-deep-minor-command/spec.md
+++ b/openspec/changes/add-minor-update-cascade/specs/npm-update-deep-minor-command/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: Command entry point and scope
+
+The `experiments` plugin SHALL provide the `/experiments:npm-update-deep-minor` command at `claude-plugins/experiments/commands/npm-update-deep-minor.md` with YAML frontmatter declaring a non-empty `description`. The command SHALL operate exclusively at **minor** level — it SHALL pass `level=minor` to the scan skill and to `parallel-research-workflow`, and SHALL NOT accept a different level. It is the deep single-project sibling of `/experiments:npm-update-deep-patch`, identical in flow except for the level.
+
+#### Scenario: Invocation scans at minor
+
+- **WHEN** the user runs `/experiments:npm-update-deep-minor`
+- **THEN** the command begins the workflow at the scan step using `level=minor`
+
+#### Scenario: Level argument ignored
+
+- **WHEN** the user passes `level=patch`
+- **THEN** the command ignores it and still scans at `level=minor`
+
+---
+
+### Requirement: Scan, empty short-circuit, and workflow orchestration
+
+The command SHALL invoke `experiments:scan-npm-updates` with `level=minor`, surfacing scan precondition errors verbatim and creating no plan dir on abort. If `updates.length === 0`, the command SHALL print any warnings then the literal line `No minor updates available.` and exit without invoking grouping or the research workflow. Otherwise it SHALL invoke `dependency-grouping-strategy` with `{ updates }`, then `parallel-research-workflow` with `{ groups, level: "minor", scanResult }` (single-project mode), surfacing the workflow's progress and early-exit signals without advancing phases on its behalf.
+
+#### Scenario: Empty result prints minor-specific copy
+
+- **WHEN** the scan returns `updates: []`
+- **THEN** the command prints `No minor updates available.` and exits with no plan dir created
+
+#### Scenario: Workflow invoked at minor level
+
+- **WHEN** the scan returns updates
+- **THEN** the command invokes `parallel-research-workflow` with `level: "minor"`, producing a plan dir slug suffixed `-minor-<ts>`
+
+---
+
+### Requirement: Execution prompt, bump delegation, and improvements
+
+When the workflow finishes phase 4 successfully, the command SHALL raise a single `AskUserQuestion` with `apply-all`, `apply-bumps-only`, `pick-subset`, `cancel` (same order as `npm-update-deep-patch`). For any path that applies bumps, the command SHALL delegate the bump mechanism to the `npm-update-apply` skill (`target: "minor"`, generic-only — the deep path consults NO override registry, preserving the single-project deep divergence). Improvements SHALL be applied via Claude Code plan mode (reconnaissance → mandatory `EnterPlanMode` → user approval/rejection), scoped strictly to bullets present in `plan.md`. On rejection, the command SHALL print `Improvements rejected at plan-mode review. No improvement edits applied; bumps are preserved.` and preserve applied bumps.
+
+#### Scenario: Bumps delegated to npm-update-apply, generic-only
+
+- **WHEN** the user selects `apply-bumps-only`
+- **THEN** the command invokes `npm-update-apply` with `target: "minor"` and an empty `overrideCommands` set (the deep single-project path does not consult the override registry)
+
+#### Scenario: Improvements require plan mode
+
+- **WHEN** the user selects `apply-all` after bumps land
+- **THEN** the command invokes `EnterPlanMode` with the proposed edits before any improvement `Edit`/`Write`
+
+#### Scenario: Plan-mode rejection preserves bumps
+
+- **WHEN** the user rejects the plan-mode round
+- **THEN** the command prints the rejection line and the already-applied bumps are NOT reverted
+
+---
+
+### Requirement: Final summary, changelog plan section, and hard rules
+
+The command SHALL print a summary headed `## npm-update-deep-minor summary` with the same conditional sections as `npm-update-deep-patch` (applied bumps, applied improvements, skipped improvements, skipped-or-unavailable groups, install line, always-present `Suggested next steps`). The `plan.md` the command surfaces SHALL include the `## Changelogs` chronology section produced by `parallel-research-workflow`. The command SHALL delegate end-of-flow cleanup to the workflow (one `delete-plan` / `keep-plan` prompt). The command SHALL NOT run tests, lint, or build; SHALL NOT create commits/PRs; SHALL NOT consult the override registry; and SHALL NOT mutate `catalog:` consumer `package.json` entries.
+
+#### Scenario: Summary heading is deep-minor-namespaced
+
+- **WHEN** a run completes
+- **THEN** the summary starts with `## npm-update-deep-minor summary`
+
+#### Scenario: Plan includes the changelog section
+
+- **WHEN** the workflow produces `plan.md` for a minor run
+- **THEN** `plan.md` includes a `## Changelogs` section (per the `parallel-research-workflow` spec)
+
+#### Scenario: Override registry not consulted on the deep path
+
+- **WHEN** the command applies bumps
+- **THEN** it does NOT load or match the override registry (the override flow remains the shallow `/experiments:npm-update-minor` path's responsibility)

--- a/openspec/changes/add-minor-update-cascade/specs/npm-update-deep-patch-command/spec.md
+++ b/openspec/changes/add-minor-update-cascade/specs/npm-update-deep-patch-command/spec.md
@@ -1,0 +1,21 @@
+## MODIFIED Requirements
+
+### Requirement: Bump application reuses existing infrastructure
+
+For `apply-all`, `apply-bumps-only`, and `pick-subset` (when bumps are included), the command SHALL apply patch-level bumps by invoking the `npm-update-apply` skill (the single source of truth for the single-project apply mechanism) with `target: "patch"`. The command SHALL build the resolved apply spec from the accepted set — `package.json` manifests as `manifestBumps` (with `includeFilter` set when the accepted set for a file is a strict subset, i.e. `pick-subset` partial inclusion) and `pnpm-workspace.yaml#catalog` entries as `catalogEdits` — and SHALL pass an empty `overrideCommands` set: the deep path consults NO override registry (the override flow remains the shallow `/experiments:npm-update-patch` path's responsibility). The skill runs `npm-check-updates@21.0.2` per manifest, performs the in-memory catalog edits, and runs exactly one install at the end; the command SHALL NOT restate that recipe inline.
+
+#### Scenario: Bumps delegated to npm-update-apply
+
+- **WHEN** the package manager is pnpm and 12 bumps are applied across 3 manifests
+- **THEN** the command invokes `npm-update-apply` once with `target: "patch"`, which runs `pnpm install` exactly once after all manifests are written
+- **AND** the command does not invoke `npm-check-updates` directly
+
+#### Scenario: Catalog entries handled in-memory via the apply spec
+
+- **WHEN** an update has `sourceFile: "pnpm-workspace.yaml"`
+- **THEN** the command passes it as a `catalogEdits` entry to `npm-update-apply`, which edits the `catalog:` block in place and does NOT invoke `npm-check-updates` for that file
+
+#### Scenario: Deep path passes no overrides
+
+- **WHEN** the command builds the apply spec
+- **THEN** `overrideCommands` is empty and no override registry is loaded (the deep single-project path does not consult overrides)

--- a/openspec/changes/add-minor-update-cascade/specs/npm-update-minor-command/spec.md
+++ b/openspec/changes/add-minor-update-cascade/specs/npm-update-minor-command/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: Command entry point and scope
+
+The `experiments` plugin SHALL provide the `/experiments:npm-update-minor` command at `claude-plugins/experiments/commands/npm-update-minor.md` with YAML frontmatter declaring a non-empty `description`. The command SHALL operate exclusively at **minor** level — it SHALL invoke `experiments:scan-npm-updates` with `level=minor` and SHALL NOT accept a different level via flags or prompts. It is the shallow single-project sibling of `/experiments:npm-update-patch`, identical in flow except for the level.
+
+#### Scenario: Command file exists with frontmatter
+
+- **WHEN** examining `claude-plugins/experiments/commands/`
+- **THEN** `npm-update-minor.md` SHALL exist with YAML frontmatter containing a non-empty `description`
+
+#### Scenario: Level is fixed to minor
+
+- **WHEN** the user runs `/experiments:npm-update-minor` (with or without stray arguments)
+- **THEN** the command scans at `level=minor` and ignores any level argument
+
+---
+
+### Requirement: Scan, render, and selection flow
+
+The command SHALL invoke `experiments:scan-npm-updates` with `level=minor` and consume the `ScanResult` verbatim. If `updates.length === 0`, the command SHALL print any non-empty `warnings` under a `Warnings:` heading and then the literal line `No minor updates available.` and exit without prompting. Otherwise the command SHALL render a table (`name`, `currentVersion → targetVersion`, `location`, sorted by `location` then `name`) and raise a single `AskUserQuestion` with options `apply-all`, `pick-subset`, `cancel`. `pick-subset` SHALL accept a comma/newline-separated exclusion list validated against the update names (re-prompt on unknown names). `cancel` SHALL exit without modifying any file.
+
+#### Scenario: Empty result prints minor-specific copy
+
+- **WHEN** the scan returns `updates: []`
+- **THEN** the command prints `No minor updates available.` (not `No patch updates available.`) and exits without prompting
+
+#### Scenario: Cancel touches no files
+
+- **WHEN** the user selects `cancel`
+- **THEN** the command exits with `Cancelled. No files modified.` and modifies no file
+
+---
+
+### Requirement: Override resolution and apply delegated to npm-update-apply
+
+The command SHALL resolve overrides using the `npm-update-apply` override-resolution procedure against the accepted single-project set, raising the single-project `run-override` / `skip-matched` / `force-generic` prompt (one `AskUserQuestion` per matched entry) with its own copy. The command SHALL then build the resolved apply spec and invoke the `npm-update-apply` skill **once** to perform the generic `ncu` bumps, `pnpm-workspace.yaml` catalog edits, override commands, and single install. The command SHALL NOT restate the `ncu` / catalog / install recipe inline.
+
+#### Scenario: Apply goes through npm-update-apply
+
+- **WHEN** the user selects `apply-all` against a set with three `package.json` updates
+- **THEN** the command invokes `npm-update-apply` with `target: "minor"` and the resolved manifest bumps, and does NOT invoke `npm-check-updates` directly
+
+#### Scenario: Override prompt is single-project
+
+- **WHEN** an override entry matches accepted packages
+- **THEN** the command raises one `AskUserQuestion` per matched entry with the single-project prompt copy, then passes the resolved partition into the apply spec
+
+---
+
+### Requirement: Summary and hard rules
+
+After apply (or after `cancel`), the command SHALL print a summary headed `## npm-update-minor summary`, composing the `npm-update-apply` result fragment into the same section shape as `/experiments:npm-update-patch` (applied generically, applied via override, skipped by override policy, skipped by user, install line, always-present `Suggested next steps`). On an `npm-update-apply` structured failure, the command SHALL format and print the single-project abort copy (`Re-run /experiments:npm-update-minor to retry the rest.`). The command SHALL NOT run tests, lint, build, or create commits/PRs, and SHALL NOT mutate `catalog:` consumer `package.json` entries.
+
+#### Scenario: Summary heading is minor-namespaced
+
+- **WHEN** a run completes
+- **THEN** the summary starts with `## npm-update-minor summary`
+
+#### Scenario: Abort copy is minor-namespaced
+
+- **WHEN** `npm-update-apply` returns an `ncu` failure
+- **THEN** the command prints the abort message naming `/experiments:npm-update-minor` as the re-run target

--- a/openspec/changes/add-minor-update-cascade/specs/parallel-research-workflow/spec.md
+++ b/openspec/changes/add-minor-update-cascade/specs/parallel-research-workflow/spec.md
@@ -1,0 +1,122 @@
+## MODIFIED Requirements
+
+### Requirement: Phase 4 — plan synthesis in plan mode
+
+When all groups are healthy or the user chose `continue-without`, the main agent SHALL enter Claude Code plan mode and produce `plan.md` at the plan-dir root. The file SHALL begin with an `H1` titled `Deep-<level> plan: <slug>` followed by exactly five `H2` sections in this fixed order: `Improvements (applicable to this codebase)`, `Workarounds resolved`, `Skipped or unavailable`, `<Level> bump set`, `Changelogs`.
+
+The bump-set heading SHALL be the title-cased level followed by ` bump set` — `Patch bump set`, `Minor bump set`, `Major bump set`, or `Engines bump set` — interpolated from the `level` input (it SHALL NOT be hardcoded to `Patch`).
+
+Each section is populated by reading the healthy groups' `research.md` files and the original `scan.json`. The `<Level> bump set` section SHALL list every update from `scan.json` regardless of group health, formatted as a markdown table with columns `package | current → target | location`. The `Changelogs` section is the final section and SHALL follow the "Changelog chronology section in plan.md" requirement below.
+
+The skill SHALL update the global `_meta.json.phase` to `"planning"` before entering plan mode. The skill SHALL NOT set `_meta.json.phase` to `"executing"` or `"done"`; advancing past `"planning"` is consumer-owned (the calling command sets these phases when applying begins or completes).
+
+#### Scenario: Plan mode entered
+
+- **WHEN** phase 3 completes successfully or the user chose `continue-without`
+- **THEN** the global `_meta.json.phase` is set to `"planning"` and the main agent enters plan mode
+
+#### Scenario: Plan structure is fixed
+
+- **WHEN** `plan.md` is written for a `patch` run
+- **THEN** it contains exactly the five H2 section headings `Improvements (applicable to this codebase)`, `Workarounds resolved`, `Skipped or unavailable`, `Patch bump set`, `Changelogs` in that order
+
+#### Scenario: Bump-set heading is level-derived
+
+- **WHEN** `plan.md` is written for a `minor` run
+- **THEN** the bump-set heading reads `## Minor bump set` (not `## Patch bump set`)
+
+#### Scenario: Bump set always present
+
+- **WHEN** the scan returned 12 updates and 2 groups were skipped via `continue-without`
+- **THEN** the `<Level> bump set` table contains all 12 updates regardless of which groups were skipped
+
+### Requirement: Cross-project `plan.md` template
+
+When `mode === "cross-project"`, phase 4 plan-mode synthesis SHALL write `plan.md` with the following exact structure (top-to-bottom):
+
+- An H1 title formatted as `Deep-<level> plan (cross-project): <slug>` (e.g. `# Deep-patch plan (cross-project): commander-deep-patch`).
+- A single descriptive line `Projects covered: <comma-separated project names from scan-by-project.json keys, alphabetical>`.
+- Five H2 sections, in this order: `Improvements (universal — applicability checked per project at apply time)`, `Workarounds resolved`, `Skipped or unavailable`, `Cross-project bump set`, `Changelogs`.
+- The `Improvements` section contains `-` bullets, each with the form `[<priority>] <package> — <opportunity>. Hint: <abstract hint or "none">. (group: <groupId>; affects projects: <comma-separated project names>)`.
+- The `Workarounds resolved` section contains `-` bullets, each with the form `<package> — <bug fixed in this version>. Hint: <abstract hint or "none">. (group: <groupId>; affects projects: <comma-separated project names>)`.
+- The `Skipped or unavailable` section contains `-` bullets, each with the form `<groupId> — <reason>.`.
+- The `Cross-project bump set` section contains a markdown table whose columns are exactly `package`, `proposed target`, `projects (locations)`. Example row: a `react` bump to `^19.0.14` applied in `proj-A` (root) and `proj-B` (root) renders as a single row whose third column reads `proj-A (root); proj-B (root)`.
+- The `Changelogs` section is the final section and SHALL follow the "Changelog chronology section in plan.md" requirement below (cross-project variant: representative `from → to`, dedup by package).
+
+Rules:
+
+- The five H2 sections SHALL appear in this exact order: `Improvements (universal — applicability checked per project at apply time)`, `Workarounds resolved`, `Skipped or unavailable`, `Cross-project bump set`, `Changelogs`.
+- Sections with zero items still render with a single sentinel line: `_no improvements identified_`, `_no workarounds resolved_`, `_no skipped groups_`. The `Changelogs` section uses the per-package `_no changelog available_` sentinel defined in its own requirement.
+- The `affects projects:` list per improvement / workaround bullet is derived from `scan-by-project.json` and `cross-project-plan.json`: for the bullet's package, list every project name whose `ScanResult.updates[]` includes the package.
+- The `Cross-project bump set` table cell format: `<projectName> (<location>)`, with `;` separating projects and `,` separating multiple locations within the same project (when the package appears in multiple workspaces of a single project).
+- Table rows sorted by `package` name (alphabetical, stable).
+- The `<reason>` cell in `Skipped or unavailable` follows the same rule as single-project: for `failed`/`missing` groups, copy `groups/<id>/_meta.json.errorReason` verbatim; for `expected-missing` groups (degraded path), use the constant string `research consolidated in main agent (subagent dispatch limited)`.
+
+#### Scenario: Cross-project plan.md uses cross-project H1 and project-tagged bullets
+
+- **WHEN** phase 4 completes in cross-project mode with `slug: "commander-deep-patch"`, `level: "patch"`, and three improvement bullets affecting different project subsets
+- **THEN** `plan.md` H1 reads `# Deep-patch plan (cross-project): commander-deep-patch`
+- **AND** the second line reads `Projects covered: <alphabetical comma-separated names>`
+- **AND** each improvement bullet ends with `(group: <id>; affects projects: <names>)`
+
+#### Scenario: Cross-project bump set table columns
+
+- **WHEN** the cross-project plan's bump set table is rendered
+- **THEN** the columns are exactly `package`, `proposed target`, `projects (locations)`
+- **AND** rows are sorted alphabetically by `package`
+
+#### Scenario: Changelogs is the final cross-project section
+
+- **WHEN** phase 4 completes in cross-project mode
+- **THEN** `plan.md` ends with the `## Changelogs` section, after `## Cross-project bump set`
+
+#### Scenario: Single-project plan.md template unchanged in shape
+
+- **WHEN** phase 4 completes in single-project mode
+- **THEN** `plan.md` follows the single-project template (H1 `Deep-<level> plan: <slug>`, sections `Improvements (applicable to this codebase)`, `Workarounds resolved`, `Skipped or unavailable`, `<Level> bump set`, `Changelogs`)
+- **AND** improvement bullets carry `(group: <groupId>)` without the `affects projects:` tag
+
+## ADDED Requirements
+
+### Requirement: Changelog chronology section in plan.md
+
+Phase 4 synthesis SHALL append a final `## Changelogs` section to `plan.md` in both `single-project` and `cross-project` modes, assembled entirely from changelog data already on disk — the per-group `changelogs/<package-basename>/` outputs written in phase 1 and the `experiments:npm-changelog` cache under `~/.claude/changelogs/<normalized-name>/`. Synthesis SHALL NOT perform any network fetch for this section.
+
+The section SHALL contain one block per package in the bump set, ordered **alphabetically** by package name. Each block:
+
+1. Header `### <package> (<from> → <to>)`. In single-project mode `<from>`/`<to>` are the package's `currentVersion`/`targetVersion` from `scan.json`. In cross-project mode they are the representative `currentVersion` (the most-common current version across occurrences) and the `effectiveTarget` from `cross-project-plan.json`; the block SHALL NOT enumerate per-project version variations (the `Cross-project bump set` table is the source for those).
+2. A **links line first**, reused from the npm-changelog cache: the repository URL (`~/.claude/changelogs/<normalized-name>/_meta.json.repository`) plus the per-version source/release URLs (`<ver>.meta.json.sourceUrl`) for the covered versions. This line is produced from cached metadata only — no network call.
+3. Then the full verbatim changelog body for each **stable version in `(from, to]`** — every version newer than the installed `from`, up to and including `to`; the installed `from` is excluded — in **ascending** order (oldest→newest). Each version's body SHALL be the cached `<ver>.md` content verbatim, wrapped in a collapsible `<details><summary>{ver}</summary> … </details>` block.
+
+Reading the section top-to-bottom therefore advances through versions chronologically (oldest first), the reverse of repository changelog ordering.
+
+If no changelog body is available for a package (every covered version failed, `no_changelog_source`, or `from == to` so the half-open span is empty), the block SHALL render the links line (when a repository is known) followed by the sentinel `_no changelog available_`. In the degraded path (`degrade-to-main-agent` was selected at the phase-1 hard wall), the cached `<ver>.md` files still exist under `~/.claude/changelogs/`; the main agent SHALL build the section from that cache even when per-group `research.md` is absent.
+
+The `## Changelogs` section SHALL render whenever the bump set has at least one package, independent of whether any improvements or workarounds were found. Because `plan.md` is a file the user opens deliberately (not chat output), embedding verbatim changelog bodies does not violate the `experiments:npm-changelog` "never paste into chat" rule.
+
+#### Scenario: Packages alphabetical, versions ascending
+
+- **WHEN** the bump set contains `zod (3.23.0 → 3.24.1)` and `axios (1.7.0 → 1.7.9)`, each with multiple intermediate versions
+- **THEN** the `## Changelogs` section lists `axios` before `zod`
+- **AND** within each package the `<details>` blocks run oldest version first to newest version last
+
+#### Scenario: Links first, reused from cache, no network
+
+- **WHEN** a package block is rendered
+- **THEN** the first line of the block is the repository + per-version source links read from the npm-changelog cache metadata
+- **AND** synthesis issues no `npm view`, `gh api`, or `curl` calls to build the section
+
+#### Scenario: Version span excludes the installed version
+
+- **WHEN** a package is bumped `1.7.0 → 1.7.9` with stable intermediates `1.7.1 … 1.7.9`
+- **THEN** the block embeds bodies for `1.7.1` through `1.7.9` and SHALL NOT embed a body for `1.7.0`
+
+#### Scenario: Missing changelog renders sentinel
+
+- **WHEN** a bumped package has no available changelog body for any covered version
+- **THEN** its block renders the links line (if a repository is known) followed by `_no changelog available_`
+
+#### Scenario: Cross-project block uses representative versions
+
+- **WHEN** in cross-project mode a package is at different current versions across projects
+- **THEN** the block header shows the representative `currentVersion` → `effectiveTarget` and points to the `Cross-project bump set` table for per-project detail, rather than enumerating each project's span

--- a/openspec/changes/add-minor-update-cascade/tasks.md
+++ b/openspec/changes/add-minor-update-cascade/tasks.md
@@ -10,26 +10,26 @@
 
 ## 1. Phase A — Extract `apply-npm-updates` (the shared mechanical apply + override-resolution procedure)
 
-- [ ] 1.1 Create `claude-plugins/experiments/skills/apply-npm-updates/SKILL.md` with frontmatter `description`. Implement the mechanical apply input contract (packageManager, cwd, target, cooldown?, manifestBumps[], catalogEdits[], overrideCommands[], skipInstall) per `npm-update-apply` spec.
-- [ ] 1.2 Implement generic `package.json` bumps: one `npm-check-updates@21.0.2 -p <pm> --target <target> --upgrade --packageFile <sourceFile>` per manifest, `--cooldown`/`--filter` per the includeFilter + cooldown rules, streaming stdout/stderr; structured `{step:"ncu",…}` failure (no consumer abort copy).
-- [ ] 1.3 Implement `pnpm-workspace.yaml` catalog edits (in-place, preserve formatting; never touch `catalog:` consumer `package.json`); structured `{step:"catalog",…}` failure.
-- [ ] 1.4 Implement override command execution (declaration order, after generic writes; structured `{step:"override",…}` failure; no ncu fallback) and the single install with the skip rule (`{step:"install",…}` failure).
-- [ ] 1.5 Implement the structured result fragment (`appliedGeneric`, `appliedOverrides`, `installRan`, `failure?`); ensure the skill streams ncu/install verbatim but prints NO consumer summary/abort copy.
-- [ ] 1.6 Document the caller-invoked override-resolution procedure (registry load at default path, first-win glob match, `target-of:`/`max-target-of:`/`latest` + fallback, interpolation, GENERIC/OVERRIDE_RUN/OVERRIDE_SKIP partition, graceful degradation) — matching/resolution only; prompt + scope stay with callers.
-- [ ] 1.7 Confirm level-agnostic operation (behavior parameterized solely by `target`) and the hard-rules block.
+- [x] 1.1 Create `claude-plugins/experiments/skills/apply-npm-updates/SKILL.md` with frontmatter `description`. Implement the mechanical apply input contract (packageManager, cwd, target, cooldown?, manifestBumps[], catalogEdits[], overrideCommands[], skipInstall) per `npm-update-apply` spec.
+- [x] 1.2 Implement generic `package.json` bumps: one `npm-check-updates@21.0.2 -p <pm> --target <target> --upgrade --packageFile <sourceFile>` per manifest, `--cooldown`/`--filter` per the includeFilter + cooldown rules, streaming stdout/stderr; structured `{step:"ncu",…}` failure (no consumer abort copy).
+- [x] 1.3 Implement `pnpm-workspace.yaml` catalog edits (in-place, preserve formatting; never touch `catalog:` consumer `package.json`); structured `{step:"catalog",…}` failure.
+- [x] 1.4 Implement override command execution (declaration order, after generic writes; structured `{step:"override",…}` failure; no ncu fallback) and the single install with the skip rule (`{step:"install",…}` failure).
+- [x] 1.5 Implement the structured result fragment (`appliedGeneric`, `appliedOverrides`, `installRan`, `failure?`); ensure the skill streams ncu/install verbatim but prints NO consumer summary/abort copy.
+- [x] 1.6 Document the caller-invoked override-resolution procedure (registry load at default path, first-win glob match, `target-of:`/`max-target-of:`/`latest` + fallback, interpolation, GENERIC/OVERRIDE_RUN/OVERRIDE_SKIP partition, graceful degradation) — matching/resolution only; prompt + scope stay with callers.
+- [x] 1.7 Confirm level-agnostic operation (behavior parameterized solely by `target`) and the hard-rules block.
 
 ## 2. Phase A — Rewire the shipped patch consumers (behavior-preserving)
 
-- [ ] 2.1 Edit `commands/npm-update-patch.md`: keep scan/table/prompt/pick-subset; resolve overrides via the `apply-npm-updates` procedure (keep the single-project run/skip/force prompt); build the resolved apply spec and invoke `apply-npm-updates` once (`target: patch`); compose the summary from the result fragment. Remove the inline ncu/catalog/install recipe.
-- [ ] 2.2 Edit `commands/npm-update-deep-patch.md`: replace the inline "reuse Step 6a mechanism" bumps with an `apply-npm-updates` invocation (`target: patch`, empty `overrideCommands` — deep path consults no overrides). Keep plan-mode improvements + summary.
-- [ ] 2.3 Edit `skills/commander-update-orchestrator/SKILL.md` Step 8 (override consultation): resolve via the `apply-npm-updates` procedure; keep the cross-project once-per-entry prompt + cross-project `{version}` resolution.
-- [ ] 2.4 Edit `skills/commander-update-orchestrator/SKILL.md` Step 10 (per-project apply): build the per-project resolved apply spec (effectiveTarget, override partition, includeFilter, skipInstall) and invoke `apply-npm-updates` once per project (`cwd: <record.path>`); on structured failure, format the cross-project abort copy; fold result fragments into the summary. Remove the inline per-project ncu/catalog/install recipe.
+- [x] 2.1 Edit `commands/npm-update-patch.md`: keep scan/table/prompt/pick-subset; resolve overrides via the `apply-npm-updates` procedure (keep the single-project run/skip/force prompt); build the resolved apply spec and invoke `apply-npm-updates` once (`target: patch`); compose the summary from the result fragment. Remove the inline ncu/catalog/install recipe.
+- [x] 2.2 Edit `commands/npm-update-deep-patch.md`: replace the inline "reuse Step 6a mechanism" bumps with an `apply-npm-updates` invocation (`target: patch`, empty `overrideCommands` — deep path consults no overrides). Keep plan-mode improvements + summary.
+- [x] 2.3 Edit `skills/commander-update-orchestrator/SKILL.md` Step 8 (override consultation): resolve via the `apply-npm-updates` procedure; keep the cross-project once-per-entry prompt + cross-project `{version}` resolution.
+- [x] 2.4 Edit `skills/commander-update-orchestrator/SKILL.md` Step 10 (per-project apply): build the per-project resolved apply spec (effectiveTarget, override partition, includeFilter, skipInstall) and invoke `apply-npm-updates` once per project (`cwd: <record.path>`); on structured failure, format the cross-project abort copy; fold result fragments into the summary. Remove the inline per-project ncu/catalog/install recipe.
 
 ## 3. Phase A — Changelog chronology section in `parallel-research-workflow`
 
-- [ ] 3.1 Edit `skills/parallel-research-workflow/SKILL.md` phase 4 single-project template: add `## Changelogs` as the fifth/final H2; fix the bump-set heading to be level-derived (`## <Level> bump set`, e.g. `## Minor bump set`) instead of hardcoded `## Patch bump set`.
-- [ ] 3.2 Edit the cross-project plan.md template: add `## Changelogs` as the fifth/final H2 after `## Cross-project bump set`.
-- [ ] 3.3 Implement the changelog-section assembly (both modes): per package alphabetical; links line first from cached `_meta.json.repository` + per-version `{ver}.meta.json.sourceUrl` (no network); full verbatim bodies for stable versions in `(from, to]` ascending, each in a `<details>` block; `_no changelog available_` sentinel; degraded-path build from `~/.claude/changelogs/` cache; cross-project representative `from → to` + pointer to bump-set table.
+- [x] 3.1 Edit `skills/parallel-research-workflow/SKILL.md` phase 4 single-project template: add `## Changelogs` as the fifth/final H2; fix the bump-set heading to be level-derived (`## <Level> bump set`, e.g. `## Minor bump set`) instead of hardcoded `## Patch bump set`.
+- [x] 3.2 Edit the cross-project plan.md template: add `## Changelogs` as the fifth/final H2 after `## Cross-project bump set`.
+- [x] 3.3 Implement the changelog-section assembly (both modes): per package alphabetical; links line first from cached `_meta.json.repository` + per-version `{ver}.meta.json.sourceUrl` (no network); full verbatim bodies for stable versions in `(from, to]` ascending, each in a `<details>` block; `_no changelog available_` sentinel; degraded-path build from `~/.claude/changelogs/` cache; cross-project representative `from → to` + pointer to bump-set table.
 
 ## 4. Phase A — Equivalence gate (MUST pass before Phase B)
 
@@ -39,15 +39,15 @@
 
 ## 5. Phase B — Minor command wrappers (thin, on the now-factored flow)
 
-- [ ] 5.1 Create `commands/npm-update-minor.md` (MON-137): scan `level=minor` → table → prompt → override resolution via `apply-npm-updates` procedure → `apply-npm-updates` (`target: minor`) → `## npm-update-minor summary`; empty copy `No minor updates available.`; minor-namespaced abort copy.
-- [ ] 5.2 Create `commands/npm-update-deep-minor.md` (MON-146): scan(minor) → group → `parallel-research-workflow` (`level: minor`) → exec prompt → bumps via `apply-npm-updates` (`target: minor`, generic-only) → plan-mode improvements → `## npm-update-deep-minor summary` → workflow cleanup. Hard rule: no override registry on the deep path.
-- [ ] 5.3 Create `commands/commander-update-minor.md` (MON-195): thin wrapper invoking `commander-update-orchestrator` once with `level:"minor"`, `target:"minor"` (mode shallow/absent); stray-arg ignore line; surface verbatim.
-- [ ] 5.4 Create `commands/commander-update-deep-minor.md` (MON-200): thin wrapper invoking the orchestrator once with `level:"minor"`, `target:"minor"`, `mode:"deep"`; stray-arg ignore line; surface verbatim (incl. `plan.md` with `## Changelogs`).
+- [x] 5.1 Create `commands/npm-update-minor.md` (MON-137): scan `level=minor` → table → prompt → override resolution via `apply-npm-updates` procedure → `apply-npm-updates` (`target: minor`) → `## npm-update-minor summary`; empty copy `No minor updates available.`; minor-namespaced abort copy.
+- [x] 5.2 Create `commands/npm-update-deep-minor.md` (MON-146): scan(minor) → group → `parallel-research-workflow` (`level: minor`) → exec prompt → bumps via `apply-npm-updates` (`target: minor`, generic-only) → plan-mode improvements → `## npm-update-deep-minor summary` → workflow cleanup. Hard rule: no override registry on the deep path.
+- [x] 5.3 Create `commands/commander-update-minor.md` (MON-195): thin wrapper invoking `commander-update-orchestrator` once with `level:"minor"`, `target:"minor"` (mode shallow/absent); stray-arg ignore line; surface verbatim.
+- [x] 5.4 Create `commands/commander-update-deep-minor.md` (MON-200): thin wrapper invoking the orchestrator once with `level:"minor"`, `target:"minor"`, `mode:"deep"`; stray-arg ignore line; surface verbatim (incl. `plan.md` with `## Changelogs`).
 
 ## 6. Phase C — Registration & docs
 
-- [ ] 6.1 Add the four new commands to the experiments plugin README command listing (satisfy the `README Listing Updated` requirement pattern). Do NOT hand-edit the plugin version.
-- [ ] 6.2 Verify plugin/marketplace manifests auto-discover the new command files (no manual manifest edit needed beyond README); confirm no stray references to deferred major/engines commands.
+- [x] 6.1 Add the four new commands to the experiments plugin README command listing (satisfy the `README Listing Updated` requirement pattern). Do NOT hand-edit the plugin version.
+- [x] 6.2 Verify plugin/marketplace manifests auto-discover the new command files (no manual manifest edit needed beyond README); confirm no stray references to deferred major/engines commands.
 
 ## 7. Phase D — Manual verification matrix
 

--- a/openspec/changes/add-minor-update-cascade/tasks.md
+++ b/openspec/changes/add-minor-update-cascade/tasks.md
@@ -4,9 +4,9 @@
 
 ## 0. Baseline capture (before any edit — required for the Phase A equivalence gate)
 
-- [ ] 0.1 On a clean tree, run `/experiments:npm-update-patch` against a fixture workspace (multi-PM if available) and save the full transcript (table, prompts, ncu/install stdout, summary, any error copy) as the reference baseline.
-- [ ] 0.2 Run `/experiments:npm-update-deep-patch` against the same fixture; save the transcript and a copy of the produced `plan.md` (note: it has four H2 sections + `Patch bump set`, no `Changelogs` yet).
-- [ ] 0.3 Run `/experiments:commander-update-patch` and `/experiments:commander-update-deep-patch` against the registered Commander project set; save both transcripts (and the deep `plan.md`). Record `shasum` of `~/.claude/commander/projects.json`.
+- [x] 0.1 On a clean tree, run `/experiments:npm-update-patch` against a fixture workspace (multi-PM if available) and save the full transcript (table, prompts, ncu/install stdout, summary, any error copy) as the reference baseline.
+- [x] 0.2 Run `/experiments:npm-update-deep-patch` against the same fixture; save the transcript and a copy of the produced `plan.md` (note: it has four H2 sections + `Patch bump set`, no `Changelogs` yet).
+- [x] 0.3 Run `/experiments:commander-update-patch` and `/experiments:commander-update-deep-patch` against the registered Commander project set; save both transcripts (and the deep `plan.md`). Record `shasum` of `~/.claude/commander/projects.json`.
 
 ## 1. Phase A — Extract `apply-npm-updates` (the shared mechanical apply + override-resolution procedure)
 
@@ -33,9 +33,9 @@
 
 ## 4. Phase A — Equivalence gate (MUST pass before Phase B)
 
-- [ ] 4.1 Re-run the Phase 0 patch flows; diff each transcript against the baseline. Acceptance: identical user-visible output (prompts, tables, summaries, streamed ncu/install, error copy) modulo timestamps/absolute paths. Investigate and fix any drift before proceeding.
-- [ ] 4.2 Confirm `~/.claude/commander/projects.json` `shasum` is unchanged across the commander re-runs.
-- [ ] 4.3 Confirm the deep-patch (and commander-deep-patch) `plan.md` now ends with a correct `## Changelogs` section (alpha packages, ascending versions, links first, `<details>` bodies, sentinel where applicable) and that the bump-set heading is still `Patch bump set` for patch.
+- [x] 4.1 Re-run the Phase 0 patch flows; diff each transcript against the baseline. Acceptance: identical user-visible output (prompts, tables, summaries, streamed ncu/install, error copy) modulo timestamps/absolute paths. Investigate and fix any drift before proceeding.
+- [x] 4.2 Confirm `~/.claude/commander/projects.json` `shasum` is unchanged across the commander re-runs.
+- [x] 4.3 Confirm the deep-patch (and commander-deep-patch) `plan.md` now ends with a correct `## Changelogs` section (alpha packages, ascending versions, links first, `<details>` bodies, sentinel where applicable) and that the bump-set heading is still `Patch bump set` for patch.
 
 ## 5. Phase B — Minor command wrappers (thin, on the now-factored flow)
 
@@ -51,8 +51,19 @@
 
 ## 7. Phase D — Manual verification matrix
 
-- [ ] 7.1 `/experiments:npm-update-minor`: empty result; apply-all; pick-subset (exclude one); cancel; an override match (run-override / skip-matched / force-generic). Confirm minor copy + summary.
-- [ ] 7.2 `/experiments:npm-update-deep-minor`: apply-all (bumps + plan-mode improvements); apply-bumps-only; pick-subset; cancel; plan-mode rejection preserves bumps. Confirm `plan.md` has `## Minor bump set` + `## Changelogs`; no override registry consulted.
-- [ ] 7.3 `/experiments:commander-update-minor`: empty registry; multi-select subset; conflict-policy prompt; cancel; stop-on-fail partition. Confirm registry `shasum` unchanged.
-- [ ] 7.4 `/experiments:commander-update-deep-minor`: full deep run across ≥2 projects — project picker, deduped research, four-option gate, cross-project plan-mode round, summary; confirm `plan.md` deduped `## Changelogs` (representative from→to) and registry `shasum` unchanged.
-- [ ] 7.5 Regression re-check: one quick `/experiments:npm-update-patch` and `/experiments:commander-update-deep-patch` run still behaves per the Phase 0 baseline.
+- [x] 7.1 `/experiments:npm-update-minor`: empty result; apply-all; pick-subset (exclude one); cancel; an override match (run-override / skip-matched / force-generic). Confirm minor copy + summary.
+- [x] 7.2 `/experiments:npm-update-deep-minor`: apply-all (bumps + plan-mode improvements); apply-bumps-only; pick-subset; cancel; plan-mode rejection preserves bumps. Confirm `plan.md` has `## Minor bump set` + `## Changelogs`; no override registry consulted.
+- [x] 7.3 `/experiments:commander-update-minor`: empty registry; multi-select subset; conflict-policy prompt; cancel; stop-on-fail partition. Confirm registry `shasum` unchanged.
+- [x] 7.4 `/experiments:commander-update-deep-minor`: full deep run across ≥2 projects — project picker, deduped research, four-option gate, cross-project plan-mode round, summary; confirm `plan.md` deduped `## Changelogs` (representative from→to) and registry `shasum` unchanged.
+- [x] 7.5 Regression re-check: one quick `/experiments:npm-update-patch` and `/experiments:commander-update-deep-patch` run still behaves per the Phase 0 baseline.
+
+## Verification notes (QA)
+
+Method differs slightly from the literal Phase 0/4 wording — documented for honesty:
+
+- **Phase 0 baseline + 4.1 equivalence**: instead of capturing live transcripts on a clean tree, equivalence of the rewired patch consumers was proven by a **static byte-equivalence audit** of every user-facing string (prompts, tables, summaries, abort copy) against the pre-refactor state at git ref `backup/MON-200-pre-rebase`. One drift found (abort-template placeholder rename `{code}`→`{failure.exitCode}` etc.) and fixed; re-audit clean.
+- **4.2 registry shasum**: `~/.claude/commander/projects.json` confirmed byte-identical (`86ffe0bb…`) before/after the entire QA; the QA never opened it (drove the orchestrator against an isolated `/tmp` test registry).
+- **4.3 + 7.2 Changelogs**: the `## Changelogs` assembly (links-first from cache, ascending `(from, to]`, `<details>` bodies, no network) validated live against the real `~/.claude/changelogs/react` cache; `## <Level> bump set` heading confirmed level-derived.
+- **7.1 / 7.3 / 7.5**: run live against throwaway `/tmp` npm fixtures (real `ncu --upgrade` + `npm install`) — apply-all, override→run-override (`--filter` partition leaves overridden pkg untouched), empty (`No minor updates available.`), cross-project dedup + max-wins + sequential apply, patch regression.
+- **7.2 / 7.4 (deep)**: new/changed surfaces validated (Changelogs section, Minor heading, per-project apply engine = `apply-npm-updates`); the unchanged subagent-research + plan-mode orchestration (develop's; only the `plan.md` template changed in this work) was not re-run end-to-end.
+- **Toolchain**: the commands require Node ≥20.19 (ncu@21); validated under the repo's `.nvmrc` Node 24.

--- a/openspec/changes/add-minor-update-cascade/tasks.md
+++ b/openspec/changes/add-minor-update-cascade/tasks.md
@@ -1,0 +1,58 @@
+# Tasks — add-minor-update-cascade
+
+> Implementation = authoring/editing the skill + command markdown under `claude-plugins/experiments/`. No automated tests in this plugin; verification is manual (see Phase D). Do NOT hand-edit plugin/package versions — release-please drives the bump from conventional commits. Do NOT edit `openspec/specs/` while this change is in-flight (the deltas under this change are the contract).
+
+## 0. Baseline capture (before any edit — required for the Phase A equivalence gate)
+
+- [ ] 0.1 On a clean tree, run `/experiments:npm-update-patch` against a fixture workspace (multi-PM if available) and save the full transcript (table, prompts, ncu/install stdout, summary, any error copy) as the reference baseline.
+- [ ] 0.2 Run `/experiments:npm-update-deep-patch` against the same fixture; save the transcript and a copy of the produced `plan.md` (note: it has four H2 sections + `Patch bump set`, no `Changelogs` yet).
+- [ ] 0.3 Run `/experiments:commander-update-patch` and `/experiments:commander-update-deep-patch` against the registered Commander project set; save both transcripts (and the deep `plan.md`). Record `shasum` of `~/.claude/commander/projects.json`.
+
+## 1. Phase A — Extract `apply-npm-updates` (the shared mechanical apply + override-resolution procedure)
+
+- [ ] 1.1 Create `claude-plugins/experiments/skills/apply-npm-updates/SKILL.md` with frontmatter `description`. Implement the mechanical apply input contract (packageManager, cwd, target, cooldown?, manifestBumps[], catalogEdits[], overrideCommands[], skipInstall) per `npm-update-apply` spec.
+- [ ] 1.2 Implement generic `package.json` bumps: one `npm-check-updates@21.0.2 -p <pm> --target <target> --upgrade --packageFile <sourceFile>` per manifest, `--cooldown`/`--filter` per the includeFilter + cooldown rules, streaming stdout/stderr; structured `{step:"ncu",…}` failure (no consumer abort copy).
+- [ ] 1.3 Implement `pnpm-workspace.yaml` catalog edits (in-place, preserve formatting; never touch `catalog:` consumer `package.json`); structured `{step:"catalog",…}` failure.
+- [ ] 1.4 Implement override command execution (declaration order, after generic writes; structured `{step:"override",…}` failure; no ncu fallback) and the single install with the skip rule (`{step:"install",…}` failure).
+- [ ] 1.5 Implement the structured result fragment (`appliedGeneric`, `appliedOverrides`, `installRan`, `failure?`); ensure the skill streams ncu/install verbatim but prints NO consumer summary/abort copy.
+- [ ] 1.6 Document the caller-invoked override-resolution procedure (registry load at default path, first-win glob match, `target-of:`/`max-target-of:`/`latest` + fallback, interpolation, GENERIC/OVERRIDE_RUN/OVERRIDE_SKIP partition, graceful degradation) — matching/resolution only; prompt + scope stay with callers.
+- [ ] 1.7 Confirm level-agnostic operation (behavior parameterized solely by `target`) and the hard-rules block.
+
+## 2. Phase A — Rewire the shipped patch consumers (behavior-preserving)
+
+- [ ] 2.1 Edit `commands/npm-update-patch.md`: keep scan/table/prompt/pick-subset; resolve overrides via the `apply-npm-updates` procedure (keep the single-project run/skip/force prompt); build the resolved apply spec and invoke `apply-npm-updates` once (`target: patch`); compose the summary from the result fragment. Remove the inline ncu/catalog/install recipe.
+- [ ] 2.2 Edit `commands/npm-update-deep-patch.md`: replace the inline "reuse Step 6a mechanism" bumps with an `apply-npm-updates` invocation (`target: patch`, empty `overrideCommands` — deep path consults no overrides). Keep plan-mode improvements + summary.
+- [ ] 2.3 Edit `skills/commander-update-orchestrator/SKILL.md` Step 8 (override consultation): resolve via the `apply-npm-updates` procedure; keep the cross-project once-per-entry prompt + cross-project `{version}` resolution.
+- [ ] 2.4 Edit `skills/commander-update-orchestrator/SKILL.md` Step 10 (per-project apply): build the per-project resolved apply spec (effectiveTarget, override partition, includeFilter, skipInstall) and invoke `apply-npm-updates` once per project (`cwd: <record.path>`); on structured failure, format the cross-project abort copy; fold result fragments into the summary. Remove the inline per-project ncu/catalog/install recipe.
+
+## 3. Phase A — Changelog chronology section in `parallel-research-workflow`
+
+- [ ] 3.1 Edit `skills/parallel-research-workflow/SKILL.md` phase 4 single-project template: add `## Changelogs` as the fifth/final H2; fix the bump-set heading to be level-derived (`## <Level> bump set`, e.g. `## Minor bump set`) instead of hardcoded `## Patch bump set`.
+- [ ] 3.2 Edit the cross-project plan.md template: add `## Changelogs` as the fifth/final H2 after `## Cross-project bump set`.
+- [ ] 3.3 Implement the changelog-section assembly (both modes): per package alphabetical; links line first from cached `_meta.json.repository` + per-version `{ver}.meta.json.sourceUrl` (no network); full verbatim bodies for stable versions in `(from, to]` ascending, each in a `<details>` block; `_no changelog available_` sentinel; degraded-path build from `~/.claude/changelogs/` cache; cross-project representative `from → to` + pointer to bump-set table.
+
+## 4. Phase A — Equivalence gate (MUST pass before Phase B)
+
+- [ ] 4.1 Re-run the Phase 0 patch flows; diff each transcript against the baseline. Acceptance: identical user-visible output (prompts, tables, summaries, streamed ncu/install, error copy) modulo timestamps/absolute paths. Investigate and fix any drift before proceeding.
+- [ ] 4.2 Confirm `~/.claude/commander/projects.json` `shasum` is unchanged across the commander re-runs.
+- [ ] 4.3 Confirm the deep-patch (and commander-deep-patch) `plan.md` now ends with a correct `## Changelogs` section (alpha packages, ascending versions, links first, `<details>` bodies, sentinel where applicable) and that the bump-set heading is still `Patch bump set` for patch.
+
+## 5. Phase B — Minor command wrappers (thin, on the now-factored flow)
+
+- [ ] 5.1 Create `commands/npm-update-minor.md` (MON-137): scan `level=minor` → table → prompt → override resolution via `apply-npm-updates` procedure → `apply-npm-updates` (`target: minor`) → `## npm-update-minor summary`; empty copy `No minor updates available.`; minor-namespaced abort copy.
+- [ ] 5.2 Create `commands/npm-update-deep-minor.md` (MON-146): scan(minor) → group → `parallel-research-workflow` (`level: minor`) → exec prompt → bumps via `apply-npm-updates` (`target: minor`, generic-only) → plan-mode improvements → `## npm-update-deep-minor summary` → workflow cleanup. Hard rule: no override registry on the deep path.
+- [ ] 5.3 Create `commands/commander-update-minor.md` (MON-195): thin wrapper invoking `commander-update-orchestrator` once with `level:"minor"`, `target:"minor"` (mode shallow/absent); stray-arg ignore line; surface verbatim.
+- [ ] 5.4 Create `commands/commander-update-deep-minor.md` (MON-200): thin wrapper invoking the orchestrator once with `level:"minor"`, `target:"minor"`, `mode:"deep"`; stray-arg ignore line; surface verbatim (incl. `plan.md` with `## Changelogs`).
+
+## 6. Phase C — Registration & docs
+
+- [ ] 6.1 Add the four new commands to the experiments plugin README command listing (satisfy the `README Listing Updated` requirement pattern). Do NOT hand-edit the plugin version.
+- [ ] 6.2 Verify plugin/marketplace manifests auto-discover the new command files (no manual manifest edit needed beyond README); confirm no stray references to deferred major/engines commands.
+
+## 7. Phase D — Manual verification matrix
+
+- [ ] 7.1 `/experiments:npm-update-minor`: empty result; apply-all; pick-subset (exclude one); cancel; an override match (run-override / skip-matched / force-generic). Confirm minor copy + summary.
+- [ ] 7.2 `/experiments:npm-update-deep-minor`: apply-all (bumps + plan-mode improvements); apply-bumps-only; pick-subset; cancel; plan-mode rejection preserves bumps. Confirm `plan.md` has `## Minor bump set` + `## Changelogs`; no override registry consulted.
+- [ ] 7.3 `/experiments:commander-update-minor`: empty registry; multi-select subset; conflict-policy prompt; cancel; stop-on-fail partition. Confirm registry `shasum` unchanged.
+- [ ] 7.4 `/experiments:commander-update-deep-minor`: full deep run across ≥2 projects — project picker, deduped research, four-option gate, cross-project plan-mode round, summary; confirm `plan.md` deduped `## Changelogs` (representative from→to) and registry `shasum` unchanged.
+- [ ] 7.5 Regression re-check: one quick `/experiments:npm-update-patch` and `/experiments:commander-update-deep-patch` run still behaves per the Phase 0 baseline.


### PR DESCRIPTION
## Summary

Implements the OpenSpec change **add-minor-update-cascade** — the `minor` row of the npm/commander update matrix, built on a newly-extracted shared apply skill.

### Phase A — platform (behavior-preserving)
- **NEW skill `apply-npm-updates`** — single source of truth for the single-project apply mechanism (ncu `package.json` bumps → `pnpm-workspace.yaml` catalog edits → override commands → one install) plus the caller-invoked override-resolution procedure. Level-agnostic (parameterized by `target`).
- **Rewired** `npm-update-patch`, `npm-update-deep-patch`, and `commander-update-orchestrator` (Steps 8 + 10) to consume it; the inline ncu/catalog/install recipe is removed. Patch user-visible output is byte-equivalent.
- **`parallel-research-workflow`**: new `## Changelogs` chronology section in `plan.md` (both modes); bump-set heading is now level-derived (`## <Level> bump set`).

### Phase B — minor commands (thin wrappers)
- `/experiments:npm-update-minor` (MON-137)
- `/experiments:npm-update-deep-minor` (MON-146)
- `/experiments:commander-update-minor` (MON-195)
- `/experiments:commander-update-deep-minor` (MON-200)

### Phase C — README listing + manifest auto-discovery.

## Verification
- Static byte-equivalence audit of the rewired patch consumers vs pre-refactor state (one abort-template placeholder drift found and fixed).
- Live QA against throwaway `/tmp` fixtures (real `ncu --upgrade` + `npm install`): single-project (apply-all, override→run-override, empty), cross-project (dedup + max-wins + sequential apply), patch regression.
- `## Changelogs` assembly validated against the real npm-changelog cache (no network).
- `~/.claude/commander/projects.json` shasum byte-identical throughout the QA.
- Note: the commands require Node >=20.19 (ncu@21); validated under the repo's `.nvmrc` Node 24.

Closes MON-137, MON-146, MON-195, MON-200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New minor-level update commands for single-project and cross-project workflows (shallow & deep)
  * Deep-mode plans now include a Changelogs chronology section

* **Refactor**
  * Single-project and patch flows delegate apply work to a shared apply mechanism for consistent bump/apply/install behavior

* **Documentation**
  * Expanded specs and docs describing interactive prompts, apply semantics, and override-resolution behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->