### PR TITLE
test(ci): [THROWAWAY] validate empty-matrix skip (do not merge)

### DIFF
--- a/claude-plugins/README.md
+++ b/claude-plugins/README.md
@@ -40,3 +40,5 @@ claude --plugin-dir ./claude-plugins/<plugin-name>
 # Install a plugin
 /plugin install <plugin-name>@monolab
 ```
+
+<!-- ci-validation: codecov empty-matrix scenario (throwaway, do not merge) -->


### PR DESCRIPTION
Throwaway validation PR. Touches only `claude-plugins/README.md` (owned by no nx project) → `nx affected` empty → expected: `upload-codecov` **skipped**, run green. Will be closed + branch deleted after CI confirms.