### PR TITLE
fix(nx): make tsc -b builds cache-deterministic (fixes poisoned dist cache)

### DIFF
--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "type": "module",
     "scripts": {
-        "build": "tsc -b && vite build",
+        "build": "tsc -b --clean && tsc -b && vite build",
         "dev": "vite",
         "lint:eslint": "eslint --cache --concurrency=auto --max-warnings 60 .",
         "lint:eslint:config-check": "eslint-config-prettier src/index.tsx",

--- a/nx.json
+++ b/nx.json
@@ -19,11 +19,7 @@
             "cache": true,
             "dependsOn": ["^build"],
             "inputs": ["default"],
-            "outputs": [
-                "{projectRoot}/dist",
-                "{projectRoot}/tsconfig.lib.tsbuildinfo",
-                "{projectRoot}/tsconfig.tsbuildinfo"
-            ]
+            "outputs": ["{projectRoot}/dist"]
         },
         "build:check-exports": {
             "dependsOn": ["^build", "build", "^build:check-exports"]

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -30,7 +30,7 @@
         "registry": "https://registry.npmjs.org/"
     },
     "scripts": {
-        "build": "tsc -b",
+        "build": "tsc -b --clean && tsc -b",
         "lint:eslint": "eslint --cache --concurrency=auto --max-warnings 40 .",
         "lint:eslint:config-check": "eslint-config-prettier src/index.ts",
         "lint:eslint:fix": "eslint --cache --concurrency=auto --max-warnings 40 --fix .",

--- a/packages/ts-types/package.json
+++ b/packages/ts-types/package.json
@@ -29,7 +29,7 @@
         "registry": "https://registry.npmjs.org/"
     },
     "scripts": {
-        "build": "tsc -b",
+        "build": "tsc -b --clean && tsc -b",
         "lint:eslint": "eslint --cache --concurrency=auto --max-warnings 40 .",
         "lint:eslint:config-check": "eslint-config-prettier src/index.ts",
         "lint:eslint:fix": "eslint --cache --concurrency=auto --max-warnings 40 --fix .",


### PR DESCRIPTION
## Problem

The cacheable `build` target runs incremental **`tsc -b`** and declares the incremental state (`tsconfig*.tsbuildinfo`) as **cached outputs**. That makes the task non-deterministic: if a build ever starts from a state where `.tsbuildinfo` says "declarations up to date" but `dist/*.d.ts` are stale/missing, `tsc -b` **skips re-emitting declarations** and produces a **partial `dist`** — which Nx then caches and replays on every hit.

This poisoned `@m0n0lab/ts-types:build`'s remote cache with a `dist/index.d.ts` that kept the value export `isNullable` but dropped the **type-only** re-export `Nullable`. It stayed invisible on `develop` (consumers were cache hits), then surfaced on a cache-busting PR (a lockfile change) as:

```
packages/react-clean/src/use-view-model.hook.ts:4 — error TS2724:
'@m0n0lab/ts-types' has no exported member named 'Nullable'. Did you mean 'isNullable'?
```

The source and toolchain were always correct — a clean build emits `Nullable` fine. This is a cache-correctness bug, not a source bug.

## Fix

- **A — deterministic emit:** clean before build in the `tsc -b` packages so a partial `dist` can never be produced/cached:
  - `@m0n0lab/ts-types`, `@m0n0lab/http-client`: `tsc -b` → `tsc -b --clean && tsc -b`
  - `@m0n0lab/demo`: `tsc -b && vite build` → `tsc -b --clean && tsc -b && vite build`
- **B — stop caching incremental state:** drop `tsconfig.lib.tsbuildinfo` / `tsconfig.tsbuildinfo` from the `build` target's `outputs` in `nx.json` (keep only `{projectRoot}/dist`). `.tsbuildinfo` is gitignored local incremental state; restoring it into a "should-be-pure" cached task is what allowed the drift.

## Verification (local)

Reproduced the exact poisoning and confirmed the fix:

| step | `.d.ts` in ts-types/dist |
|---|---|
| clean build (new script) | 6 (incl. `Nullable`) ✓ |
| poison: delete `*.d.ts` (keep `.d.ts.map` + tsbuildinfo) | 0 |
| **old** `tsc -b` (incremental) | **0 — bug reproduced** |
| **new** `tsc -b --clean && tsc -b` | **6 (incl. `Nullable`) — healed** ✓ |

- `nx run @m0n0lab/react-clean:build --skip-nx-cache` → green (exercises the `^build` chain with the new clean ts-types build).
- `nx run @m0n0lab/http-client:build --skip-nx-cache` → green.

## Impact

Merging re-keys the affected `build` tasks (script + outputs change) → Nx rebuilds them clean and re-populates the remote cache with correct artifacts, healing the poisoned entries workspace-wide. After this lands, the deps PR (#269) goes green on re-run/rebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved build reliability by cleaning previous TypeScript build artifacts before compilation.
  - Streamlined build output tracking to improve caching consistency and reduce unnecessary rebuilds.
  - Applied the updated build process across demo and shared packages for more predictable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->